### PR TITLE
Route owner listing detail to /my/listings/{id}

### DIFF
--- a/backend/src/api/router.rs
+++ b/backend/src/api/router.rs
@@ -95,9 +95,16 @@ async fn route_dynamic_routes(
         return handle(result);
     }
 
-    if let Some(listing_id) = event.uri().path().strip_prefix("/listings/") {
+    if let Some(listing_id) = event.uri().path().strip_prefix("/my/listings/") {
         let result = match event.method().as_str() {
             "GET" => listing::get_listing(event, correlation_id, listing_id).await,
+            _ => method_not_allowed(),
+        };
+        return handle(result);
+    }
+
+    if let Some(listing_id) = event.uri().path().strip_prefix("/listings/") {
+        let result = match event.method().as_str() {
             "PUT" => listing::update_listing(event, correlation_id, listing_id).await,
             _ => method_not_allowed(),
         };


### PR DESCRIPTION
## Summary
Moves owner-scoped listing detail reads from `GET /listings/{id}` to `GET /my/listings/{id}` for consistency with existing owner routes.

## Why
- Keeps owner-scoped routes under `/my/*`
- Frees `GET /listings/{id}` for a future public listing detail endpoint

## Changes
- `backend/src/api/router.rs`
  - Added dynamic route: `GET /my/listings/{listingId}` -> `listing::get_listing`
  - Removed `GET /listings/{listingId}` mapping
  - Kept `PUT /listings/{listingId}` mapping unchanged

## Notes
Could not run local checks in this environment due command execution restrictions.