### PR TITLE
feat(frontend): add My Listings and Local Discovery views

### DIFF
--- a/frontend/src/components/Listings/GrowerListingPanel.test.tsx
+++ b/frontend/src/components/Listings/GrowerListingPanel.test.tsx
@@ -203,4 +203,41 @@ describe('GrowerListingPanel', () => {
       expect(screen.getByText(/listings request failed/i)).toBeInTheDocument();
     });
   });
+
+  it('pre-seeds edit form from selected listing while detail query is loading', async () => {
+    const user = userEvent.setup();
+    const activeListing = makeListing({
+      id: 'listing-1',
+      title: 'Tomatoes Basket',
+      status: 'active',
+      quantityTotal: '12',
+      quantityRemaining: '8',
+    });
+
+    mockListMyListings.mockResolvedValue({
+      items: [activeListing],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    let resolveDetail: ((value: Listing) => void) | undefined;
+    const pendingDetail = new Promise<Listing>((resolve) => {
+      resolveDetail = resolve;
+    });
+    mockGetMyListing.mockReturnValue(pendingDetail);
+
+    renderPanel();
+
+    await user.click(screen.getByRole('tab', { name: /my listings/i }));
+    expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(await screen.findByRole('heading', { name: /edit listing/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/listing title/i)).toHaveValue('Tomatoes Basket');
+
+    resolveDetail?.(activeListing);
+  });
 });


### PR DESCRIPTION
## Summary
Implements issue #6 by extending the grower listing workspace with dedicated frontend views for listing verification and self-discovery.

## What changed
- Added a dedicated `My Listings` view in `GrowerListingPanel` using `GET /my/listings`
- Added status filter chips for `all`, `active`, `expired`, and `completed`
- Added listing status chips on each list item
- Added listing detail navigation (`View details`) that loads detail via `GET /my/listings/{listingId}`
- Added a `Local Discovery` view that shows active listings in local-context order (distance from grower default location when available)
- Preserved existing create/edit listing workflow in a tabbed workspace
- Added focused component tests for:
  - list rendering
  - status filtering
  - detail navigation
  - empty states
  - error states

## Files
- `frontend/src/components/Listings/GrowerListingPanel.tsx`
- `frontend/src/components/Listings/GrowerListingPanel.test.tsx`

## Acceptance criteria mapping
- Grower can verify posted listings from in-app `My Listings` view without backend console checks
- Empty, loading, and error states are explicitly handled in `My Listings` and `Local Discovery` views
- Tests cover listing filters and basic detail navigation

Closes #6

## Required quality gates
Blocked in this execution environment due command policy restrictions:
- Frontend unit tests
- Backend unit tests
- Frontend linting
- Backend linting
- Backend formatting check (`fmt`)

I attempted to run `npm run lint` and `npm run test` in `frontend/`, but command execution was rejected by policy in this session. Please advise if you want me to re-run all gates in a less restricted environment.