### PR TITLE
feat: add AI labels and user opt-out controls in searcher flow

### DIFF
--- a/frontend/src/types/feed.ts
+++ b/frontend/src/types/feed.ts
@@ -1,0 +1,64 @@
+export interface DerivedFeedSignal {
+  geoBoundaryKey: string;
+  cropId: string | null;
+  windowDays: number;
+  listingCount: number;
+  requestCount: number;
+  supplyQuantity: string;
+  demandQuantity: string;
+  scarcityScore: number;
+  abundanceScore: number;
+  computedAt: string;
+  expiresAt: string;
+}
+
+export interface DerivedFeedFreshness {
+  asOf: string;
+  isStale: boolean;
+  staleFallbackUsed: boolean;
+  staleReason: string | null;
+}
+
+export interface DerivedFeedAiSummary {
+  summaryText: string;
+  modelId: string;
+  modelVersion: string;
+  generatedAt: string;
+  expiresAt: string;
+  fromCache: boolean;
+}
+
+export interface GrowerGuidanceSignalRef {
+  geoBoundaryKey: string;
+  cropId: string | null;
+  scarcityScore: number;
+  abundanceScore: number;
+  listingCount: number;
+  requestCount: number;
+}
+
+export interface GrowerGuidanceExplanation {
+  season: string;
+  strategy: string;
+  windowDays: number;
+  sourceSignalCount: number;
+  strongestScarcitySignal: GrowerGuidanceSignalRef | null;
+  strongestAbundanceSignal: GrowerGuidanceSignalRef | null;
+}
+
+export interface GrowerGuidance {
+  guidanceText: string;
+  explanation: GrowerGuidanceExplanation;
+}
+
+export interface DerivedFeedResponse {
+  items: unknown[];
+  signals: DerivedFeedSignal[];
+  freshness: DerivedFeedFreshness;
+  aiSummary: DerivedFeedAiSummary | null;
+  growerGuidance: GrowerGuidance | null;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}


### PR DESCRIPTION
## Summary
- add derived feed API client/types for frontend consumption
- add AI insights card in SearcherRequestPanel with explicit "AI-assisted" labeling
- add per-user local opt-out toggle that persists by account/device
- ensure opting out keeps core discovery/request workflow intact
- add tests for label visibility and opt-out behavior

## Why
Implements #16 to make AI behavior transparent and user-controllable without breaking non-AI workflows.

## Validation
- npm run lint
- npm test -- --run src/components/Listings/SearcherRequestPanel.test.tsx
- npm run build
