### PR TITLE
feat: add idempotency replay protection for listing writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ The CI/CD pipeline handles:
 
 See [CI/CD Quick Reference](./docs/ci-cd-quick-reference.md) for common operations.
 
+### API Idempotency Contract (Phase 5)
+
+Write endpoints support retry-safe behavior using the `Idempotency-Key` request header.
+
+- Reusing the same key for the same authenticated user replays the original successful write response.
+- Reusing the same key for a *different* payload that hashes to an existing record owned by another user returns a conflict.
+- Current coverage:
+  - `POST /requests`
+  - `POST /listings`
+- Clients should generate a stable UUID-like key per user action attempt and reuse it across retries/timeouts.
+
 ### Quick Start (Manual Deployment)
 
 1. **Clone the repository**


### PR DESCRIPTION
## Summary
- add idempotency-key handling to `POST /listings`
- derive deterministic listing IDs from `(user_id, Idempotency-Key)`
- replay existing listing response for retry with same key/payload instead of creating duplicates
- return conflict on cross-user/id collision edge case
- emit `listing.created` event only for newly inserted rows (not replay)
- document idempotency contract in README for clients
- add unit tests for deterministic listing-id derivation

## Why
Implements #17 duplicate-write protection and deterministic replay behavior for write APIs.

## Validation
- `cargo fmt --all --`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
