### PR TITLE
perf(frontend): lazy-load app surfaces and enforce bundle budgets

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -129,6 +129,9 @@ jobs:
           VITE_FRONTEND_URL: https://placeholder.cloudfront.net
           VITE_AWS_REGION: us-east-1
 
+      - name: Performance budget check
+        run: npm run perf:budget
+
   summary:
     name: All Checks Passed
     runs-on: ubuntu-latest

--- a/docs/frontend-performance-resiliency.md
+++ b/docs/frontend-performance-resiliency.md
@@ -1,0 +1,28 @@
+# Frontend Performance & Resiliency Hardening (Phase 5)
+
+This phase is tuned for solo/passive operations: simple guardrails, low maintenance, and fast user-perceived performance.
+
+## Implemented
+
+1. **Route/component lazy loading**
+   - Auth and profile/onboarding surfaces are now lazily loaded in `App.tsx`.
+   - Reduces initial JS evaluation for first paint and lowers startup cost on slower devices.
+
+2. **Automated bundle budget gate in CI**
+   - Added `npm run perf:budget` (script: `scripts/check-performance-budget.mjs`).
+   - Enforced in PR checks after frontend build.
+   - Current budget thresholds:
+     - Main bundle <= 220 KB
+     - Vendor bundle <= 520 KB
+     - Total JS <= 900 KB
+
+## Why this matches solo/passive ops
+
+- No always-on monitoring service required.
+- Regressions are caught at PR time (where you already review).
+- Clear, low-noise pass/fail behavior.
+
+## Next optional steps (only if needed)
+
+- Add one degraded-network UX smoke test for key request/listing flow.
+- Introduce one additional code-split boundary around heavy listing/search panels if bundle growth continues.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "perf:budget": "node scripts/check-performance-budget.mjs"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.15.0",

--- a/frontend/scripts/check-performance-budget.mjs
+++ b/frontend/scripts/check-performance-budget.mjs
@@ -1,0 +1,47 @@
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST_ASSETS = join(process.cwd(), 'dist', 'assets');
+
+const jsFiles = readdirSync(DIST_ASSETS)
+  .filter((name) => name.endsWith('.js'))
+  .map((name) => ({ name, size: statSync(join(DIST_ASSETS, name)).size }));
+
+if (jsFiles.length === 0) {
+  console.error('No JS bundles found in dist/assets. Run build first.');
+  process.exit(1);
+}
+
+const mainBundle = jsFiles.find((file) => file.name.startsWith('index-'));
+const vendorBundle = jsFiles.find((file) => file.name.includes('vendor'));
+
+const MAX_MAIN_BYTES = 220 * 1024;
+const MAX_VENDOR_BYTES = 520 * 1024;
+const MAX_TOTAL_BYTES = 900 * 1024;
+
+const totalBytes = jsFiles.reduce((sum, file) => sum + file.size, 0);
+
+function assertWithinBudget(label, value, max) {
+  if (value > max) {
+    console.error(`${label} exceeded budget: ${value} bytes > ${max} bytes`);
+    process.exitCode = 1;
+  }
+}
+
+if (mainBundle) {
+  assertWithinBudget('Main bundle', mainBundle.size, MAX_MAIN_BYTES);
+}
+if (vendorBundle) {
+  assertWithinBudget('Vendor bundle', vendorBundle.size, MAX_VENDOR_BYTES);
+}
+assertWithinBudget('Total JS bundle size', totalBytes, MAX_TOTAL_BYTES);
+
+console.log('Performance budget report');
+for (const file of jsFiles) {
+  console.log(`- ${file.name}: ${file.size} bytes`);
+}
+console.log(`Total: ${totalBytes} bytes`);
+
+if (process.exitCode && process.exitCode !== 0) {
+  process.exit(process.exitCode);
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -58,7 +58,7 @@ describe('App', () => {
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
-  it('shows login page when not authenticated', () => {
+  it('shows login page when not authenticated', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -72,11 +72,11 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
   });
 
-  it('shows profile view when authenticated', () => {
+  it('shows profile view when authenticated', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -108,7 +108,7 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/profile view/i)).toBeInTheDocument();
+    expect(await screen.findByText(/profile view/i)).toBeInTheDocument();
   });
 
   it('navigates to signup page', async () => {
@@ -126,11 +126,11 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /sign up/i }));
 
-    expect(screen.getByText(/already have an account/i)).toBeInTheDocument();
+    expect(await screen.findByText(/already have an account/i)).toBeInTheDocument();
   });
 
   it('navigates to forgot password page', async () => {
@@ -148,11 +148,11 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /forgot your password/i }));
 
-    expect(screen.getByText(/we'll help you get back into your account/i)).toBeInTheDocument();
+    expect(await screen.findByText(/we'll help you get back into your account/i)).toBeInTheDocument();
   });
 
   it('navigates back to login from signup', async () => {
@@ -172,11 +172,11 @@ describe('App', () => {
 
     // Navigate to signup
     await user.click(screen.getByRole('button', { name: /sign up/i }));
-    expect(screen.getByText(/already have an account/i)).toBeInTheDocument();
+    expect(await screen.findByText(/already have an account/i)).toBeInTheDocument();
 
     // Navigate back to login
     await user.click(screen.getByRole('button', { name: /sign in/i }));
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
   });
 
   it('navigates back to login from forgot password', async () => {
@@ -200,10 +200,10 @@ describe('App', () => {
 
     // Navigate back to login
     await user.click(screen.getByRole('button', { name: /back to login/i }));
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
   });
 
-  it('prevents access to protected content when not authenticated', () => {
+  it('prevents access to protected content when not authenticated', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -218,11 +218,11 @@ describe('App', () => {
     render(<App />);
 
     // Should show login page, not profile
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
     expect(screen.queryByText(/profile view/i)).not.toBeInTheDocument();
   });
 
-  it('transitions from unauthenticated to authenticated', () => {
+  it('transitions from unauthenticated to authenticated', async () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -236,7 +236,7 @@ describe('App', () => {
 
     const { rerender } = render(<App />);
 
-    expect(screen.getByText(/good roots network/i)).toBeInTheDocument();
+    expect(await screen.findByText(/good roots network/i)).toBeInTheDocument();
 
     // Simulate successful authentication
     mockUseAuth.mockReturnValue({
@@ -271,8 +271,12 @@ describe('App', () => {
     rerender(<App />);
 
     expect(screen.queryByText(/good roots network/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/profile view/i)).toBeInTheDocument();
+    expect(await screen.findByText(/profile view/i)).toBeInTheDocument();
   });
 });
+
+
+
+
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,73 +1,72 @@
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { useAuth } from './hooks/useAuth'
-import { LoginPage } from './pages/LoginPage'
-import { SignUpPage } from './pages/SignUpPage'
-import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
-import { ProfileView } from './components/Profile/ProfileView'
 import { PlantLoader } from './components/branding/PlantLoader'
-import { OnboardingGuard } from './components/Onboarding/OnboardingGuard'
 import './App.css'
 
 type AuthView = 'login' | 'signup' | 'forgot-password';
 
-/**
- * Main App Component
- *
- * Handles authentication state and routing between auth pages and authenticated views.
- * For Phase 0, this provides a simple authentication gate with multiple auth flows.
- */
-function App() {
-  const { isAuthenticated, isLoading, refreshAuth } = useAuth()
-  const [authView, setAuthView] = useState<AuthView>('login')
+const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })));
+const SignUpPage = lazy(() => import('./pages/SignUpPage').then((m) => ({ default: m.SignUpPage })));
+const ForgotPasswordPage = lazy(() =>
+  import('./pages/ForgotPasswordPage').then((m) => ({ default: m.ForgotPasswordPage }))
+);
+const ProfileView = lazy(() => import('./components/Profile/ProfileView').then((m) => ({ default: m.ProfileView })));
+const OnboardingGuard = lazy(() =>
+  import('./components/Onboarding/OnboardingGuard').then((m) => ({ default: m.OnboardingGuard }))
+);
 
-  // Show loading state while checking authentication
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <PlantLoader size="md" />
-          <p className="text-gray-600 mt-4">Loading...</p>
-        </div>
-      </div>
-    )
-  }
-
-  // Show auth pages if not authenticated
-  if (!isAuthenticated) {
-    if (authView === 'signup') {
-      return (
-        <SignUpPage
-          onSuccess={() => setAuthView('login')}
-          onNavigateToLogin={() => setAuthView('login')}
-        />
-      )
-    }
-
-    if (authView === 'forgot-password') {
-      return (
-        <ForgotPasswordPage
-          onSuccess={() => setAuthView('login')}
-          onNavigateToLogin={() => setAuthView('login')}
-        />
-      )
-    }
-
-    return (
-      <LoginPage
-        onSuccess={() => {
-          // Refresh auth state after successful sign-in
-          refreshAuth();
-        }}
-        onNavigateToSignUp={() => setAuthView('signup')}
-        onNavigateToForgotPassword={() => setAuthView('forgot-password')}
-      />
-    )
-  }
-
-  // Show authenticated view with ProfileView component wrapped in OnboardingGuard
+function FullPageLoader() {
   return (
-    <OnboardingGuard>
-      <ProfileView />
-    </OnboardingGuard>
-  )
-}export default App
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center">
+        <PlantLoader size="md" />
+        <p className="text-gray-600 mt-4">Loading...</p>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const { isAuthenticated, isLoading, refreshAuth } = useAuth();
+  const [authView, setAuthView] = useState<AuthView>('login');
+
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Suspense fallback={<FullPageLoader />}>
+        {authView === 'signup' ? (
+          <SignUpPage
+            onSuccess={() => setAuthView('login')}
+            onNavigateToLogin={() => setAuthView('login')}
+          />
+        ) : authView === 'forgot-password' ? (
+          <ForgotPasswordPage
+            onSuccess={() => setAuthView('login')}
+            onNavigateToLogin={() => setAuthView('login')}
+          />
+        ) : (
+          <LoginPage
+            onSuccess={() => {
+              refreshAuth();
+            }}
+            onNavigateToSignUp={() => setAuthView('signup')}
+            onNavigateToForgotPassword={() => setAuthView('forgot-password')}
+          />
+        )}
+      </Suspense>
+    );
+  }
+
+  return (
+    <Suspense fallback={<FullPageLoader />}>
+      <OnboardingGuard>
+        <ProfileView />
+      </OnboardingGuard>
+    </Suspense>
+  );
+}
+
+export default App


### PR DESCRIPTION
## Summary
- lazy-load auth and authenticated app surfaces in `App.tsx` using `React.lazy` + `Suspense`
- add frontend performance budget script (`npm run perf:budget`) to enforce JS bundle ceilings
- wire performance budget check into PR CI workflow after build
- add documentation for solo/passive-ops-friendly frontend perf/resiliency posture
- update app tests for lazy-loading behavior

## Issue
Implements #28.

## Validation
- `npm run lint`
- `npm test -- --run src/App.test.tsx`
- `npm run build`
- `npm run perf:budget`
