### PR TITLE
feat(frontend): add abundant vs scarce market snapshot to derived feed UI

### DIFF
--- a/frontend/src/components/Listings/SearcherRequestPanel.test.tsx
+++ b/frontend/src/components/Listings/SearcherRequestPanel.test.tsx
@@ -122,7 +122,34 @@ describe('SearcherRequestPanel', () => {
 
     mockGetDerivedFeed.mockResolvedValue({
       items: [],
-      signals: [],
+      signals: [
+        {
+          geoBoundaryKey: '9v6k',
+          cropId: 'crop-1',
+          windowDays: 7,
+          listingCount: 2,
+          requestCount: 8,
+          supplyQuantity: '20',
+          demandQuantity: '80',
+          scarcityScore: 0.92,
+          abundanceScore: 0.18,
+          computedAt: '2026-02-20T10:00:00.000Z',
+          expiresAt: '2026-02-20T16:00:00.000Z',
+        },
+        {
+          geoBoundaryKey: '9v6k',
+          cropId: null,
+          windowDays: 7,
+          listingCount: 12,
+          requestCount: 3,
+          supplyQuantity: '160',
+          demandQuantity: '20',
+          scarcityScore: 0.10,
+          abundanceScore: 0.94,
+          computedAt: '2026-02-20T10:00:00.000Z',
+          expiresAt: '2026-02-20T16:00:00.000Z',
+        },
+      ],
       freshness: {
         asOf: '2026-02-20T10:00:00.000Z',
         isStale: false,
@@ -429,6 +456,11 @@ describe('SearcherRequestPanel', () => {
     expect(aiSummaryCard).toBeInTheDocument();
     expect(within(aiSummaryCard).getByText(/ai-assisted/i)).toBeInTheDocument();
     expect(within(aiSummaryCard).getByText(/ai summary for local produce trends/i)).toBeInTheDocument();
+
+    const marketSnapshot = await screen.findByTestId('market-snapshot-card');
+    expect(marketSnapshot).toBeInTheDocument();
+    expect(within(marketSnapshot).getByText(/likely scarce/i)).toBeInTheDocument();
+    expect(within(marketSnapshot).getByText(/likely abundant/i)).toBeInTheDocument();
   });
 
   it('supports opt-out for AI insights while preserving core listing flow', async () => {


### PR DESCRIPTION
## Summary
- add a derived-feed **Market snapshot** UI card in Searcher Request flow
- present top **Likely scarce** and **Likely abundant** signals for the last 7 days
- keep messaging newbie-friendly and action-oriented
- map signal crop IDs to friendly crop names where possible
- add test coverage for snapshot visibility alongside AI-assisted labeling

## UX intent
Surface useful supply/demand context without overwhelming users:
- quick read
- plain language
- clear distinction between scarce vs abundant signals

## Issue
Implements #27.

## Validation
- `npm run lint`
- `npm test -- --run src/components/Listings/SearcherRequestPanel.test.tsx`
- `npm run build`
- `npm run perf:budget`
