### PR TITLE
feat(entitlements): define free/premium matrix and API contract v1

### DIFF
--- a/config/entitlements/v1.tiers.json
+++ b/config/entitlements/v1.tiers.json
@@ -1,0 +1,48 @@
+{
+  "version": "v1",
+  "tiers": {
+    "free": {
+      "name": "Free",
+      "description": "Core gardening/homesteading experience with deterministic reminders.",
+      "entitlements": [
+        "core.discovery",
+        "core.listings.write",
+        "core.requests.write",
+        "core.claims.write",
+        "core.derived_feed.read",
+        "reminders.deterministic.schedule",
+        "reminders.deterministic.manage"
+      ]
+    },
+    "premium": {
+      "name": "Premium",
+      "description": "Everything in Free plus AI and advanced automations.",
+      "inherits": [
+        "free"
+      ],
+      "entitlements": [
+        "ai.copilot.weekly_grow_plan",
+        "ai.feed_insights.read",
+        "agent.tasks.automation",
+        "premium.analytics.read"
+      ]
+    }
+  },
+  "policies": {
+    "ai_is_premium_only": true,
+    "free_reminders_are_deterministic_only": true
+  },
+  "feature_map": {
+    "discover_listings": "core.discovery",
+    "create_listing": "core.listings.write",
+    "create_request": "core.requests.write",
+    "create_claim": "core.claims.write",
+    "derived_feed": "core.derived_feed.read",
+    "scheduled_reminders": "reminders.deterministic.schedule",
+    "manage_reminders": "reminders.deterministic.manage",
+    "ai_copilot": "ai.copilot.weekly_grow_plan",
+    "ai_feed_cards": "ai.feed_insights.read",
+    "agentic_automations": "agent.tasks.automation",
+    "premium_dashboard": "premium.analytics.read"
+  }
+}

--- a/docs/api/entitlements-contract.md
+++ b/docs/api/entitlements-contract.md
@@ -1,0 +1,49 @@
+# Entitlements API Contract (v1)
+
+## Purpose
+Provide a single backend contract for entitlement checks used by frontend and API handlers.
+
+## Response shape
+
+`GET /me/entitlements`
+
+```json
+{
+  "tier": "free",
+  "entitlementsVersion": "v1",
+  "entitlements": [
+    "core.discovery",
+    "core.listings.write",
+    "reminders.deterministic.schedule"
+  ],
+  "policy": {
+    "aiIsPremiumOnly": true,
+    "freeRemindersDeterministicOnly": true
+  }
+}
+```
+
+## Backend check contract
+
+Pseudo-signature:
+
+```text
+require_entitlement(user_id, entitlement_key) -> Ok | EntitlementDenied
+```
+
+Denied response (recommended):
+
+```json
+{
+  "error": "feature_locked",
+  "entitlementKey": "ai.feed_insights.read",
+  "requiredTier": "premium",
+  "upgradeHintKey": "upgrade.premium"
+}
+```
+
+## Enforcement notes
+
+- All AI endpoints must enforce premium entitlements.
+- Reminder endpoints must enforce deterministic-only behavior for free-tier paths.
+- Frontend can pre-check via `/me/entitlements`, but backend remains source of truth.

--- a/docs/phase-6-entitlements-matrix.md
+++ b/docs/phase-6-entitlements-matrix.md
@@ -1,0 +1,33 @@
+# Phase 6 Entitlements Matrix (v1)
+
+This defines what is available in **free** vs **premium** and acts as the source of truth for backend/frontend gating.
+
+Machine-readable source:
+- `config/entitlements/v1.tiers.json`
+
+## Tier matrix
+
+| Capability | Entitlement Key | Free | Premium |
+|---|---|---:|---:|
+| Discover listings | `core.discovery` | ✅ | ✅ |
+| Create/update listings | `core.listings.write` | ✅ | ✅ |
+| Create/update requests | `core.requests.write` | ✅ | ✅ |
+| Claims flow | `core.claims.write` | ✅ | ✅ |
+| Derived feed (deterministic) | `core.derived_feed.read` | ✅ | ✅ |
+| Scheduled reminders (deterministic) | `reminders.deterministic.schedule` | ✅ | ✅ |
+| Manage reminders | `reminders.deterministic.manage` | ✅ | ✅ |
+| AI copilot | `ai.copilot.weekly_grow_plan` | ❌ | ✅ |
+| AI feed insight cards | `ai.feed_insights.read` | ❌ | ✅ |
+| Agentic automations | `agent.tasks.automation` | ❌ | ✅ |
+| Premium analytics | `premium.analytics.read` | ❌ | ✅ |
+
+## Product policy rules
+
+1. **AI is premium-only.**
+2. **Free-tier reminders must be deterministic (non-LLM).**
+3. Premium inherits all free entitlements.
+
+## Versioning
+
+- Version: `v1`
+- Any entitlement key rename/removal requires a version bump and migration notes.


### PR DESCRIPTION
## Summary
- add versioned, machine-readable tier matrix: `config/entitlements/v1.tiers.json`
- define explicit free vs premium entitlement keys
- enforce product policy in matrix metadata:
  - AI is premium-only
  - free-tier reminders are deterministic-only
- add human-readable matrix doc: `docs/phase-6-entitlements-matrix.md`
- add backend-facing API/guard contract: `docs/api/entitlements-contract.md`

## Issue
Implements #65.

## Notes
This PR defines the contract and source-of-truth matrix. Enforcement middleware and persisted tier state are handled in follow-up issues (#66, #67).
