### PR TITLE
feat(users): persist tier state and expose subscription metadata in /me

### DIFF
--- a/backend/db/ddl.sql
+++ b/backend/db/ddl.sql
@@ -70,12 +70,18 @@ create table if not exists users (
   is_verified boolean not null default false,
   user_type text check (user_type in ('grower', 'gatherer')),
   onboarding_completed boolean not null default false,
+  tier text not null default 'free' check (tier in ('free', 'premium')),
+  subscription_status text not null default 'none' check (subscription_status in ('none', 'trialing', 'active', 'past_due', 'canceled')),
+  premium_expires_at timestamptz,
   created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
   deleted_at timestamptz
 );
 
 create index if not exists idx_users_deleted_at on users(deleted_at);
 create index if not exists idx_users_user_type on users(user_type) where user_type is not null;
+create index if not exists idx_users_tier on users(tier);
+create index if not exists idx_users_subscription_status on users(subscription_status);
 
 -- Cached rating summary (derived, but stored)
 create table if not exists user_rating_summary (

--- a/backend/db/migrations/0009_user_tier_subscription_state.sql
+++ b/backend/db/migrations/0009_user_tier_subscription_state.sql
@@ -1,0 +1,17 @@
+-- 0009_user_tier_subscription_state.sql
+-- Adds tier/subscription metadata for premium entitlements.
+
+begin;
+
+alter table users
+  add column if not exists tier text not null default 'free'
+    check (tier in ('free', 'premium')),
+  add column if not exists subscription_status text not null default 'none'
+    check (subscription_status in ('none', 'trialing', 'active', 'past_due', 'canceled')),
+  add column if not exists premium_expires_at timestamptz,
+  add column if not exists updated_at timestamptz not null default now();
+
+create index if not exists idx_users_tier on users(tier);
+create index if not exists idx_users_subscription_status on users(subscription_status);
+
+commit;

--- a/backend/src/api/models/profile.rs
+++ b/backend/src/api/models/profile.rs
@@ -41,6 +41,14 @@ pub struct UserRatingSummary {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SubscriptionMetadata {
+    pub tier: String,
+    pub subscription_status: String,
+    pub premium_expires_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MeProfileResponse {
     pub id: String,
     pub email: Option<String>,
@@ -49,6 +57,7 @@ pub struct MeProfileResponse {
     pub user_type: Option<UserType>,
     pub onboarding_completed: bool,
     pub created_at: String,
+    pub subscription: SubscriptionMetadata,
     pub grower_profile: Option<GrowerProfile>,
     pub gatherer_profile: Option<GathererProfile>,
     pub rating_summary: Option<UserRatingSummary>,


### PR DESCRIPTION
## Summary
- add user tier/subscription persistence fields via migration:
  - `users.tier` (`free|premium`, default `free`)
  - `users.subscription_status` (`none|trialing|active|past_due|canceled`, default `none`)
  - `users.premium_expires_at`
  - `users.updated_at`
- add indexes for tier/subscription status filtering
- extend `GET /me` + `PUT /me` user row reads to include subscription metadata
- include new `subscription` object in `MeProfileResponse`

## Issue
Implements #67.

## Notes
- Existing users default to free-tier via migration defaults.
- This PR provides persisted state + profile exposure; enforcement middleware remains in #66.
