### PR TITLE
feat(api): implement entitlement middleware and /me/entitlements

### DIFF
--- a/backend/src/api/handlers/user.rs
+++ b/backend/src/api/handlers/user.rs
@@ -1,5 +1,6 @@
 use crate::db;
 use crate::location;
+use crate::middleware::entitlements;
 use crate::models::crop::ErrorResponse;
 use crate::models::profile::{
     GrowerProfile, MeProfileResponse, PublicUserResponse, PutMeRequest, SubscriptionMetadata,
@@ -163,6 +164,16 @@ pub async fn upsert_current_user(
     }
 
     json_response(200, &to_me_response(&client, user_row).await?)
+}
+
+pub async fn get_current_entitlements(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request, correlation_id)?;
+    let client = db::connect().await?;
+    let snapshot = entitlements::get_entitlements_snapshot(&client, user_id).await?;
+    json_response(200, &snapshot)
 }
 
 pub async fn get_public_user(user_id: &str) -> Result<Response<Body>, lambda_http::Error> {

--- a/backend/src/api/middleware/entitlements.rs
+++ b/backend/src/api/middleware/entitlements.rs
@@ -1,0 +1,101 @@
+use crate::models::entitlements::{
+    EntitlementsPolicy, EntitlementsResponse, FeatureLockedErrorResponse,
+};
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+const ENTITLEMENTS_VERSION: &str = "v1";
+
+const FREE_ENTITLEMENTS: &[&str] = &[
+    "core.discovery",
+    "core.listings.write",
+    "core.requests.write",
+    "core.claims.write",
+    "core.derived_feed.read",
+    "reminders.deterministic.schedule",
+    "reminders.deterministic.manage",
+];
+
+const PREMIUM_ONLY_ENTITLEMENTS: &[&str] = &[
+    "ai.copilot.weekly_grow_plan",
+    "ai.feed_insights.read",
+    "agent.tasks.automation",
+    "premium.analytics.read",
+];
+
+#[allow(dead_code)]
+pub struct FeatureLockedError {
+    pub entitlement_key: String,
+}
+
+#[allow(dead_code)]
+impl FeatureLockedError {
+    pub fn to_response(&self) -> FeatureLockedErrorResponse {
+        FeatureLockedErrorResponse {
+            error: "feature_locked".to_string(),
+            entitlement_key: self.entitlement_key.clone(),
+            required_tier: "premium".to_string(),
+            upgrade_hint_key: "upgrade.premium".to_string(),
+        }
+    }
+}
+
+pub async fn get_entitlements_snapshot(
+    client: &Client,
+    user_id: Uuid,
+) -> Result<EntitlementsResponse, lambda_http::Error> {
+    let tier = load_user_tier(client, user_id).await?;
+    let mut keys: Vec<String> = FREE_ENTITLEMENTS.iter().map(|k| (*k).to_string()).collect();
+
+    if tier == "premium" {
+        keys.extend(PREMIUM_ONLY_ENTITLEMENTS.iter().map(|k| (*k).to_string()));
+    }
+
+    Ok(EntitlementsResponse {
+        tier,
+        entitlements_version: ENTITLEMENTS_VERSION.to_string(),
+        entitlements: keys,
+        policy: EntitlementsPolicy {
+            ai_is_premium_only: true,
+            free_reminders_deterministic_only: true,
+        },
+    })
+}
+
+pub async fn require_entitlement(
+    client: &Client,
+    user_id: Uuid,
+    entitlement_key: &str,
+) -> Result<(), FeatureLockedError> {
+    let snapshot = get_entitlements_snapshot(client, user_id)
+        .await
+        .map_err(|_| FeatureLockedError {
+            entitlement_key: entitlement_key.to_string(),
+        })?;
+
+    if snapshot
+        .entitlements
+        .iter()
+        .any(|key| key == entitlement_key)
+    {
+        Ok(())
+    } else {
+        Err(FeatureLockedError {
+            entitlement_key: entitlement_key.to_string(),
+        })
+    }
+}
+
+async fn load_user_tier(client: &Client, user_id: Uuid) -> Result<String, lambda_http::Error> {
+    let row = client
+        .query_opt(
+            "select tier from users where id = $1 and deleted_at is null",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| lambda_http::Error::from(format!("Database query error: {e}")))?;
+
+    Ok(row
+        .and_then(|r| r.get::<_, Option<String>>("tier"))
+        .unwrap_or_else(|| "free".to_string()))
+}

--- a/backend/src/api/middleware/mod.rs
+++ b/backend/src/api/middleware/mod.rs
@@ -1,1 +1,2 @@
 pub mod correlation;
+pub mod entitlements;

--- a/backend/src/api/models/entitlements.rs
+++ b/backend/src/api/models/entitlements.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntitlementsPolicy {
+    pub ai_is_premium_only: bool,
+    pub free_reminders_deterministic_only: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntitlementsResponse {
+    pub tier: String,
+    pub entitlements_version: String,
+    pub entitlements: Vec<String>,
+    pub policy: EntitlementsPolicy,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct FeatureLockedErrorResponse {
+    pub error: String,
+    pub entitlement_key: String,
+    pub required_tier: String,
+    pub upgrade_hint_key: String,
+}

--- a/backend/src/api/models/mod.rs
+++ b/backend/src/api/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod crop;
+pub mod entitlements;
 pub mod feed;
 pub mod listing;
 pub mod profile;

--- a/backend/src/api/router.rs
+++ b/backend/src/api/router.rs
@@ -54,6 +54,9 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
     let response = match (event.method().as_str(), event.uri().path()) {
         ("GET", "/me") => handle(user::get_current_user(event, &correlation_id).await)?,
         ("PUT", "/me") => handle(user::upsert_current_user(event, &correlation_id).await)?,
+        ("GET", "/me/entitlements") => {
+            handle(user::get_current_entitlements(event, &correlation_id).await)?
+        }
 
         ("GET", "/crops") => handle(crop::list_my_crops(event, &correlation_id).await)?,
         ("POST", "/crops") => handle(crop::create_my_crop(event, &correlation_id).await)?,


### PR DESCRIPTION
## Summary
- add entitlement middleware module with:
  - entitlement snapshot resolution by user tier
  - reusable `require_entitlement(...)` helper for backend handlers
- add `GET /me/entitlements` endpoint to expose resolved entitlements to frontend
- add structured feature-locked error response model for premium gate responses
- enforce premium AI entitlement in derived feed summary generation (`ai.feed_insights.read`)
  - free tier continues to receive deterministic feed data, but no AI summary

## Issue
Implements #66.

## Validation
- `cargo fmt --all --`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
