### PR TITLE
feat(reminders): add deterministic free-tier reminder engine foundation

### DIFF
--- a/backend/db/ddl.sql
+++ b/backend/db/ddl.sql
@@ -92,6 +92,38 @@ create unique index if not exists idx_users_stripe_subscription_id
   on users(stripe_subscription_id)
   where stripe_subscription_id is not null;
 
+create table if not exists reminder_rules (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  title text not null,
+  reminder_type text not null check (reminder_type in ('watering', 'harvest', 'checkin', 'custom')),
+  cadence_days integer not null check (cadence_days between 1 and 365),
+  start_date date not null,
+  timezone text not null default 'UTC',
+  status text not null default 'active' check (status in ('active', 'paused')),
+  next_run_at timestamptz not null,
+  last_run_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index if not exists idx_reminder_rules_user_status_next
+  on reminder_rules(user_id, status, next_run_at)
+  where deleted_at is null;
+
+create table if not exists reminder_dispatches (
+  id bigserial primary key,
+  reminder_rule_id uuid not null references reminder_rules(id) on delete cascade,
+  scheduled_for timestamptz not null,
+  dispatched_at timestamptz,
+  delivery_status text not null default 'queued' check (delivery_status in ('queued', 'sent', 'failed')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_reminder_dispatches_rule_scheduled
+  on reminder_dispatches(reminder_rule_id, scheduled_for desc);
+
 create table if not exists stripe_webhook_events (
   id text primary key,
   event_type text not null,

--- a/backend/db/migrations/0012_deterministic_reminders.sql
+++ b/backend/db/migrations/0012_deterministic_reminders.sql
@@ -1,0 +1,38 @@
+-- 0012_deterministic_reminders.sql
+-- Free-tier deterministic reminder engine foundation.
+
+begin;
+
+create table if not exists reminder_rules (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  title text not null,
+  reminder_type text not null check (reminder_type in ('watering', 'harvest', 'checkin', 'custom')),
+  cadence_days integer not null check (cadence_days between 1 and 365),
+  start_date date not null,
+  timezone text not null default 'UTC',
+  status text not null default 'active' check (status in ('active', 'paused')),
+  next_run_at timestamptz not null,
+  last_run_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index if not exists idx_reminder_rules_user_status_next
+  on reminder_rules(user_id, status, next_run_at)
+  where deleted_at is null;
+
+create table if not exists reminder_dispatches (
+  id bigserial primary key,
+  reminder_rule_id uuid not null references reminder_rules(id) on delete cascade,
+  scheduled_for timestamptz not null,
+  dispatched_at timestamptz,
+  delivery_status text not null default 'queued' check (delivery_status in ('queued', 'sent', 'failed')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_reminder_dispatches_rule_scheduled
+  on reminder_dispatches(reminder_rule_id, scheduled_for desc);
+
+commit;

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -6,5 +6,6 @@ pub mod crop;
 pub mod feed;
 pub mod listing;
 pub mod listing_discovery;
+pub mod reminder;
 pub mod request;
 pub mod user;

--- a/backend/src/api/handlers/reminder.rs
+++ b/backend/src/api/handlers/reminder.rs
@@ -1,0 +1,293 @@
+use crate::auth::extract_auth_context;
+use crate::db;
+use lambda_http::{Body, Request, Response};
+use serde::{Deserialize, Serialize};
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateReminderRequest {
+    pub title: String,
+    pub reminder_type: String,
+    pub cadence_days: i32,
+    pub start_date: String,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateReminderStatusRequest {
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderResponse {
+    pub id: String,
+    pub title: String,
+    pub reminder_type: String,
+    pub cadence_days: i32,
+    pub start_date: String,
+    pub timezone: String,
+    pub status: String,
+    pub next_run_at: String,
+    pub last_run_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderListResponse {
+    pub items: Vec<ReminderResponse>,
+}
+
+pub async fn list_reminders(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let client = db::connect().await?;
+
+    let rows = client
+        .query(
+            "
+            select id, title, reminder_type, cadence_days, start_date::text as start_date,
+                   timezone, status, next_run_at, last_run_at, created_at
+              from reminder_rules
+             where user_id = $1
+               and deleted_at is null
+             order by next_run_at asc
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        reminder_count = rows.len(),
+        "Listed deterministic reminders"
+    );
+
+    json_response(
+        200,
+        &ReminderListResponse {
+            items: rows.iter().map(row_to_response).collect(),
+        },
+    )
+}
+
+pub async fn create_reminder(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let payload: CreateReminderRequest = parse_json_body(request)?;
+
+    if payload.title.trim().is_empty() {
+        return error_response(400, "title is required");
+    }
+
+    if !matches!(
+        payload.reminder_type.as_str(),
+        "watering" | "harvest" | "checkin" | "custom"
+    ) {
+        return error_response(
+            400,
+            "reminderType must be one of watering|harvest|checkin|custom",
+        );
+    }
+
+    if !(1..=365).contains(&payload.cadence_days) {
+        return error_response(400, "cadenceDays must be between 1 and 365");
+    }
+
+    let start_date = chrono::NaiveDate::parse_from_str(&payload.start_date, "%Y-%m-%d")
+        .map_err(|_| lambda_http::Error::from("startDate must use YYYY-MM-DD"))?;
+    let timezone = payload.timezone.unwrap_or_else(|| "UTC".to_string());
+
+    let next_run_at = calculate_next_run_at(start_date, payload.cadence_days);
+
+    let client = db::connect().await?;
+    let row = client
+        .query_one(
+            "
+            insert into reminder_rules (
+              user_id, title, reminder_type, cadence_days, start_date, timezone, status, next_run_at
+            )
+            values ($1, $2, $3, $4, $5, $6, 'active', $7)
+            returning id, title, reminder_type, cadence_days, start_date::text as start_date,
+                      timezone, status, next_run_at, last_run_at, created_at
+            ",
+            &[
+                &user_id,
+                &payload.title.trim(),
+                &payload.reminder_type,
+                &payload.cadence_days,
+                &start_date,
+                &timezone,
+                &next_run_at,
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        reminder_id = %row.get::<_, Uuid>("id"),
+        "Created deterministic reminder"
+    );
+
+    json_response(201, &row_to_response(&row))
+}
+
+pub async fn update_reminder_status(
+    request: &Request,
+    correlation_id: &str,
+    reminder_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let reminder_uuid = Uuid::parse_str(reminder_id)
+        .map_err(|_| lambda_http::Error::from("Invalid reminder id"))?;
+    let payload: UpdateReminderStatusRequest = parse_json_body(request)?;
+
+    if !matches!(payload.status.as_str(), "active" | "paused") {
+        return error_response(400, "status must be active or paused");
+    }
+
+    let client = db::connect().await?;
+    let row = client
+        .query_opt(
+            "
+            update reminder_rules
+               set status = $3,
+                   updated_at = now()
+             where id = $1
+               and user_id = $2
+               and deleted_at is null
+            returning id, title, reminder_type, cadence_days, start_date::text as start_date,
+                      timezone, status, next_run_at, last_run_at, created_at
+            ",
+            &[&reminder_uuid, &user_id, &payload.status],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let Some(row) = row else {
+        return error_response(404, "Reminder not found");
+    };
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        reminder_id,
+        status = payload.status,
+        "Updated deterministic reminder status"
+    );
+
+    json_response(200, &row_to_response(&row))
+}
+
+fn calculate_next_run_at(
+    start_date: chrono::NaiveDate,
+    cadence_days: i32,
+) -> chrono::DateTime<chrono::Utc> {
+    use chrono::{Datelike, Duration, TimeZone, Utc};
+
+    let now = Utc::now();
+    let mut next = Utc
+        .with_ymd_and_hms(
+            start_date.year(),
+            start_date.month(),
+            start_date.day(),
+            9,
+            0,
+            0,
+        )
+        .single()
+        .unwrap_or(now);
+
+    while next < now {
+        next += Duration::days(i64::from(cadence_days));
+    }
+
+    next
+}
+
+fn row_to_response(row: &Row) -> ReminderResponse {
+    ReminderResponse {
+        id: row.get::<_, Uuid>("id").to_string(),
+        title: row.get("title"),
+        reminder_type: row.get("reminder_type"),
+        cadence_days: row.get("cadence_days"),
+        start_date: row.get("start_date"),
+        timezone: row.get("timezone"),
+        status: row.get("status"),
+        next_run_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("next_run_at")
+            .to_rfc3339(),
+        last_run_at: row
+            .get::<_, Option<chrono::DateTime<chrono::Utc>>>("last_run_at")
+            .map(|v| v.to_rfc3339()),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+    }
+}
+
+fn extract_user_id(request: &Request) -> Result<Uuid, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    Uuid::parse_str(&auth.user_id).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn error_response(status: u16, message: &str) -> Result<Response<Body>, lambda_http::Error> {
+    json_response(status, &serde_json::json!({ "error": message }))
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_run_calculation_is_deterministic_and_future() {
+        let start_date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let next = calculate_next_run_at(start_date, 7);
+        assert!(next > chrono::Utc::now() - chrono::Duration::days(7));
+    }
+}

--- a/backend/src/api/router.rs
+++ b/backend/src/api/router.rs
@@ -1,5 +1,6 @@
 use crate::handlers::{
-    billing, catalog, claim, claim_read, crop, feed, listing, listing_discovery, request, user,
+    billing, catalog, claim, claim_read, crop, feed, listing, listing_discovery, reminder, request,
+    user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -78,6 +79,9 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
         ("GET", "/claims") => handle(claim_read::list_claims(event, &correlation_id).await)?,
         ("POST", "/claims") => handle(claim::create_claim(event, &correlation_id).await)?,
 
+        ("GET", "/reminders") => handle(reminder::list_reminders(event, &correlation_id).await)?,
+        ("POST", "/reminders") => handle(reminder::create_reminder(event, &correlation_id).await)?,
+
         ("GET", "/catalog/crops") => handle(catalog::list_catalog_crops().await)?,
 
         _ => route_dynamic_routes(event, &correlation_id).await?,
@@ -129,6 +133,14 @@ async fn route_dynamic_routes(
     if let Some(request_id) = event.uri().path().strip_prefix("/requests/") {
         let result = match event.method().as_str() {
             "PUT" => request::update_request(event, correlation_id, request_id).await,
+            _ => method_not_allowed(),
+        };
+        return handle(result);
+    }
+
+    if let Some(reminder_id) = event.uri().path().strip_prefix("/reminders/") {
+        let result = match event.method().as_str() {
+            "PUT" => reminder::update_reminder_status(event, correlation_id, reminder_id).await,
             _ => method_not_allowed(),
         };
         return handle(result);


### PR DESCRIPTION
## Summary
- add deterministic reminder engine foundation for free tier (no AI)
- add DB migration + schema for reminder rules and dispatch history
- add reminder API endpoints:
  - `GET /reminders` (list)
  - `POST /reminders` (create)
  - `PUT /reminders/{id}` (pause/resume via status)
- deterministic next-run calculation based on `startDate + cadenceDays`
- include validation for reminder type, cadence, and start date

## Issue
Implements #70.

## Policy alignment
- Free-tier reminders are deterministic only (no LLM dependency)

## Validation
- `cargo fmt --all --`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
