### PR TITLE
feat(frontend): add deterministic reminder management UX (watering/harvest/fertilizer)

### DIFF
--- a/frontend/src/components/Profile/ProfileView.tsx
+++ b/frontend/src/components/Profile/ProfileView.tsx
@@ -6,6 +6,7 @@ import { PlantLoader } from '../branding/PlantLoader';
 import { Button } from '../ui/Button';
 import { GrowerListingPanel } from '../Listings/GrowerListingPanel';
 import { SearcherRequestPanel } from '../Listings/SearcherRequestPanel';
+import { ReminderPanel } from '../Reminders/ReminderPanel';
 
 /**
  * ProfileView Component
@@ -182,6 +183,8 @@ export function ProfileView() {
               defaultRadiusMiles={profile.gathererProfile?.searchRadiusMiles}
             />
           )}
+
+          <ReminderPanel />
 
           <Button
             onClick={handleSignOut}

--- a/frontend/src/components/Reminders/ReminderPanel.tsx
+++ b/frontend/src/components/Reminders/ReminderPanel.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createReminder,
+  listReminders,
+  type ReminderType,
+  updateReminderStatus,
+} from '../../services/api';
+import { Button } from '../ui/Button';
+
+const REMINDER_TYPES: Array<{ value: ReminderType; label: string }> = [
+  { value: 'watering', label: 'Watering' },
+  { value: 'harvest', label: 'Harvest' },
+  { value: 'fertilizer', label: 'Fertilizer' },
+  { value: 'checkin', label: 'Garden check-in' },
+  { value: 'custom', label: 'Custom' },
+];
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function ReminderPanel() {
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState('');
+  const [reminderType, setReminderType] = useState<ReminderType>('watering');
+  const [cadenceDays, setCadenceDays] = useState(7);
+  const [startDate, setStartDate] = useState(todayIsoDate());
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const remindersQuery = useQuery({
+    queryKey: ['reminders'],
+    queryFn: listReminders,
+    staleTime: 30_000,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createReminder,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['reminders'] });
+      setTitle('');
+      setReminderType('watering');
+      setCadenceDays(7);
+      setStartDate(todayIsoDate());
+      setFormError(null);
+    },
+    onError: (error) => {
+      setFormError(error instanceof Error ? error.message : 'Failed to create reminder');
+    },
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: ({ reminderId, status }: { reminderId: string; status: 'active' | 'paused' }) =>
+      updateReminderStatus(reminderId, status),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['reminders'] });
+    },
+  });
+
+  const sortedReminders = useMemo(() => {
+    const items = remindersQuery.data?.items ?? [];
+    return [...items].sort((a, b) => a.nextRunAt.localeCompare(b.nextRunAt));
+  }, [remindersQuery.data?.items]);
+
+  const submit = () => {
+    if (!title.trim()) {
+      setFormError('Title is required.');
+      return;
+    }
+
+    createMutation.mutate({
+      title: title.trim(),
+      reminderType,
+      cadenceDays,
+      startDate,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900">Deterministic reminders</h3>
+        <p className="text-sm text-gray-600 mt-1">
+          Set recurring reminders for watering, harvest, fertilizer, and check-ins.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="text-sm">
+          <span className="block text-gray-600 mb-1">Reminder title</span>
+          <input
+            className="w-full rounded-md border border-gray-300 px-3 py-2"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Tomatoes - fertilize"
+          />
+        </label>
+
+        <label className="text-sm">
+          <span className="block text-gray-600 mb-1">Type</span>
+          <select
+            className="w-full rounded-md border border-gray-300 px-3 py-2"
+            value={reminderType}
+            onChange={(event) => setReminderType(event.target.value as ReminderType)}
+          >
+            {REMINDER_TYPES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="text-sm">
+          <span className="block text-gray-600 mb-1">Every (days)</span>
+          <input
+            type="number"
+            min={1}
+            max={365}
+            className="w-full rounded-md border border-gray-300 px-3 py-2"
+            value={cadenceDays}
+            onChange={(event) => setCadenceDays(Number(event.target.value) || 1)}
+          />
+        </label>
+
+        <label className="text-sm">
+          <span className="block text-gray-600 mb-1">Start date</span>
+          <input
+            type="date"
+            className="w-full rounded-md border border-gray-300 px-3 py-2"
+            value={startDate}
+            onChange={(event) => setStartDate(event.target.value)}
+          />
+        </label>
+      </div>
+
+      {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+
+      <Button onClick={submit} disabled={createMutation.isPending} variant="primary">
+        {createMutation.isPending ? 'Creating...' : 'Create reminder'}
+      </Button>
+
+      <div className="border-t pt-4">
+        <h4 className="text-sm font-semibold text-gray-900 mb-2">Upcoming reminders</h4>
+
+        {remindersQuery.isLoading ? <p className="text-sm text-gray-600">Loading reminders...</p> : null}
+
+        {remindersQuery.isError ? (
+          <p className="text-sm text-red-600">Could not load reminders right now.</p>
+        ) : null}
+
+        {!remindersQuery.isLoading && !remindersQuery.isError && sortedReminders.length === 0 ? (
+          <p className="text-sm text-gray-600">No reminders yet. Create one above.</p>
+        ) : null}
+
+        <ul className="space-y-2">
+          {sortedReminders.map((reminder) => {
+            const isPaused = reminder.status === 'paused';
+            return (
+              <li
+                key={reminder.id}
+                className="rounded-md border border-gray-200 px-3 py-2 flex items-center justify-between gap-3"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900">{reminder.title}</p>
+                  <p className="text-xs text-gray-600">
+                    {reminder.reminderType} • every {reminder.cadenceDays} days • next{' '}
+                    {new Date(reminder.nextRunAt).toLocaleString()}
+                  </p>
+                </div>
+                <Button
+                  variant={isPaused ? 'primary' : 'secondary'}
+                  onClick={() =>
+                    statusMutation.mutate({
+                      reminderId: reminder.id,
+                      status: isPaused ? 'active' : 'paused',
+                    })
+                  }
+                  disabled={statusMutation.isPending}
+                >
+                  {isPaused ? 'Resume' : 'Pause'}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default ReminderPanel;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -718,6 +718,33 @@ export interface CreateCheckoutSessionResponse {
   checkoutSessionId: string;
 }
 
+export type ReminderType = 'watering' | 'harvest' | 'fertilizer' | 'checkin' | 'custom';
+
+export interface ReminderItem {
+  id: string;
+  title: string;
+  reminderType: ReminderType;
+  cadenceDays: number;
+  startDate: string;
+  timezone: string;
+  status: 'active' | 'paused';
+  nextRunAt: string;
+  lastRunAt: string | null;
+  createdAt: string;
+}
+
+export interface ReminderListResponse {
+  items: ReminderItem[];
+}
+
+export interface CreateReminderRequest {
+  title: string;
+  reminderType: ReminderType;
+  cadenceDays: number;
+  startDate: string;
+  timezone?: string;
+}
+
 export async function getDerivedFeed({
   geoKey,
   windowDays = 7,
@@ -744,6 +771,27 @@ export async function createCheckoutSession(
   return apiFetch<CreateCheckoutSessionResponse>('/billing/checkout-session', {
     method: 'POST',
     body: JSON.stringify(payload),
+  });
+}
+
+export async function listReminders(): Promise<ReminderListResponse> {
+  return apiFetch<ReminderListResponse>('/reminders');
+}
+
+export async function createReminder(payload: CreateReminderRequest): Promise<ReminderItem> {
+  return apiFetch<ReminderItem>('/reminders', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateReminderStatus(
+  reminderId: string,
+  status: 'active' | 'paused'
+): Promise<ReminderItem> {
+  return apiFetch<ReminderItem>(`/reminders/${encodeURIComponent(reminderId)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ status }),
   });
 }
 


### PR DESCRIPTION
## Summary
- add full reminder management UI panel in Profile experience
- support creating reminders with beginner-friendly types:
  - watering
  - harvest
  - fertilizer
  - check-in/custom
- show next-run preview and upcoming reminder list
- add pause/resume controls for predictable reminder management
- wire frontend to reminder API endpoints (`GET/POST/PUT /reminders`)

## Issue
Implements #71.

## UX goals met
- setup in under a minute
- clear next reminder timing
- low-friction pause/resume
