### PR TITLE
feat(agent): add premium agentic task runner foundation

### DIFF
--- a/backend/db/ddl.sql
+++ b/backend/db/ddl.sql
@@ -124,6 +124,38 @@ create table if not exists reminder_dispatches (
 create index if not exists idx_reminder_dispatches_rule_scheduled
   on reminder_dispatches(reminder_rule_id, scheduled_for desc);
 
+create table if not exists agent_tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  name text not null,
+  schedule_cron text not null,
+  instruction text not null,
+  status text not null default 'active' check (status in ('active', 'paused')),
+  last_run_at timestamptz,
+  next_run_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index if not exists idx_agent_tasks_user_status_next
+  on agent_tasks(user_id, status, next_run_at)
+  where deleted_at is null;
+
+create table if not exists agent_task_runs (
+  id bigserial primary key,
+  agent_task_id uuid not null references agent_tasks(id) on delete cascade,
+  run_status text not null check (run_status in ('queued', 'running', 'succeeded', 'failed')),
+  output jsonb,
+  error_message text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_agent_task_runs_task_created
+  on agent_task_runs(agent_task_id, created_at desc);
+
 create table if not exists stripe_webhook_events (
   id text primary key,
   event_type text not null,

--- a/backend/db/migrations/0013_agentic_task_runner.sql
+++ b/backend/db/migrations/0013_agentic_task_runner.sql
@@ -1,0 +1,38 @@
+-- 0013_agentic_task_runner.sql
+-- Premium agentic task runner foundation.
+
+begin;
+
+create table if not exists agent_tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  name text not null,
+  schedule_cron text not null,
+  instruction text not null,
+  status text not null default 'active' check (status in ('active', 'paused')),
+  last_run_at timestamptz,
+  next_run_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index if not exists idx_agent_tasks_user_status_next
+  on agent_tasks(user_id, status, next_run_at)
+  where deleted_at is null;
+
+create table if not exists agent_task_runs (
+  id bigserial primary key,
+  agent_task_id uuid not null references agent_tasks(id) on delete cascade,
+  run_status text not null check (run_status in ('queued', 'running', 'succeeded', 'failed')),
+  output jsonb,
+  error_message text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_agent_task_runs_task_created
+  on agent_task_runs(agent_task_id, created_at desc);
+
+commit;

--- a/backend/src/api/handlers/agent_task.rs
+++ b/backend/src/api/handlers/agent_task.rs
@@ -1,0 +1,227 @@
+use crate::auth::extract_auth_context;
+use crate::db;
+use crate::middleware::entitlements;
+use lambda_http::{Body, Request, Response};
+use serde::{Deserialize, Serialize};
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAgentTaskRequest {
+    pub name: String,
+    pub schedule_cron: String,
+    pub instruction: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAgentTaskStatusRequest {
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTaskResponse {
+    pub id: String,
+    pub name: String,
+    pub schedule_cron: String,
+    pub instruction: String,
+    pub status: String,
+    pub last_run_at: Option<String>,
+    pub next_run_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTaskListResponse {
+    pub items: Vec<AgentTaskResponse>,
+}
+
+pub async fn list_agent_tasks(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let client = db::connect().await?;
+    if let Err(feature_locked) = require_premium_automation(&client, user_id).await {
+        return json_response(403, &feature_locked.to_response());
+    }
+
+    let rows = client
+        .query(
+            "
+            select id, name, schedule_cron, instruction, status, last_run_at, next_run_at, created_at
+              from agent_tasks
+             where user_id = $1 and deleted_at is null
+             order by created_at desc
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(correlation_id = correlation_id, user_id = %user_id, count = rows.len(), "Listed agent tasks");
+
+    json_response(
+        200,
+        &AgentTaskListResponse {
+            items: rows.iter().map(row_to_response).collect(),
+        },
+    )
+}
+
+pub async fn create_agent_task(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let payload: CreateAgentTaskRequest = parse_json_body(request)?;
+    let client = db::connect().await?;
+    if let Err(feature_locked) = require_premium_automation(&client, user_id).await {
+        return json_response(403, &feature_locked.to_response());
+    }
+
+    if payload.name.trim().is_empty() || payload.instruction.trim().is_empty() {
+        return error_response(400, "name and instruction are required");
+    }
+
+    if payload.schedule_cron.split_whitespace().count() < 5 {
+        return error_response(400, "scheduleCron must look like a cron expression");
+    }
+
+    let row = client
+        .query_one(
+            "
+            insert into agent_tasks (user_id, name, schedule_cron, instruction, status)
+            values ($1, $2, $3, $4, 'active')
+            returning id, name, schedule_cron, instruction, status, last_run_at, next_run_at, created_at
+            ",
+            &[
+                &user_id,
+                &payload.name.trim(),
+                &payload.schedule_cron.trim(),
+                &payload.instruction.trim(),
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        task_id = %row.get::<_, Uuid>("id"),
+        "Created premium agent task"
+    );
+
+    json_response(201, &row_to_response(&row))
+}
+
+pub async fn update_agent_task_status(
+    request: &Request,
+    correlation_id: &str,
+    task_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = extract_user_id(request)?;
+    let task_uuid =
+        Uuid::parse_str(task_id).map_err(|_| lambda_http::Error::from("Invalid task id"))?;
+    let payload: UpdateAgentTaskStatusRequest = parse_json_body(request)?;
+    let client = db::connect().await?;
+    if let Err(feature_locked) = require_premium_automation(&client, user_id).await {
+        return json_response(403, &feature_locked.to_response());
+    }
+
+    if !matches!(payload.status.as_str(), "active" | "paused") {
+        return error_response(400, "status must be active or paused");
+    }
+
+    let row = client
+        .query_opt(
+            "
+            update agent_tasks
+               set status = $3,
+                   updated_at = now()
+             where id = $1 and user_id = $2 and deleted_at is null
+             returning id, name, schedule_cron, instruction, status, last_run_at, next_run_at, created_at
+            ",
+            &[&task_uuid, &user_id, &payload.status],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let Some(row) = row else {
+        return error_response(404, "Agent task not found");
+    };
+
+    tracing::info!(correlation_id = correlation_id, user_id = %user_id, task_id = task_id, status = payload.status, "Updated agent task status");
+
+    json_response(200, &row_to_response(&row))
+}
+
+fn row_to_response(row: &Row) -> AgentTaskResponse {
+    AgentTaskResponse {
+        id: row.get::<_, Uuid>("id").to_string(),
+        name: row.get("name"),
+        schedule_cron: row.get("schedule_cron"),
+        instruction: row.get("instruction"),
+        status: row.get("status"),
+        last_run_at: row
+            .get::<_, Option<chrono::DateTime<chrono::Utc>>>("last_run_at")
+            .map(|v| v.to_rfc3339()),
+        next_run_at: row
+            .get::<_, Option<chrono::DateTime<chrono::Utc>>>("next_run_at")
+            .map(|v| v.to_rfc3339()),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+    }
+}
+
+async fn require_premium_automation(
+    client: &tokio_postgres::Client,
+    user_id: Uuid,
+) -> Result<(), entitlements::FeatureLockedError> {
+    entitlements::require_entitlement(client, user_id, "agent.tasks.automation").await
+}
+
+fn extract_user_id(request: &Request) -> Result<Uuid, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    Uuid::parse_str(&auth.user_id).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn error_response(status: u16, message: &str) -> Result<Response<Body>, lambda_http::Error> {
+    json_response(status, &serde_json::json!({ "error": message }))
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_task;
 pub mod ai_copilot;
 pub mod billing;
 pub mod catalog;

--- a/backend/src/api/router.rs
+++ b/backend/src/api/router.rs
@@ -1,6 +1,6 @@
 use crate::handlers::{
-    ai_copilot, billing, catalog, claim, claim_read, crop, feed, listing, listing_discovery,
-    reminder, request, user,
+    agent_task, ai_copilot, billing, catalog, claim, claim_read, crop, feed, listing,
+    listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -68,6 +68,13 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
 
         ("POST", "/ai/copilot/weekly-plan") => {
             handle(ai_copilot::generate_weekly_plan(event, &correlation_id).await)?
+        }
+
+        ("GET", "/agent-tasks") => {
+            handle(agent_task::list_agent_tasks(event, &correlation_id).await)?
+        }
+        ("POST", "/agent-tasks") => {
+            handle(agent_task::create_agent_task(event, &correlation_id).await)?
         }
 
         ("GET", "/crops") => handle(crop::list_my_crops(event, &correlation_id).await)?,
@@ -145,6 +152,14 @@ async fn route_dynamic_routes(
     if let Some(reminder_id) = event.uri().path().strip_prefix("/reminders/") {
         let result = match event.method().as_str() {
             "PUT" => reminder::update_reminder_status(event, correlation_id, reminder_id).await,
+            _ => method_not_allowed(),
+        };
+        return handle(result);
+    }
+
+    if let Some(task_id) = event.uri().path().strip_prefix("/agent-tasks/") {
+        let result = match event.method().as_str() {
+            "PUT" => agent_task::update_agent_task_status(event, correlation_id, task_id).await,
             _ => method_not_allowed(),
         };
         return handle(result);


### PR DESCRIPTION
## Summary
- add premium agentic task runner data model + migration:
  - `agent_tasks`
  - `agent_task_runs`
- add premium-gated task management API endpoints:
  - `GET /agent-tasks`
  - `POST /agent-tasks`
  - `PUT /agent-tasks/{id}` (pause/resume)
- enforce entitlement `agent.tasks.automation`
- validate task payloads (name, instruction, cron-like schedule)
- include task status + run timestamps in response model

## Issue
Implements #74.

## Notes
This is foundation CRUD + gating for premium task automation; scheduler/executor orchestration can layer on next while preserving this contract.
