### PR TITLE
feat(ai): add safety and cost guardrails for premium AI features

### DIFF
--- a/backend/db/ddl.sql
+++ b/backend/db/ddl.sql
@@ -156,6 +156,24 @@ create table if not exists agent_task_runs (
 create index if not exists idx_agent_task_runs_task_created
   on agent_task_runs(agent_task_id, created_at desc);
 
+create table if not exists ai_usage_events (
+  id bigserial primary key,
+  user_id uuid not null references users(id) on delete cascade,
+  feature_key text not null,
+  model_id text not null,
+  estimated_tokens integer not null default 0,
+  estimated_cost_usd numeric(10, 4) not null default 0,
+  status text not null check (status in ('allowed', 'blocked')),
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ai_usage_events_user_created
+  on ai_usage_events(user_id, created_at desc);
+
+create index if not exists idx_ai_usage_events_feature_created
+  on ai_usage_events(feature_key, created_at desc);
+
 create table if not exists stripe_webhook_events (
   id text primary key,
   event_type text not null,

--- a/backend/db/migrations/0014_ai_guardrails_usage_budget.sql
+++ b/backend/db/migrations/0014_ai_guardrails_usage_budget.sql
@@ -1,0 +1,24 @@
+-- 0014_ai_guardrails_usage_budget.sql
+-- Premium AI safety + cost guardrails foundation.
+
+begin;
+
+create table if not exists ai_usage_events (
+  id bigserial primary key,
+  user_id uuid not null references users(id) on delete cascade,
+  feature_key text not null,
+  model_id text not null,
+  estimated_tokens integer not null default 0,
+  estimated_cost_usd numeric(10, 4) not null default 0,
+  status text not null check (status in ('allowed', 'blocked')),
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ai_usage_events_user_created
+  on ai_usage_events(user_id, created_at desc);
+
+create index if not exists idx_ai_usage_events_feature_created
+  on ai_usage_events(feature_key, created_at desc);
+
+commit;

--- a/backend/src/api/handlers/ai_copilot.rs
+++ b/backend/src/api/handlers/ai_copilot.rs
@@ -1,6 +1,6 @@
 use crate::auth::extract_auth_context;
 use crate::db;
-use crate::middleware::entitlements;
+use crate::middleware::{ai_guardrails, entitlements};
 use lambda_http::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
 use tokio_postgres::Row;
@@ -87,12 +87,31 @@ pub async fn generate_weekly_plan(
         .unwrap_or_else(|_| "amazon.nova-lite-v1:0".to_string());
     let model_version = std::env::var("BEDROCK_MODEL_VERSION").unwrap_or_else(|_| "v1".to_string());
 
+    let guardrails = ai_guardrails::enforce_and_record(
+        &client,
+        user_id,
+        "ai.copilot.weekly_grow_plan",
+        &model_id,
+    )
+    .await?;
+
+    if !guardrails.allowed {
+        return error_response(
+            429,
+            guardrails
+                .reason
+                .as_deref()
+                .unwrap_or("ai_guardrail_blocked"),
+        );
+    }
+
     tracing::info!(
         correlation_id = correlation_id,
         user_id = %user_id,
         geo_prefix,
         window_days,
         recommendation_count = recommendations.len(),
+        estimated_tokens = guardrails.estimated_tokens,
         "Generated premium weekly grow plan"
     );
 

--- a/backend/src/api/handlers/feed.rs
+++ b/backend/src/api/handlers/feed.rs
@@ -2,7 +2,7 @@ use crate::ai::{SummaryArtifact, SummaryGenerator};
 use crate::auth::extract_auth_context;
 use crate::db;
 use crate::location;
-use crate::middleware::entitlements;
+use crate::middleware::{ai_guardrails, entitlements};
 use crate::models::feed::{
     DerivedFeedAiSummary, DerivedFeedFreshness, DerivedFeedResponse, DerivedFeedSignal,
     GrowerGuidance, GrowerGuidanceExplanation, GrowerGuidanceSignalRef,
@@ -160,12 +160,25 @@ pub async fn get_derived_feed(
         .await
         .is_ok()
     {
-        load_or_generate_ai_summary(&client, &geo_prefix, query.window_days, &signals)
-            .await
-            .unwrap_or_else(|error| {
-                tracing::warn!(error = %error, "AI summary generation failed; degrading gracefully");
-                None
-            })
+        let model_id = std::env::var("BEDROCK_MODEL_PRIMARY")
+            .or_else(|_| std::env::var("BEDROCK_MODEL_ID"))
+            .unwrap_or_else(|_| "amazon.nova-lite-v1:0".to_string());
+
+        let guardrails =
+            ai_guardrails::enforce_and_record(&client, user_id, "ai.feed_insights.read", &model_id)
+                .await
+                .ok();
+
+        if matches!(guardrails.as_ref().map(|g| g.allowed), Some(false)) {
+            None
+        } else {
+            load_or_generate_ai_summary(&client, &geo_prefix, query.window_days, &signals)
+                .await
+                .unwrap_or_else(|error| {
+                    tracing::warn!(error = %error, "AI summary generation failed; degrading gracefully");
+                    None
+                })
+        }
     } else {
         None
     };

--- a/backend/src/api/middleware/ai_guardrails.rs
+++ b/backend/src/api/middleware/ai_guardrails.rs
@@ -1,0 +1,99 @@
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+pub struct GuardrailsConfig {
+    pub max_daily_requests_per_user: i64,
+    pub max_daily_tokens_per_user: i64,
+    pub default_estimated_tokens: i32,
+}
+
+pub struct GuardrailsDecision {
+    pub allowed: bool,
+    pub reason: Option<String>,
+    pub estimated_tokens: i32,
+}
+
+pub fn load_config() -> GuardrailsConfig {
+    GuardrailsConfig {
+        max_daily_requests_per_user: std::env::var("AI_MAX_DAILY_REQUESTS_PER_USER")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(30),
+        max_daily_tokens_per_user: std::env::var("AI_MAX_DAILY_TOKENS_PER_USER")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(60000),
+        default_estimated_tokens: std::env::var("AI_DEFAULT_ESTIMATED_TOKENS")
+            .ok()
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(1200),
+    }
+}
+
+pub async fn enforce_and_record(
+    client: &Client,
+    user_id: Uuid,
+    feature_key: &str,
+    model_id: &str,
+) -> Result<GuardrailsDecision, lambda_http::Error> {
+    let cfg = load_config();
+
+    let row = client
+        .query_one(
+            "
+            select
+              count(*)::bigint as request_count,
+              coalesce(sum(estimated_tokens), 0)::bigint as token_sum
+            from ai_usage_events
+            where user_id = $1
+              and created_at >= now() - interval '24 hours'
+              and status = 'allowed'
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let request_count: i64 = row.get("request_count");
+    let token_sum: i64 = row.get("token_sum");
+
+    let (allowed, reason): (bool, Option<String>) = if request_count
+        >= cfg.max_daily_requests_per_user
+    {
+        (false, Some("daily_request_cap_reached".to_string()))
+    } else if token_sum + i64::from(cfg.default_estimated_tokens) > cfg.max_daily_tokens_per_user {
+        (false, Some("daily_token_cap_reached".to_string()))
+    } else {
+        (true, None)
+    };
+
+    client
+        .execute(
+            "
+            insert into ai_usage_events (
+              user_id, feature_key, model_id, estimated_tokens, estimated_cost_usd, status, reason
+            )
+            values ($1, $2, $3, $4, 0, $5, $6)
+            ",
+            &[
+                &user_id,
+                &feature_key,
+                &model_id,
+                &cfg.default_estimated_tokens,
+                &(if allowed { "allowed" } else { "blocked" }),
+                &reason,
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    Ok(GuardrailsDecision {
+        allowed,
+        reason,
+        estimated_tokens: cfg.default_estimated_tokens,
+    })
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}

--- a/backend/src/api/middleware/mod.rs
+++ b/backend/src/api/middleware/mod.rs
@@ -1,2 +1,3 @@
+pub mod ai_guardrails;
 pub mod correlation;
 pub mod entitlements;

--- a/docs/ai-safety-cost-guardrails.md
+++ b/docs/ai-safety-cost-guardrails.md
@@ -1,0 +1,38 @@
+# AI Safety + Cost Guardrails (Premium)
+
+This document defines baseline guardrails for premium AI features.
+
+## Guardrails implemented
+
+- Per-user daily request cap
+- Per-user daily estimated token cap
+- Structured logging of allow/deny decisions in DB
+- 429 response for blocked premium copilot calls
+- Soft-block for feed AI cards when caps are exceeded (degrades to deterministic UX)
+
+## Environment variables
+
+- `AI_MAX_DAILY_REQUESTS_PER_USER` (default: `30`)
+- `AI_MAX_DAILY_TOKENS_PER_USER` (default: `60000`)
+- `AI_DEFAULT_ESTIMATED_TOKENS` (default: `1200`)
+
+## Data model
+
+- `ai_usage_events`
+  - user_id
+  - feature_key
+  - model_id
+  - estimated_tokens
+  - estimated_cost_usd
+  - status (`allowed|blocked`)
+  - reason
+
+## Feature keys used
+
+- `ai.copilot.weekly_grow_plan`
+- `ai.feed_insights.read`
+
+## Product behavior
+
+- If premium copilot exceeds cap: return `429` with guardrail reason.
+- If feed AI card exceeds cap: hide AI card and continue deterministic feed UX.


### PR DESCRIPTION
## Summary
- add AI safety/cost guardrail middleware with per-user daily caps
- enforce request and estimated-token budgets via env-configurable limits
- record allow/deny decisions in `ai_usage_events`
- block premium copilot endpoint with `429` when caps are exceeded
- gracefully degrade feed AI cards when guardrails block usage
- add migration + schema updates for AI usage telemetry
- document guardrail behavior and env config

## Issue
Implements #75.

## Env variables
- `AI_MAX_DAILY_REQUESTS_PER_USER` (default: 30)
- `AI_MAX_DAILY_TOKENS_PER_USER` (default: 60000)
- `AI_DEFAULT_ESTIMATED_TOKENS` (default: 1200)
