### PR TITLE
feat(analytics): add premium conversion KPI tracking and reporting

### DIFF
--- a/backend/db/ddl.sql
+++ b/backend/db/ddl.sql
@@ -174,6 +174,23 @@ create index if not exists idx_ai_usage_events_user_created
 create index if not exists idx_ai_usage_events_feature_created
   on ai_usage_events(feature_key, created_at desc);
 
+create table if not exists premium_analytics_events (
+  id bigserial primary key,
+  user_id uuid references users(id) on delete set null,
+  event_name text not null,
+  event_source text not null default 'backend',
+  metadata jsonb,
+  occurred_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_premium_analytics_events_name_time
+  on premium_analytics_events(event_name, occurred_at desc);
+
+create index if not exists idx_premium_analytics_events_user_time
+  on premium_analytics_events(user_id, occurred_at desc)
+  where user_id is not null;
+
 create table if not exists stripe_webhook_events (
   id text primary key,
   event_type text not null,

--- a/backend/db/migrations/0015_premium_analytics_events.sql
+++ b/backend/db/migrations/0015_premium_analytics_events.sql
@@ -1,0 +1,23 @@
+-- 0015_premium_analytics_events.sql
+-- Premium analytics event stream for conversion/retention reporting.
+
+begin;
+
+create table if not exists premium_analytics_events (
+  id bigserial primary key,
+  user_id uuid references users(id) on delete set null,
+  event_name text not null,
+  event_source text not null default 'backend',
+  metadata jsonb,
+  occurred_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_premium_analytics_events_name_time
+  on premium_analytics_events(event_name, occurred_at desc);
+
+create index if not exists idx_premium_analytics_events_user_time
+  on premium_analytics_events(user_id, occurred_at desc)
+  where user_id is not null;
+
+commit;

--- a/backend/src/api/handlers/analytics.rs
+++ b/backend/src/api/handlers/analytics.rs
@@ -1,0 +1,187 @@
+use crate::auth::extract_auth_context;
+use crate::db;
+use lambda_http::{Body, Request, Response};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackEventRequest {
+    pub event_name: String,
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PremiumKpiResponse {
+    pub window_days: i32,
+    pub funnel: HashMap<String, i64>,
+    pub conversion_rate: f64,
+}
+
+pub async fn track_premium_event(
+    request: &Request,
+    _correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    let user_id = Uuid::parse_str(&auth.user_id)
+        .map_err(|_| lambda_http::Error::from("Invalid user ID format"))?;
+    let payload: TrackEventRequest = parse_json_body(request)?;
+
+    if !matches!(
+        payload.event_name.as_str(),
+        "paywall_view" | "checkout_start" | "subscribe" | "cancel"
+    ) {
+        return error_response(400, "Unsupported analytics event");
+    }
+
+    let metadata = payload
+        .metadata
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| lambda_http::Error::from(format!("Invalid metadata JSON: {e}")))?;
+
+    let client = db::connect().await?;
+    client
+        .execute(
+            "
+            insert into premium_analytics_events (user_id, event_name, event_source, metadata)
+            values ($1, $2, 'frontend', $3::jsonb)
+            ",
+            &[&user_id, &payload.event_name, &metadata],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    json_response(202, &serde_json::json!({"accepted": true}))
+}
+
+pub async fn get_premium_kpis(
+    request: &Request,
+    _correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let _ = extract_auth_context(request)?;
+
+    let window_days = parse_window_days(request).unwrap_or(7);
+    let client = db::connect().await?;
+
+    let rows = client
+        .query(
+            "
+            select event_name, count(*)::bigint as total
+              from premium_analytics_events
+             where occurred_at >= now() - make_interval(days => $1)
+             group by event_name
+            ",
+            &[&window_days],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let mut funnel: HashMap<String, i64> = HashMap::new();
+    for row in rows {
+        let event_name: String = row.get("event_name");
+        let total: i64 = row.get("total");
+        funnel.insert(event_name, total);
+    }
+
+    let checkout_start = *funnel.get("checkout_start").unwrap_or(&0);
+    let subscribe = *funnel.get("subscribe").unwrap_or(&0);
+    let conversion_rate = if checkout_start > 0 {
+        count_to_f64(subscribe) / count_to_f64(checkout_start)
+    } else {
+        0.0
+    };
+
+    json_response(
+        200,
+        &PremiumKpiResponse {
+            window_days,
+            funnel,
+            conversion_rate,
+        },
+    )
+}
+
+pub async fn log_backend_event(
+    client: &tokio_postgres::Client,
+    user_id: Option<Uuid>,
+    event_name: &str,
+    metadata: Option<serde_json::Value>,
+) -> Result<(), lambda_http::Error> {
+    let metadata = metadata
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| lambda_http::Error::from(format!("Invalid metadata JSON: {e}")))?;
+
+    client
+        .execute(
+            "
+            insert into premium_analytics_events (user_id, event_name, event_source, metadata)
+            values ($1, $2, 'backend', $3::jsonb)
+            ",
+            &[&user_id, &event_name, &metadata],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    Ok(())
+}
+
+fn parse_window_days(request: &Request) -> Option<i32> {
+    request.uri().query().and_then(|query| {
+        query
+            .split('&')
+            .find_map(|pair| pair.split_once('='))
+            .and_then(|(k, v)| {
+                if k == "days" {
+                    v.parse::<i32>().ok()
+                } else {
+                    None
+                }
+            })
+    })
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn error_response(status: u16, message: &str) -> Result<Response<Body>, lambda_http::Error> {
+    json_response(status, &serde_json::json!({ "error": message }))
+}
+
+fn count_to_f64(value: i64) -> f64 {
+    i32::try_from(value).map_or_else(|_| f64::from(i32::MAX), f64::from)
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}

--- a/backend/src/api/handlers/billing.rs
+++ b/backend/src/api/handlers/billing.rs
@@ -1,5 +1,6 @@
 use crate::auth::extract_auth_context;
 use crate::db;
+use crate::handlers::analytics;
 use lambda_http::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -75,6 +76,14 @@ pub async fn create_checkout_session(
         .get("id")
         .and_then(Value::as_str)
         .ok_or_else(|| lambda_http::Error::from("Stripe checkout id missing"))?;
+
+    let _ = analytics::log_backend_event(
+        &db::connect().await?,
+        Some(user_id),
+        "checkout_start",
+        Some(serde_json::json!({ "checkoutSessionId": checkout_session_id })),
+    )
+    .await;
 
     tracing::info!(
         correlation_id = correlation_id,
@@ -208,6 +217,17 @@ async fn apply_checkout_session_completed(
             )
             .await
             .map_err(|e| format!("Failed to apply checkout completion: {e}"))?;
+
+        let _ = analytics::log_backend_event(
+            client,
+            Some(user_id),
+            "subscribe",
+            Some(serde_json::json!({
+                "source": "stripe_webhook",
+                "status": "active"
+            })),
+        )
+        .await;
     }
 
     Ok(())
@@ -226,7 +246,7 @@ async fn apply_subscription_update(
 
     if let Some(subscription_id) = stripe_subscription_id {
         let (tier, sub_status) = map_subscription_status(status);
-        client
+        let updated = client
             .execute(
                 "
                 update users
@@ -241,6 +261,24 @@ async fn apply_subscription_update(
             )
             .await
             .map_err(|e| format!("Failed to apply subscription update: {e}"))?;
+
+        if updated > 0 {
+            let event_name = if tier == "premium" {
+                "subscribe"
+            } else {
+                "cancel"
+            };
+            let _ = analytics::log_backend_event(
+                client,
+                None,
+                event_name,
+                Some(serde_json::json!({
+                    "source": "stripe_webhook",
+                    "subscriptionStatus": sub_status
+                })),
+            )
+            .await;
+        }
     }
 
     Ok(())

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_task;
 pub mod ai_copilot;
+pub mod analytics;
 pub mod billing;
 pub mod catalog;
 pub mod claim;

--- a/backend/src/api/router.rs
+++ b/backend/src/api/router.rs
@@ -1,5 +1,5 @@
 use crate::handlers::{
-    agent_task, ai_copilot, billing, catalog, claim, claim_read, crop, feed, listing,
+    agent_task, ai_copilot, analytics, billing, catalog, claim, claim_read, crop, feed, listing,
     listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
@@ -68,6 +68,13 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
 
         ("POST", "/ai/copilot/weekly-plan") => {
             handle(ai_copilot::generate_weekly_plan(event, &correlation_id).await)?
+        }
+
+        ("POST", "/analytics/premium/events") => {
+            handle(analytics::track_premium_event(event, &correlation_id).await)?
+        }
+        ("GET", "/analytics/premium/kpis") => {
+            handle(analytics::get_premium_kpis(event, &correlation_id).await)?
         }
 
         ("GET", "/agent-tasks") => {


### PR DESCRIPTION
## Summary
- add premium analytics event store (`premium_analytics_events`) with migration/indexes
- add backend analytics endpoints:
  - `POST /analytics/premium/events` (track paywall/conversion events)
  - `GET /analytics/premium/kpis?days=7` (funnel + conversion rate)
- add backend event logging helper for billing flows
- emit backend conversion events from Stripe flow:
  - `checkout_start`
  - `subscribe` / `cancel`
- provide weekly KPI response suitable for lightweight dashboard/reporting

## Issue
Implements #76.

## KPI coverage
- paywall view
- checkout start
- subscribe
- cancel
- conversion rate (`subscribe / checkout_start`) over configurable window
