### PR TITLE
feat(ai): standardize Bedrock Nova env config + structured JSON contract

### DIFF
--- a/backend/src/api/ai.rs
+++ b/backend/src/api/ai.rs
@@ -1,3 +1,4 @@
+use crate::ai_model_config;
 use crate::models::feed::DerivedFeedSignal;
 use chrono::{Duration, Utc};
 
@@ -103,11 +104,12 @@ fn bedrock_generate(
         signals.len()
     );
 
+    let model_cfg = ai_model_config::load_model_config();
+
     Ok(SummaryArtifact {
         summary_text,
-        model_id: std::env::var("BEDROCK_MODEL_ID")
-            .unwrap_or_else(|_| "anthropic.claude-3-5-sonnet-20240620-v1:0".to_string()),
-        model_version: "bedrock-configured".to_string(),
+        model_id: model_cfg.model_id,
+        model_version: format!("{}-{}", model_cfg.response_mode, model_cfg.schema_version),
         generated_at,
         expires_at: generated_at + Duration::hours(6),
     })

--- a/backend/src/api/ai_model_config.rs
+++ b/backend/src/api/ai_model_config.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiModelConfig {
+    pub provider: String,
+    pub model_id: String,
+    pub fallback_model_id: String,
+    pub region: String,
+    pub response_mode: String,
+    pub schema_version: String,
+}
+
+pub fn load_model_config() -> AiModelConfig {
+    AiModelConfig {
+        provider: std::env::var("AI_PROVIDER").unwrap_or_else(|_| "bedrock".to_string()),
+        model_id: std::env::var("BEDROCK_MODEL_PRIMARY")
+            .or_else(|_| std::env::var("BEDROCK_MODEL_ID"))
+            .unwrap_or_else(|_| "amazon.nova-lite-v1:0".to_string()),
+        fallback_model_id: std::env::var("BEDROCK_MODEL_FALLBACK")
+            .unwrap_or_else(|_| "amazon.nova-micro-v1:0".to_string()),
+        region: std::env::var("BEDROCK_REGION")
+            .or_else(|_| std::env::var("AWS_REGION"))
+            .unwrap_or_else(|_| "us-east-1".to_string()),
+        response_mode: std::env::var("AI_RESPONSE_MODE")
+            .unwrap_or_else(|_| "structured_json".to_string()),
+        schema_version: std::env::var("AI_RESPONSE_SCHEMA_VERSION")
+            .unwrap_or_else(|_| "v1".to_string()),
+    }
+}

--- a/backend/src/api/handlers/ai_copilot.rs
+++ b/backend/src/api/handlers/ai_copilot.rs
@@ -1,3 +1,4 @@
+use crate::ai_model_config;
 use crate::auth::extract_auth_context;
 use crate::db;
 use crate::middleware::{ai_guardrails, entitlements};
@@ -82,10 +83,9 @@ pub async fn generate_weekly_plan(
 
     let recommendations = build_recommendations(&rows);
 
-    let model_id = std::env::var("BEDROCK_MODEL_PRIMARY")
-        .or_else(|_| std::env::var("BEDROCK_MODEL_ID"))
-        .unwrap_or_else(|_| "amazon.nova-lite-v1:0".to_string());
-    let model_version = std::env::var("BEDROCK_MODEL_VERSION").unwrap_or_else(|_| "v1".to_string());
+    let model_cfg = ai_model_config::load_model_config();
+    let model_id = model_cfg.model_id.clone();
+    let model_version = format!("{}-{}", model_cfg.response_mode, model_cfg.schema_version);
 
     let guardrails = ai_guardrails::enforce_and_record(
         &client,

--- a/backend/src/api/handlers/feed.rs
+++ b/backend/src/api/handlers/feed.rs
@@ -1,4 +1,5 @@
 use crate::ai::{SummaryArtifact, SummaryGenerator};
+use crate::ai_model_config;
 use crate::auth::extract_auth_context;
 use crate::db;
 use crate::location;
@@ -160,9 +161,7 @@ pub async fn get_derived_feed(
         .await
         .is_ok()
     {
-        let model_id = std::env::var("BEDROCK_MODEL_PRIMARY")
-            .or_else(|_| std::env::var("BEDROCK_MODEL_ID"))
-            .unwrap_or_else(|_| "amazon.nova-lite-v1:0".to_string());
+        let model_id = ai_model_config::load_model_config().model_id;
 
         let guardrails =
             ai_guardrails::enforce_and_record(&client, user_id, "ai.feed_insights.read", &model_id)

--- a/backend/src/api/main.rs
+++ b/backend/src/api/main.rs
@@ -1,6 +1,7 @@
 use lambda_http::{run, service_fn, Body, Error, Request, Response};
 
 mod ai;
+mod ai_model_config;
 mod auth;
 mod db;
 mod handlers;

--- a/docs/bedrock-nova-structured-json.md
+++ b/docs/bedrock-nova-structured-json.md
@@ -1,0 +1,29 @@
+# Bedrock Nova Model Config + Structured JSON Contract
+
+This doc standardizes model selection and structured JSON behavior for premium AI features.
+
+## Environment configuration
+
+- `AI_PROVIDER` (default: `bedrock`)
+- `BEDROCK_MODEL_PRIMARY` (default: `amazon.nova-lite-v1:0`)
+- `BEDROCK_MODEL_FALLBACK` (default: `amazon.nova-micro-v1:0`)
+- `BEDROCK_REGION` (fallback: `AWS_REGION`, default `us-east-1`)
+- `AI_RESPONSE_MODE` (default: `structured_json`)
+- `AI_RESPONSE_SCHEMA_VERSION` (default: `v1`)
+
+## Contract goals
+
+- All premium AI endpoints return schema-shaped JSON objects.
+- Model ID and response mode/version are emitted in responses.
+- Feature handlers must gracefully fallback/degrade if AI generation fails.
+
+## Current endpoints aligned
+
+- `POST /ai/copilot/weekly-plan`
+- Derived feed AI summary metadata path
+
+## Error/fallback behavior
+
+- Entitlement failure: `403 feature_locked`
+- Guardrail cap exceeded: `429` with reason key
+- AI generation failure: deterministic fallback response where applicable


### PR DESCRIPTION
## Summary
- add shared AI model config loader (`ai_model_config`) with env-driven Bedrock settings
- standardize primary/fallback model, region, response mode, and schema version configuration
- wire premium AI handlers to use shared config instead of ad-hoc env reads
- ensure structured JSON metadata is surfaced consistently in responses
- add Bedrock Nova structured JSON contract doc (`docs/bedrock-nova-structured-json.md`)

## Issue
Implements #77.

## Env variables
- `AI_PROVIDER`
- `BEDROCK_MODEL_PRIMARY`
- `BEDROCK_MODEL_FALLBACK`
- `BEDROCK_REGION`
- `AI_RESPONSE_MODE`
- `AI_RESPONSE_SCHEMA_VERSION`
