### PR TITLE
feat(ai): enforce tool-first structured JSON validation + fallback

### DIFF
--- a/backend/src/api/handlers/ai_copilot.rs
+++ b/backend/src/api/handlers/ai_copilot.rs
@@ -2,6 +2,7 @@ use crate::ai_model_config;
 use crate::auth::extract_auth_context;
 use crate::db;
 use crate::middleware::{ai_guardrails, entitlements};
+use crate::structured_json;
 use lambda_http::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
 use tokio_postgres::Row;
@@ -115,17 +116,39 @@ pub async fn generate_weekly_plan(
         "Generated premium weekly grow plan"
     );
 
-    json_response(
-        200,
-        &WeeklyPlanResponse {
-            model_id,
-            model_version,
+    let response = WeeklyPlanResponse {
+        model_id,
+        model_version,
+        structured_json: true,
+        geo_key,
+        window_days,
+        recommendations,
+    };
+
+    if let Err(reason) = structured_json::validate_weekly_plan_response(&response) {
+        tracing::warn!(reason = %reason, "Weekly plan schema validation failed; using fallback response");
+
+        let fallback = WeeklyPlanResponse {
+            model_id: response.model_id.clone(),
+            model_version: response.model_version.clone(),
             structured_json: true,
-            geo_key,
-            window_days,
-            recommendations,
-        },
-    )
+            geo_key: response.geo_key.clone(),
+            window_days: response.window_days,
+            recommendations: vec![WeeklyPlanRecommendation {
+                recommendation:
+                    "Use a balanced planting mix this week while local premium insights recalibrate."
+                        .to_string(),
+                confidence: 0.4,
+                rationale: vec![
+                    "Fallback triggered due to response schema validation mismatch.".to_string(),
+                ],
+            }],
+        };
+
+        return json_response(200, &fallback);
+    }
+
+    json_response(200, &response)
 }
 
 fn build_recommendations(rows: &[Row]) -> Vec<WeeklyPlanRecommendation> {

--- a/backend/src/api/main.rs
+++ b/backend/src/api/main.rs
@@ -9,6 +9,7 @@ mod location;
 mod middleware;
 mod models;
 mod router;
+mod structured_json;
 
 async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     router::route_request(&event).await

--- a/backend/src/api/structured_json.rs
+++ b/backend/src/api/structured_json.rs
@@ -1,0 +1,41 @@
+use crate::handlers::ai_copilot::{WeeklyPlanRecommendation, WeeklyPlanResponse};
+
+pub fn validate_weekly_plan_response(payload: &WeeklyPlanResponse) -> Result<(), String> {
+    if payload.geo_key.trim().is_empty() {
+        return Err("geoKey is required".to_string());
+    }
+
+    if ![7, 14, 30].contains(&payload.window_days) {
+        return Err("windowDays must be one of 7, 14, 30".to_string());
+    }
+
+    if payload.recommendations.is_empty() {
+        return Err("recommendations must contain at least one item".to_string());
+    }
+
+    for rec in &payload.recommendations {
+        validate_weekly_plan_recommendation(rec)?;
+    }
+
+    Ok(())
+}
+
+fn validate_weekly_plan_recommendation(rec: &WeeklyPlanRecommendation) -> Result<(), String> {
+    if rec.recommendation.trim().is_empty() {
+        return Err("recommendation text is required".to_string());
+    }
+
+    if !(0.0..=1.0).contains(&rec.confidence) {
+        return Err("confidence must be within [0.0, 1.0]".to_string());
+    }
+
+    if rec.rationale.is_empty() {
+        return Err("rationale must contain at least one entry".to_string());
+    }
+
+    if rec.rationale.iter().any(|r| r.trim().is_empty()) {
+        return Err("rationale entries must be non-empty".to_string());
+    }
+
+    Ok(())
+}

--- a/docs/schemas/weekly-grow-plan.response.schema.v1.json
+++ b/docs/schemas/weekly-grow-plan.response.schema.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://community-garden/schemas/weekly-grow-plan.response.schema.v1.json",
+  "title": "WeeklyGrowPlanResponseV1",
+  "type": "object",
+  "required": [
+    "modelId",
+    "modelVersion",
+    "structuredJson",
+    "geoKey",
+    "windowDays",
+    "recommendations"
+  ],
+  "properties": {
+    "modelId": { "type": "string", "minLength": 1 },
+    "modelVersion": { "type": "string", "minLength": 1 },
+    "structuredJson": { "type": "boolean", "const": true },
+    "geoKey": { "type": "string", "minLength": 4 },
+    "windowDays": { "type": "integer", "enum": [7, 14, 30] },
+    "recommendations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["recommendation", "confidence", "rationale"],
+        "properties": {
+          "recommendation": { "type": "string", "minLength": 1 },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "rationale": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/tool-first-structured-json-standard.md
+++ b/docs/tool-first-structured-json-standard.md
@@ -1,0 +1,35 @@
+# Tool-First Structured JSON Standard
+
+This standard defines how agent-backed features must produce structured outputs.
+
+## Rules
+
+1. **Schema-first**
+   - Define target JSON shape before implementation.
+   - Keep schema versioned.
+
+2. **Tool-first generation**
+   - Prefer tool/function-based composition for structured responses.
+   - Avoid freeform prose generation when endpoint contract is JSON.
+
+3. **Validation required**
+   - Validate structured payload before returning.
+   - On validation mismatch, use deterministic fallback shape.
+
+4. **Retry/fallback behavior**
+   - First attempt: normal generation path.
+   - If invalid: log warning and return safe fallback JSON.
+   - Never return malformed or partial JSON.
+
+## Applied in code
+
+- Premium copilot endpoint (`POST /ai/copilot/weekly-plan`)
+  - Payload is validated by `structured_json::validate_weekly_plan_response`.
+  - Invalid payload triggers fallback recommendation JSON.
+
+## Recommended checklist
+
+- [ ] JSON schema/shape documented
+- [ ] Validation function exists
+- [ ] Fallback path exists and is deterministic
+- [ ] Entitlement and guardrail checks happen before generation


### PR DESCRIPTION
## Summary
- add tool-first structured JSON standard doc for agent-backed endpoints
- add JSON schema artifact for weekly grow plan response (`docs/schemas/...v1.json`)
- add runtime structured-output validator module (`structured_json`)
- wire premium copilot endpoint to validate response before returning
- add deterministic fallback JSON response when validation fails

## Issue
Implements #90.

## Acceptance mapping
- [x] Tool-first standard documented
- [x] Structured JSON path validates against schema-shaped contract
- [x] Retry/fallback behavior defined and implemented
- [x] Applied to premium AI/copilot endpoint
