### PR TITLE
hotfix: fix unresolved PremiumStackEnabled dependency in template output

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -522,6 +522,6 @@ Outputs:
 
   PremiumStackDeploymentMode:
     Description: Indicates whether premium nested stack deployment is enabled
-    Value: !Ref PremiumStackEnabled
+    Value: "true"
 
 


### PR DESCRIPTION
Hotfix for broken main deploy template.

## Fix
- Remove output reference to non-existent `PremiumStackEnabled` parameter.
- Set `PremiumStackDeploymentMode` output to static `"true"` to eliminate unresolved dependency.

## Validation
- `sam validate -t backend/template.yaml` passes.
