### PR TITLE
Add non‑prod CI auth‑seed Lambda for Postman JWTs

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -198,6 +198,7 @@ jobs:
           sed -e "s|{{STACK_NAME}}|${{ env.STACK_NAME }}|g" \
               -e "s|{{REGION}}|${{ env.AWS_REGION }}|g" \
               -e "s|{{DATABASE_URL}}|${DATABASE_URL}|g" \
+              -e "s|{{ENVIRONMENT_NAME}}|${{ env.ENVIRONMENT }}|g" \
               samconfig.template.toml > samconfig.toml
           echo "✓ Generated samconfig.toml for CI"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -230,6 +230,7 @@ jobs:
           sed -e "s|{{STACK_NAME}}|${{ env.STACK_NAME }}|g" \
               -e "s|{{REGION}}|${{ env.AWS_REGION }}|g" \
               -e "s|{{DATABASE_URL}}|${DATABASE_URL}|g" \
+              -e "s|{{ENVIRONMENT_NAME}}|staging|g" \
               samconfig.template.toml > samconfig.toml
           echo "✓ Generated samconfig.toml for CI"
 
@@ -283,6 +284,12 @@ jobs:
             --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
             --output text)
 
+          CI_AUTH_SEED_USERS_FUNCTION=$(aws cloudformation describe-stacks \
+            --stack-name ${{ env.STACK_NAME }} \
+            --region ${{ env.AWS_REGION }} \
+            --query "Stacks[0].Outputs[?OutputKey=='CiAuthSeedUsersFunctionName'].OutputValue" \
+            --output text)
+
           echo "user-pool-id=$USER_POOL_ID" >> $GITHUB_OUTPUT
           echo "user-pool-client-id=$USER_POOL_CLIENT_ID" >> $GITHUB_OUTPUT
           echo "user-pool-domain=$USER_POOL_DOMAIN" >> $GITHUB_OUTPUT
@@ -290,6 +297,34 @@ jobs:
           echo "frontend-url=$FRONTEND_URL" >> $GITHUB_OUTPUT
           echo "frontend-bucket=$FRONTEND_BUCKET" >> $GITHUB_OUTPUT
           echo "cloudfront-distribution-id=$CLOUDFRONT_DISTRIBUTION_ID" >> $GITHUB_OUTPUT
+          echo "ci-auth-seed-users-function=$CI_AUTH_SEED_USERS_FUNCTION" >> $GITHUB_OUTPUT
+
+
+      - name: Generate CI auth tokens for Postman
+        if: steps.get-outputs.outputs.ci-auth-seed-users-function != '' && steps.get-outputs.outputs.ci-auth-seed-users-function != 'None'
+        run: |
+          aws lambda invoke \
+            --function-name "${{ steps.get-outputs.outputs.ci-auth-seed-users-function }}" \
+            --payload '{}' \
+            --cli-binary-format raw-in-base64-out \
+            ci-auth-seed-response.json
+
+          GROWER_ACCESS_TOKEN=$(jq -r '.body | fromjson | .grower.access_token' ci-auth-seed-response.json)
+          GROWER_ID_TOKEN=$(jq -r '.body | fromjson | .grower.id_token' ci-auth-seed-response.json)
+          GATHERER_ACCESS_TOKEN=$(jq -r '.body | fromjson | .gatherer.access_token' ci-auth-seed-response.json)
+          GATHERER_ID_TOKEN=$(jq -r '.body | fromjson | .gatherer.id_token' ci-auth-seed-response.json)
+
+          echo "::add-mask::$GROWER_ACCESS_TOKEN"
+          echo "::add-mask::$GROWER_ID_TOKEN"
+          echo "::add-mask::$GATHERER_ACCESS_TOKEN"
+          echo "::add-mask::$GATHERER_ID_TOKEN"
+
+          echo "POSTMAN_GROWER_ACCESS_TOKEN=$GROWER_ACCESS_TOKEN" >> $GITHUB_ENV
+          echo "POSTMAN_GROWER_ID_TOKEN=$GROWER_ID_TOKEN" >> $GITHUB_ENV
+          echo "POSTMAN_GATHERER_ACCESS_TOKEN=$GATHERER_ACCESS_TOKEN" >> $GITHUB_ENV
+          echo "POSTMAN_GATHERER_ID_TOKEN=$GATHERER_ID_TOKEN" >> $GITHUB_ENV
+
+          echo "Generated ephemeral grower/gatherer Cognito JWTs for downstream Postman runs."
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/backend/functions/ci_auth_seed/app.py
+++ b/backend/functions/ci_auth_seed/app.py
@@ -1,0 +1,84 @@
+import json
+import os
+import secrets
+import string
+from typing import Dict
+
+import boto3
+from botocore.exceptions import ClientError
+
+USER_POOL_ID = os.environ["USER_POOL_ID"]
+USER_POOL_CLIENT_ID = os.environ["USER_POOL_CLIENT_ID"]
+cognito = boto3.client("cognito-idp")
+
+
+def _random_suffix() -> str:
+    return secrets.token_hex(4)
+
+
+def _strong_password() -> str:
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return (
+        secrets.choice(string.ascii_uppercase)
+        + secrets.choice(string.ascii_lowercase)
+        + secrets.choice(string.digits)
+        + secrets.choice("!@#$%^&*")
+        + "".join(secrets.choice(alphabet) for _ in range(16))
+    )
+
+
+def _create_and_sign_in_user(user_label: str) -> Dict[str, str]:
+    for _ in range(5):
+        suffix = _random_suffix()
+        email = f"ci+{user_label}-{suffix}@example.com"
+        password = _strong_password()
+
+        try:
+            cognito.admin_create_user(
+                UserPoolId=USER_POOL_ID,
+                Username=email,
+                MessageAction="SUPPRESS",
+                UserAttributes=[
+                    {"Name": "email", "Value": email},
+                    {"Name": "email_verified", "Value": "true"},
+                ],
+            )
+        except ClientError as error:
+            if error.response.get("Error", {}).get("Code") == "UsernameExistsException":
+                continue
+            raise
+
+        cognito.admin_set_user_password(
+            UserPoolId=USER_POOL_ID,
+            Username=email,
+            Password=password,
+            Permanent=True,
+        )
+
+        auth_response = cognito.admin_initiate_auth(
+            UserPoolId=USER_POOL_ID,
+            ClientId=USER_POOL_CLIENT_ID,
+            AuthFlow="ADMIN_USER_PASSWORD_AUTH",
+            AuthParameters={"USERNAME": email, "PASSWORD": password},
+        )
+
+        tokens = auth_response["AuthenticationResult"]
+        return {
+            "email": email,
+            "access_token": tokens["AccessToken"],
+            "id_token": tokens["IdToken"],
+            "refresh_token": tokens["RefreshToken"],
+        }
+
+    raise RuntimeError(f"Failed to create a unique Cognito user for label '{user_label}'")
+
+
+def handler(_event, _context):
+    grower = _create_and_sign_in_user("grower")
+    gatherer = _create_and_sign_in_user("gatherer")
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"grower": grower, "gatherer": gatherer}),
+    }

--- a/backend/samconfig.template.toml
+++ b/backend/samconfig.template.toml
@@ -14,7 +14,8 @@ capabilities = "CAPABILITY_IAM"
 confirm_changeset = false
 fail_on_empty_changeset = false
 parameter_overrides = [
-  "DatabaseUrl={{DATABASE_URL}}"
+  "DatabaseUrl={{DATABASE_URL}}",
+  "EnvironmentName={{ENVIRONMENT_NAME}}"
 ]
 
 [default.global.parameters]

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -20,9 +20,19 @@ Parameters:
     Type: String
     NoEcho: true
     Description: PostgreSQL connection string for Neon database
+  EnvironmentName:
+    Type: String
+    Default: staging
+    AllowedValues:
+      - dev
+      - staging
+      - prod
+      - pr
+    Description: Deployment environment name used for environment-specific resources
 
 Conditions:
   DeployCustomDomain: !Not [!Equals [!Ref DomainHostedZoneId, ""]]
+  DeployCiAuthSeedFunction: !Not [!Equals [!Ref EnvironmentName, prod]]
 
 Globals:
   Api:
@@ -384,6 +394,29 @@ Resources:
       Principal: cognito-idp.amazonaws.com
       SourceArn: !GetAtt UserPool.Arn
 
+  CiAuthSeedUsersFunction:
+    Type: AWS::Serverless::Function
+    Condition: DeployCiAuthSeedFunction
+    Properties:
+      CodeUri: functions/ci_auth_seed
+      Handler: app.handler
+      Runtime: python3.12
+      Timeout: 30
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - cognito-idp:AdminCreateUser
+                - cognito-idp:AdminSetUserPassword
+                - cognito-idp:AdminInitiateAuth
+              Resource: !GetAtt UserPool.Arn
+      Environment:
+        Variables:
+          USER_POOL_ID: !Ref UserPool
+          USER_POOL_CLIENT_ID: !Ref UserPoolClient
+
   ApiFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -519,6 +552,15 @@ Outputs:
     Value: !Ref FrontendDistribution
     Export:
       Name: !Sub "${AWS::StackName}-CloudFrontDistributionId"
+
+  CiAuthSeedUsersFunctionName:
+    Description: Lambda name used to generate temporary Cognito JWTs for CI Postman runs
+    Value: !If
+      - DeployCiAuthSeedFunction
+      - !Ref CiAuthSeedUsersFunction
+      - ""
+    Export:
+      Name: !Sub "${AWS::StackName}-CiAuthSeedUsersFunctionName"
 
   PremiumStackDeploymentMode:
     Description: Indicates whether premium nested stack deployment is enabled


### PR DESCRIPTION
### Motivation
- Provide an automated way for CI to generate ephemeral Cognito users (a `grower` and a `gatherer`), sign them in, and expose their JWTs to downstream Postman/newman runs so authenticated API tests can run without long‑lived or hardcoded credentials. 
- Ensure the mechanism is safe for production by making the seeding function disabled for `prod` deployments and scoped to ephemeral PR/staging stacks.

### Description
- Add a new CloudFormation/SAM parameter `EnvironmentName` and condition `DeployCiAuthSeedFunction` to enable environment‑scoped resources and to exclude the seed function from `prod` deployments by default via the `backend/template.yaml` changes. 
- Add a new SAM function resource `CiAuthSeedUsersFunction` that is only created when `EnvironmentName != prod`, and export its logical name as `CiAuthSeedUsersFunctionName` in stack outputs. 
- Implement the Lambda handler at `backend/functions/ci_auth_seed/app.py` which creates randomized Cognito users, sets permanent passwords, signs them in via `ADMIN_USER_PASSWORD_AUTH`, and returns labeled JWTs (`grower` and `gatherer`). 
- Wire the workflows and SAM config: add `EnvironmentName` to `backend/samconfig.template.toml`, pass it in CI (`pr-checks.yml` and `deploy-main.yml`), read the new CloudFormation output, invoke the Lambda after deploy, mask the tokens in logs, and export `POSTMAN_*` env vars for downstream Postman/newman steps. 

### Testing
- Ran backend formatting with `cd backend && cargo fmt --all -- --check` and it passed. 
- Ran Rust lints and tests with `cd backend && cargo clippy --all-targets --all-features -- -D warnings` and `cd backend && cargo test --all-features` and they passed. 
- Validated the Python Lambda handler syntax with `python -m py_compile backend/functions/ci_auth_seed/app.py`, which returned `OK`. 
- Attempted frontend checks with `cd frontend && npm ci` but it failed in this environment with `403 Forbidden - GET https://registry.npmjs.org/react`, so frontend lint/tests could not be executed locally (workflow will run them in CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8264192e4833192746f6c95ea0e8f)