### PR TITLE
feat(entitlements): wire backend checks to versioned matrix config (#65)

### DIFF
--- a/backend/src/api/middleware/entitlements.rs
+++ b/backend/src/api/middleware/entitlements.rs
@@ -1,27 +1,43 @@
 use crate::models::entitlements::{
     EntitlementsPolicy, EntitlementsResponse, FeatureLockedErrorResponse,
 };
+use serde::Deserialize;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::OnceLock;
 use tokio_postgres::Client;
 use uuid::Uuid;
 
-const ENTITLEMENTS_VERSION: &str = "v1";
+const ENTITLEMENTS_CONFIG_JSON: &str =
+    include_str!("../../../../config/entitlements/v1.tiers.json");
+const DEFAULT_TIER: &str = "free";
+const PREMIUM_TIER: &str = "premium";
 
-const FREE_ENTITLEMENTS: &[&str] = &[
-    "core.discovery",
-    "core.listings.write",
-    "core.requests.write",
-    "core.claims.write",
-    "core.derived_feed.read",
-    "reminders.deterministic.schedule",
-    "reminders.deterministic.manage",
-];
+static ENTITLEMENTS_CONFIG: OnceLock<Result<EntitlementsConfig, String>> = OnceLock::new();
 
-const PREMIUM_ONLY_ENTITLEMENTS: &[&str] = &[
-    "ai.copilot.weekly_grow_plan",
-    "ai.feed_insights.read",
-    "agent.tasks.automation",
-    "premium.analytics.read",
-];
+#[derive(Debug, Deserialize)]
+struct EntitlementsConfig {
+    version: String,
+    tiers: HashMap<String, TierConfig>,
+    policies: PolicyConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct TierConfig {
+    #[allow(dead_code)]
+    name: String,
+    #[allow(dead_code)]
+    description: Option<String>,
+    #[serde(default)]
+    inherits: Vec<String>,
+    #[serde(default)]
+    entitlements: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyConfig {
+    ai_is_premium_only: bool,
+    free_reminders_are_deterministic_only: bool,
+}
 
 #[allow(dead_code)]
 pub struct FeatureLockedError {
@@ -34,7 +50,7 @@ impl FeatureLockedError {
         FeatureLockedErrorResponse {
             error: "feature_locked".to_string(),
             entitlement_key: self.entitlement_key.clone(),
-            required_tier: "premium".to_string(),
+            required_tier: PREMIUM_TIER.to_string(),
             upgrade_hint_key: "upgrade.premium".to_string(),
         }
     }
@@ -45,19 +61,24 @@ pub async fn get_entitlements_snapshot(
     user_id: Uuid,
 ) -> Result<EntitlementsResponse, lambda_http::Error> {
     let tier = load_user_tier(client, user_id).await?;
-    let mut keys: Vec<String> = FREE_ENTITLEMENTS.iter().map(|k| (*k).to_string()).collect();
+    let config = load_entitlements_config()?;
+    let resolved_tier = if config.tiers.contains_key(&tier) {
+        tier
+    } else {
+        DEFAULT_TIER.to_string()
+    };
 
-    if tier == "premium" {
-        keys.extend(PREMIUM_ONLY_ENTITLEMENTS.iter().map(|k| (*k).to_string()));
-    }
+    let entitlements = resolve_entitlements_for_tier(config, &resolved_tier)?;
 
     Ok(EntitlementsResponse {
-        tier,
-        entitlements_version: ENTITLEMENTS_VERSION.to_string(),
-        entitlements: keys,
+        tier: resolved_tier,
+        entitlements_version: config.version.clone(),
+        entitlements,
         policy: EntitlementsPolicy {
-            ai_is_premium_only: true,
-            free_reminders_deterministic_only: true,
+            ai_is_premium_only: config.policies.ai_is_premium_only,
+            free_reminders_deterministic_only: config
+                .policies
+                .free_reminders_are_deterministic_only,
         },
     })
 }
@@ -86,6 +107,59 @@ pub async fn require_entitlement(
     }
 }
 
+fn load_entitlements_config() -> Result<&'static EntitlementsConfig, lambda_http::Error> {
+    let config = ENTITLEMENTS_CONFIG.get_or_init(|| {
+        serde_json::from_str::<EntitlementsConfig>(ENTITLEMENTS_CONFIG_JSON)
+            .map_err(|e| format!("Failed to parse entitlements config: {e}"))
+    });
+
+    match config {
+        Ok(parsed) => Ok(parsed),
+        Err(error) => Err(lambda_http::Error::from(error.clone())),
+    }
+}
+
+fn resolve_entitlements_for_tier(
+    config: &EntitlementsConfig,
+    tier: &str,
+) -> Result<Vec<String>, lambda_http::Error> {
+    let mut entitlements = BTreeSet::new();
+    let mut visiting = HashSet::new();
+
+    collect_entitlements_recursive(config, tier, &mut entitlements, &mut visiting)?;
+
+    Ok(entitlements.into_iter().collect())
+}
+
+fn collect_entitlements_recursive(
+    config: &EntitlementsConfig,
+    tier: &str,
+    entitlements: &mut BTreeSet<String>,
+    visiting: &mut HashSet<String>,
+) -> Result<(), lambda_http::Error> {
+    if !visiting.insert(tier.to_string()) {
+        return Err(lambda_http::Error::from(format!(
+            "Entitlements config cycle detected at tier '{tier}'"
+        )));
+    }
+
+    let tier_config = config.tiers.get(tier).ok_or_else(|| {
+        lambda_http::Error::from(format!("Unknown tier in entitlements config: {tier}"))
+    })?;
+
+    for parent in &tier_config.inherits {
+        collect_entitlements_recursive(config, parent, entitlements, visiting)?;
+    }
+
+    for entitlement in &tier_config.entitlements {
+        entitlements.insert(entitlement.clone());
+    }
+
+    visiting.remove(tier);
+
+    Ok(())
+}
+
 async fn load_user_tier(client: &Client, user_id: Uuid) -> Result<String, lambda_http::Error> {
     let row = client
         .query_opt(
@@ -97,5 +171,62 @@ async fn load_user_tier(client: &Client, user_id: Uuid) -> Result<String, lambda
 
     Ok(row
         .and_then(|r| r.get::<_, Option<String>>("tier"))
-        .unwrap_or_else(|| "free".to_string()))
+        .unwrap_or_else(|| DEFAULT_TIER.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_or_skip() -> Option<&'static EntitlementsConfig> {
+        let config = load_entitlements_config();
+        assert!(
+            config.is_ok(),
+            "entitlements config should parse successfully"
+        );
+        config.ok()
+    }
+
+    fn resolve_or_skip(config: &EntitlementsConfig, tier: &str) -> Option<Vec<String>> {
+        let entitlements = resolve_entitlements_for_tier(config, tier);
+        assert!(entitlements.is_ok(), "tier should resolve successfully");
+        entitlements.ok()
+    }
+
+    #[test]
+    fn free_tier_has_only_free_entitlements() {
+        let Some(config) = config_or_skip() else {
+            return;
+        };
+        let Some(entitlements) = resolve_or_skip(config, "free") else {
+            return;
+        };
+
+        assert!(entitlements.contains(&"core.discovery".to_string()));
+        assert!(!entitlements.contains(&"ai.copilot.weekly_grow_plan".to_string()));
+    }
+
+    #[test]
+    fn premium_tier_inherits_free_and_has_premium_entitlements() {
+        let Some(config) = config_or_skip() else {
+            return;
+        };
+        let Some(entitlements) = resolve_or_skip(config, "premium") else {
+            return;
+        };
+
+        assert!(entitlements.contains(&"core.discovery".to_string()));
+        assert!(entitlements.contains(&"ai.copilot.weekly_grow_plan".to_string()));
+        assert!(entitlements.contains(&"premium.analytics.read".to_string()));
+    }
+
+    #[test]
+    fn policy_flags_match_phase6_rules() {
+        let Some(config) = config_or_skip() else {
+            return;
+        };
+
+        assert!(config.policies.ai_is_premium_only);
+        assert!(config.policies.free_reminders_are_deterministic_only);
+    }
 }

--- a/docs/phase-6-entitlements-matrix.md
+++ b/docs/phase-6-entitlements-matrix.md
@@ -5,6 +5,9 @@ This defines what is available in **free** vs **premium** and acts as the source
 Machine-readable source:
 - `config/entitlements/v1.tiers.json`
 
+Enforcement source of truth:
+- Backend middleware (`backend/src/api/middleware/entitlements.rs`) loads this JSON directly at runtime so tier rules and API checks cannot drift.
+
 ## Tier matrix
 
 | Capability | Entitlement Key | Free | Premium |


### PR DESCRIPTION
## Summary
- make backend entitlements middleware load config/entitlements/v1.tiers.json directly
- resolve inherited entitlements recursively (premium inherits free)
- keep /me/entitlements policy flags sourced from config
- add middleware unit tests to prevent drift on free/premium and AI policy rules
- document that backend enforcement now uses the versioned JSON source of truth

## Why
This addresses #65 with a solo-maintainer-friendly setup: one versioned matrix drives docs + API checks, reducing drift and maintenance overhead.

## Validation
- cargo fmt --all
- cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged -- -D warnings
- cargo test