### PR TITLE
feat(profile): badge cabinet + seasonal timeline surfaces (#125)

### DIFF
--- a/backend/src/api/handlers/user.rs
+++ b/backend/src/api/handlers/user.rs
@@ -5,8 +5,8 @@ use crate::location;
 use crate::middleware::entitlements;
 use crate::models::crop::ErrorResponse;
 use crate::models::profile::{
-    GrowerProfile, MeProfileResponse, PublicUserResponse, PutMeRequest, SubscriptionMetadata,
-    UserRatingSummary, UserType,
+    GrowerProfile, MeProfileResponse, PublicUserResponse, PutMeRequest, SeasonalTimelineEntry,
+    SubscriptionMetadata, UserRatingSummary, UserType,
 };
 use lambda_http::{Body, Request, RequestExt, Response};
 use serde::Serialize;
@@ -338,6 +338,22 @@ async fn to_me_response(
             _ => None,
         });
 
+    let badge_cabinet = badge_cabinet::load_and_sync_badges(client, user_id).await?;
+    let seasonal_timeline = badge_cabinet
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .badge_key
+                .strip_prefix("gardener_season_")
+                .and_then(|level| level.parse::<i32>().ok())
+                .map(|level| SeasonalTimelineEntry {
+                    badge_key: entry.badge_key.clone(),
+                    level,
+                    earned_at: entry.earned_at.clone(),
+                })
+        })
+        .collect();
+
     Ok(MeProfileResponse {
         id: user_id.to_string(),
         email: user_row.get("email"),
@@ -356,7 +372,8 @@ async fn to_me_response(
                 .map(|v| v.to_rfc3339()),
         },
         gardener_tier: gardener_tier::evaluate_and_record(client, user_id).await?,
-        badge_cabinet: badge_cabinet::load_and_sync_badges(client, user_id).await?,
+        badge_cabinet,
+        seasonal_timeline,
         grower_profile: load_grower_profile(client, user_id).await?,
         gatherer_profile: load_gatherer_profile(client, user_id).await?,
         rating_summary: load_rating_summary(client, user_id).await?,

--- a/backend/src/api/models/profile.rs
+++ b/backend/src/api/models/profile.rs
@@ -62,9 +62,18 @@ pub struct MeProfileResponse {
     pub subscription: SubscriptionMetadata,
     pub gardener_tier: GardenerTierProfile,
     pub badge_cabinet: Vec<BadgeCabinetEntry>,
+    pub seasonal_timeline: Vec<SeasonalTimelineEntry>,
     pub grower_profile: Option<GrowerProfile>,
     pub gatherer_profile: Option<GathererProfile>,
     pub rating_summary: Option<UserRatingSummary>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeasonalTimelineEntry {
+    pub badge_key: String,
+    pub level: i32,
+    pub earned_at: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/postman/collections/Community Garden API/Profile Smoke/3 - Get Current User.request.yaml
+++ b/postman/collections/Community Garden API/Profile Smoke/3 - Get Current User.request.yaml
@@ -118,6 +118,12 @@ scripts:
           }
       });
 
+      pm.test("seasonalTimeline is an array when present", function () {
+          if (jsonData.seasonalTimeline !== undefined) {
+              pm.expect(Array.isArray(jsonData.seasonalTimeline)).to.eql(true);
+          }
+      });
+
       pm.test("badgeCabinet entries use supported badge keys", function () {
           if (!Array.isArray(jsonData.badgeCabinet)) {
               return;


### PR DESCRIPTION
Implements issue #125 with profile badge cabinet exposure and seasonal timeline support. Includes incremental Postman assertion improvement per policy.