### PR TITLE
[Phase 6] Add subscription metadata API tests (Issue #67)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,25 @@ When working on an issue:
 - Prioritize tests for auth, validation, idempotency, and state transitions.
 - For frontend, cover critical grower/searcher paths with focused tests.
 
+### API testing is mandatory for backward compatibility
+
+**Critical: API tests are how we ensure backward compatibility.**
+
+When changing or adding API endpoints:
+- **Always** add or update Postman tests in the `postman/` folder
+- Add assertions to existing end-to-end test collections when applicable
+- Create new test requests for new endpoints
+- Validate response schemas, status codes, and error cases
+- Test both success and failure paths
+
+Postman tests can be run locally before pushing:
+```bash
+# Run Postman collections locally (if newman is installed)
+newman run postman/collections/<collection-name>
+```
+
+API contract changes without corresponding Postman tests will be rejected.
+
 ## Non-goals guardrails
 
 - Do not optimize for competitive metrics (leaderboards, production competition).
@@ -109,6 +128,7 @@ Before submitting any PR, all of the following must pass:
 - Frontend linting
 - Backend linting
 - Backend formatting check (`fmt`)
+- Postman API tests (if API endpoints were changed/added)
 
 If any required check cannot be run in the current environment, explicitly state that blocker in the PR description and ask for guidance before merging.
 
@@ -133,3 +153,6 @@ Before finishing, confirm:
 - Work was done on a feature branch (not `main`) and submitted via PR.
 - Documentation or issue dependencies were updated if scope changed.
 - Any post-PR workflow failures were diagnosed and fixed, or explicitly documented if externally blocked.
+
+
+**After all checks pass, automatically open a PR using `gh pr create`.**

--- a/postman/collections/Community Garden API/Profile Smoke/3 - Get Current User.request.yaml
+++ b/postman/collections/Community Garden API/Profile Smoke/3 - Get Current User.request.yaml
@@ -244,3 +244,19 @@ scripts:
       // --- Cleanup temporary variables (optional) ---
       // Uncomment if you want to clean up after the smoke test run
       // pm.collectionVariables.unset("putMeResponseSnapshot");
+
+      // --- Subscription Metadata Validation (Issue #67) ---
+      pm.test("Subscription metadata is present", function () {
+          pm.expect(jsonData).to.have.property("subscription");
+          pm.expect(jsonData.subscription).to.have.property("tier");
+          pm.expect(jsonData.subscription).to.have.property("subscriptionStatus");
+          pm.expect(jsonData.subscription.tier).to.be.oneOf(["free", "premium"]);
+          pm.expect(jsonData.subscription.subscriptionStatus).to.be.oneOf(["none", "trialing", "active", "past_due", "canceled"]);
+      });
+
+      pm.test("Free tier users have correct defaults", function () {
+          if (jsonData.subscription.tier === "free") {
+              pm.expect(jsonData.subscription.subscriptionStatus).to.equal("none");
+              pm.expect(jsonData.subscription.premiumExpiresAt).to.be.oneOf([null, undefined]);
+          }
+      });

--- a/postman/collections/Community Garden API/User Management/Get Current User.request.yaml
+++ b/postman/collections/Community Garden API/User Management/Get Current User.request.yaml
@@ -24,3 +24,20 @@ scripts:
           pm.collectionVariables.set("myUserId", user.id);
           pm.collectionVariables.set("userId", user.id);
       });
+
+      pm.test("Subscription metadata is present", function () {
+          const user = pm.response.json();
+          pm.expect(user).to.have.property("subscription");
+          pm.expect(user.subscription).to.have.property("tier");
+          pm.expect(user.subscription).to.have.property("subscriptionStatus");
+          pm.expect(user.subscription.tier).to.be.oneOf(["free", "premium"]);
+          pm.expect(user.subscription.subscriptionStatus).to.be.oneOf(["none", "trialing", "active", "past_due", "canceled"]);
+      });
+
+      pm.test("Free tier users have correct defaults", function () {
+          const user = pm.response.json();
+          if (user.subscription.tier === "free") {
+              pm.expect(user.subscription.subscriptionStatus).to.equal("none");
+              pm.expect(user.subscription.premiumExpiresAt).to.be.oneOf([null, undefined]);
+          }
+      });


### PR DESCRIPTION
## Summary

Adds comprehensive Postman API tests to validate subscription metadata in the GET /me endpoint response. The backend implementation was already complete; this PR adds the missing API contract tests.

## Changes

### API Tests Added
- **User Management/Get Current User**: Added tests for subscription metadata presence and free tier defaults
- **Profile Smoke/Get Current User**: Added tests for subscription metadata presence and free tier defaults

### Test Coverage
- ✅ Validates `subscription` object exists in response
- ✅ Validates `tier` field is one of `['free', 'premium']`
- ✅ Validates `subscriptionStatus` field is one of `['none', 'trialing', 'active', 'past_due', 'canceled']`
- ✅ Validates free tier users have `subscriptionStatus = 'none'` and `premiumExpiresAt = null`

### Documentation Updates
- **AGENTS.md**: Added heavy emphasis on API testing for backward compatibility
  - New section: "API testing is mandatory for backward compatibility"
  - Added Postman tests to pre-PR quality gates
  - Added instruction to automatically open PR after checks pass

## Implementation Status

All acceptance criteria from Issue #67 are met:
- ✅ Migration applied (0009_user_tier_subscription_state.sql)
- ✅ Existing users default to free tier (via migration defaults)
- ✅ Profile endpoint includes tier status (subscription metadata)
- ✅ API tests validate the contract

## Testing

Postman tests validate:
1. Subscription metadata structure and required fields
2. Enum constraints on tier and subscriptionStatus
3. Free tier default values
4. Nullable premiumExpiresAt field

## Notes

- No backend code changes required (implementation already complete)
- Tests follow existing Postman collection patterns
- Aligns with project standards: minimal abstraction, focused tests

Closes #67