### PR TITLE
Step 5: Derive canonical app fields with precedence rules (#164)

### DIFF
--- a/scripts/catalog/step5_derive_fields.mjs
+++ b/scripts/catalog/step5_derive_fields.mjs
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import { PATHS } from './lib/config.mjs';
+import { readJsonl, appendJsonl, computeChecksum } from './lib/io.mjs';
+import { readProgress, writeProgress, verifyChecksum, resetProgress } from './lib/progress.mjs';
+
+const pick = (arr, ...fns) => {
+  for (const fn of fns) {
+    for (const rec of arr) {
+      const v = fn(rec);
+      if (v !== null && v !== undefined && v !== '') return { value: v, rec };
+    }
+  }
+  return { value: null, rec: null };
+};
+
+const firstArray = (...vals) => vals.find((v) => Array.isArray(v) && v.length > 0) || [];
+
+export function deriveCanonicalRecord(records) {
+  const byProvider = (p) => records.filter((r) => r.source_provider === p);
+  const usda = byProvider('usda');
+  const openfarm = byProvider('openfarm');
+  const permapeople = byProvider('permapeople');
+
+  const scientific = pick(usda, (r) => r.normalized?.scientific_name);
+  const family = pick(usda, (r) => r.normalized?.family);
+  const commonOpenfarm = pick(openfarm, (r) => r.normalized?.common_names?.[0]);
+  const commonPermapeople = pick(permapeople, (r) => r.normalized?.common_names?.[0]);
+  const commonUsda = pick(usda, (r) => r.normalized?.common_names?.[0]);
+  const common = commonOpenfarm.value ? commonOpenfarm : (commonPermapeople.value ? commonPermapeople : commonUsda);
+
+  const commonFromPermapeople = commonPermapeople.value;
+  const commonFromOpenfarm = commonOpenfarm.value;
+  const commonNameMismatch = Boolean(commonFromOpenfarm && commonFromPermapeople
+    && commonFromOpenfarm.toLowerCase() !== commonFromPermapeople.toLowerCase());
+
+  const practicalSource = pick(permapeople, (r) => r.normalized);
+  const practical = practicalSource.value || {};
+
+  const lifeCycle = practical.life_cycle || null;
+  const hardiness = firstArray(practical.hardiness_zones, ...usda.map((r) => r.normalized?.hardiness_zones));
+  const useHardiness = lifeCycle && !/annual/.test(String(lifeCycle).toLowerCase()) && hardiness.length > 0;
+
+  const lead = records[0];
+  const field_sources = {};
+  if (scientific.value) field_sources.scientific_name = scientific.rec?.source_provider;
+  if (family.value) field_sources.family = family.rec?.source_provider;
+  if (common.value) field_sources.common_name = common.rec?.source_provider;
+  if (practical.edible !== undefined && practical.edible !== null) field_sources.edible = practicalSource.rec?.source_provider;
+  if (practical.edible_parts?.length) field_sources.edible_parts = practicalSource.rec?.source_provider;
+  if (useHardiness) field_sources.hardiness_zones = practicalSource.rec?.source_provider || 'usda';
+
+  return {
+    canonical_id: lead.canonical_id,
+    catalog_status: lead.catalog_status,
+    review_status: lead.review_status,
+    relevance_class: lead.relevance_class,
+    source_confidence: lead.source_confidence,
+    source_agreement_score: lead.source_agreement_score,
+    scientific_name: scientific.value,
+    family: family.value,
+    common_name: common.value,
+    edible: practical.edible ?? null,
+    edible_parts: practical.edible_parts || [],
+    water_requirement: practical.water_requirement || null,
+    light_requirements: practical.light_requirements || [],
+    life_cycle: lifeCycle,
+    hardiness_zones: useHardiness ? hardiness : [],
+    common_name_mismatch: commonNameMismatch,
+    excluded_reason: lead.catalog_status === 'excluded' ? lead.classification_reason : null,
+    field_sources,
+    source_records: records.map((r) => ({
+      source_provider: r.source_provider,
+      source_record_id: r.source_record_id,
+      match_type: r.match_type,
+      match_score: r.match_score,
+    })),
+  };
+}
+
+export async function runStep5({ reset = false, dryRun = false, limit = null } = {}) {
+  if (!fs.existsSync(PATHS.step4)) throw new Error(`Missing required input from Step 4: ${PATHS.step4}`);
+  if (reset) await resetProgress(5);
+
+  const checksum = await computeChecksum(PATHS.step4);
+  await verifyChecksum(5, checksum);
+
+  const input = [];
+  for await (const r of readJsonl(PATHS.step4)) input.push(r);
+
+  const grouped = new Map();
+  for (const rec of input) {
+    const key = rec.canonical_id || `${rec.source_provider}:${rec.source_record_id}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(rec);
+  }
+
+  const groups = Array.from(grouped.values());
+  const progress = await readProgress(5);
+  const startIndex = progress ? progress.lastProcessedIndex + 1 : 0;
+  const slice = groups.slice(startIndex, limit ? startIndex + limit : undefined);
+  const out = slice.map(deriveCanonicalRecord);
+
+  if (!dryRun) {
+    await fsp.mkdir('data/catalog', { recursive: true });
+    await appendJsonl(PATHS.step5, out);
+    if (out.length > 0) await writeProgress(5, startIndex + out.length - 1, checksum);
+  }
+
+  return { processedThisRun: out.length };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runStep5().then((s) => console.log(JSON.stringify(s, null, 2))).catch((e) => {
+    console.error(e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/catalog/tests/step5.test.mjs
+++ b/scripts/catalog/tests/step5.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveCanonicalRecord } from '../step5_derive_fields.mjs';
+
+test('step5 enforces precedence and mismatch flags', () => {
+  const out = deriveCanonicalRecord([
+    {
+      canonical_id: 'A',
+      source_provider: 'usda',
+      source_record_id: 'u1',
+      catalog_status: 'core',
+      review_status: 'auto_approved',
+      relevance_class: 'food_crop_niche',
+      source_confidence: 0.9,
+      source_agreement_score: 0.7,
+      normalized: { scientific_name: 'Solanum lycopersicum', family: 'Solanaceae', common_names: ['tomato'], hardiness_zones: ['8'] },
+    },
+    {
+      canonical_id: 'A',
+      source_provider: 'openfarm',
+      source_record_id: 'o1',
+      normalized: { common_names: ['Tomato'] },
+    },
+    {
+      canonical_id: 'A',
+      source_provider: 'permapeople',
+      source_record_id: 'p1',
+      normalized: { common_names: ['Love apple'], edible: true, edible_parts: ['fruit'], life_cycle: 'annual', hardiness_zones: ['5'] },
+    },
+  ]);
+
+  assert.equal(out.scientific_name, 'Solanum lycopersicum');
+  assert.equal(out.family, 'Solanaceae');
+  assert.equal(out.common_name, 'Tomato');
+  assert.equal(out.common_name_mismatch, true);
+  assert.deepEqual(out.hardiness_zones, []);
+  assert.equal(out.field_sources.common_name, 'openfarm');
+});


### PR DESCRIPTION
## Summary
- add Step 5 canonical field derivation runner with progress/checksum support
- enforce source precedence for scientific/family/common + practical traits
- carry excluded records and emit field provenance + mismatch flag

## Smoke Result
- 
ode --test (in scripts/catalog): pass (8/8)
- 
ode step5_derive_fields.mjs with seeded data/catalog/step4_relevance_classified.jsonl: pass