### PR TITLE
Step 6: Bedrock augmentation (presentation-only)

### DIFF
--- a/scripts/catalog/lib/bedrock.mjs
+++ b/scripts/catalog/lib/bedrock.mjs
@@ -1,0 +1,105 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function createBedrockClient({ region = process.env.AWS_REGION || 'us-east-1', client } = {}) {
+  if (client) return client;
+  return new BedrockRuntimeClient({ region });
+}
+
+export function parseModelJson(text) {
+  if (!text) throw new Error('Empty model response');
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object') throw new Error('Model response is not an object');
+    return parsed;
+  } catch (error) {
+    throw new Error(`Invalid model JSON: ${error.message}`);
+  }
+}
+
+export function validateAugmentationSchema(payload = {}) {
+  const out = {
+    description: typeof payload.description === 'string' && payload.description.trim() ? payload.description.trim() : null,
+    category: typeof payload.category === 'string' && payload.category.trim() ? payload.category.trim() : null,
+    display_notes: typeof payload.display_notes === 'string' && payload.display_notes.trim() ? payload.display_notes.trim() : null,
+    review_notes: typeof payload.review_notes === 'string' && payload.review_notes.trim() ? payload.review_notes.trim() : null,
+  };
+  return out;
+}
+
+export async function invokeAugmentModel({
+  client,
+  modelId,
+  record,
+  maxRetries = 2,
+  retryDelayMs = 500,
+  dryRun = false,
+} = {}) {
+  if (dryRun) {
+    return { result: validateAugmentationSchema({}), apiCalls: 0 };
+  }
+
+  const runtime = createBedrockClient({ client });
+  const prompt = {
+    task: 'Provide presentation-only enrichment. Do not infer identity or overwrite source fields.',
+    record: {
+      canonical_id: record.canonical_id,
+      scientific_name: record.scientific_name,
+      common_name: record.common_name,
+      family: record.family,
+      category: record.category,
+      review_status: record.review_status,
+      catalog_status: record.catalog_status,
+      source_records: record.source_records,
+    },
+    response_schema: {
+      description: 'string|null',
+      category: 'string|null',
+      display_notes: 'string|null',
+      review_notes: 'string|null',
+    },
+  };
+
+  let lastError;
+  let apiCalls = 0;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      apiCalls += 1;
+      const response = await runtime.send(new InvokeModelCommand({
+        modelId,
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: JSON.stringify(prompt),
+      }));
+      const body = Buffer.from(response.body).toString('utf8');
+      const parsed = parseModelJson(body);
+      return { result: validateAugmentationSchema(parsed), apiCalls };
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) await sleep(retryDelayMs * (attempt + 1));
+    }
+  }
+  throw new Error(`Bedrock invocation failed: ${lastError?.message || 'unknown error'}`);
+}
+
+export async function batchAugment({ records, invoke = invokeAugmentModel, batchSize = 20, ...options } = {}) {
+  const successes = [];
+  const failures = [];
+  let apiCalls = 0;
+
+  for (let i = 0; i < records.length; i += batchSize) {
+    const batch = records.slice(i, i + batchSize);
+    for (const record of batch) {
+      try {
+        const { result, apiCalls: count = 0 } = await invoke({ ...options, record });
+        apiCalls += count;
+        successes.push({ record, augmentation: result });
+      } catch (error) {
+        failures.push({ record, error: error.message });
+      }
+    }
+  }
+
+  return { successes, failures, apiCalls };
+}

--- a/scripts/catalog/lib/config.mjs
+++ b/scripts/catalog/lib/config.mjs
@@ -14,6 +14,11 @@ export const PATHS = {
   step4: path.join(DATA_DIR, 'step4_relevance_classified.jsonl'),
   step5: path.join(DATA_DIR, 'step5_canonical_drafts.jsonl'),
   step6: path.join(DATA_DIR, 'step6_augmented_catalog.jsonl'),
+  promoted: path.join(DATA_DIR, 'promoted_crops.jsonl'),
+  reviewNeedsReview: path.join(DATA_DIR, 'review_queue_needs_review.jsonl'),
+  reviewUnresolved: path.join(DATA_DIR, 'review_queue_unresolved.jsonl'),
+  reviewExcluded: path.join(DATA_DIR, 'review_queue_excluded.jsonl'),
+  reviewSummary: path.join(DATA_DIR, 'review_summary.json'),
 };
 
 export const PROGRESS_PATHS = {
@@ -23,6 +28,7 @@ export const PROGRESS_PATHS = {
   4: path.join(DATA_DIR, 'step4_progress.json'),
   5: path.join(DATA_DIR, 'step5_progress.json'),
   6: path.join(DATA_DIR, 'step6_progress.json'),
+  7: path.join(DATA_DIR, 'promote_progress.json'),
 };
 
 export const ENUMS = {

--- a/scripts/catalog/step6_llm_augment.mjs
+++ b/scripts/catalog/step6_llm_augment.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import { PATHS } from './lib/config.mjs';
+import { readJsonl, appendJsonl, computeChecksum } from './lib/io.mjs';
+import { readProgress, writeProgress, verifyChecksum, resetProgress } from './lib/progress.mjs';
+import { batchAugment } from './lib/bedrock.mjs';
+
+function isEligible(rec) {
+  return rec.catalog_status === 'core' || rec.catalog_status === 'extended';
+}
+
+function applyAugmentation(record, augmentation) {
+  const out = { ...record, field_sources: { ...(record.field_sources || {}) } };
+
+  if (augmentation.description && !out.description) {
+    out.description = augmentation.description;
+    out.field_sources.description = 'llm';
+  }
+
+  if (augmentation.display_notes) {
+    out.display_notes = augmentation.display_notes;
+    out.field_sources.display_notes = 'llm';
+  }
+
+  if (augmentation.review_notes) {
+    out.review_notes = augmentation.review_notes;
+    out.field_sources.review_notes = 'llm';
+  }
+
+  if (augmentation.category && (!out.category || out.review_status !== 'auto_approved')) {
+    out.category = augmentation.category;
+    out.field_sources.category = 'llm';
+  }
+
+  return out;
+}
+
+export async function runStep6({ reset = false, dryRun = false, limit = null, invoke, modelId = process.env.BEDROCK_MODEL_ID || 'anthropic.claude-3-haiku-20240307-v1:0' } = {}) {
+  if (!fs.existsSync(PATHS.step5)) throw new Error(`Missing required input from Step 5: ${PATHS.step5}`);
+  if (reset) await resetProgress(6);
+
+  const checksum = await computeChecksum(PATHS.step5);
+  await verifyChecksum(6, checksum);
+
+  const input = [];
+  for await (const r of readJsonl(PATHS.step5)) input.push(r);
+
+  const progress = await readProgress(6);
+  const startIndex = progress ? progress.lastProcessedIndex + 1 : 0;
+  const slice = input.slice(startIndex, limit ? startIndex + limit : undefined);
+
+  const eligible = slice.filter(isEligible);
+  const passthrough = slice.filter((rec) => !isEligible(rec));
+
+  const { successes, failures, apiCalls } = await batchAugment({
+    records: eligible,
+    invoke,
+    modelId,
+    dryRun,
+  });
+
+  const failureById = new Map(failures.map((f) => [f.record.canonical_id, f.error]));
+
+  const augmented = successes.map(({ record, augmentation }) => applyAugmentation(record, augmentation));
+  const failedRecords = eligible
+    .filter((r) => failureById.has(r.canonical_id))
+    .map((r) => ({ ...r, augmentation_error: failureById.get(r.canonical_id) }));
+
+  const out = [...augmented, ...failedRecords, ...passthrough];
+
+  const summary = {
+    processedThisRun: out.length,
+    augmentedCount: augmented.length,
+    failedCount: failedRecords.length,
+    apiCallCount: apiCalls,
+    fieldPopulationRates: {
+      description: augmented.length ? augmented.filter((r) => r.description).length / augmented.length : 0,
+      category: augmented.length ? augmented.filter((r) => r.category).length / augmented.length : 0,
+      display_notes: augmented.length ? augmented.filter((r) => r.display_notes).length / augmented.length : 0,
+      review_notes: augmented.length ? augmented.filter((r) => r.review_notes).length / augmented.length : 0,
+    },
+  };
+
+  if (!dryRun) {
+    await fsp.mkdir('data/catalog', { recursive: true });
+    await appendJsonl(PATHS.step6, out);
+    if (out.length > 0) await writeProgress(6, startIndex + out.length - 1, checksum);
+  }
+
+  return summary;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runStep6().then((s) => console.log(JSON.stringify(s, null, 2))).catch((e) => {
+    console.error(e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/catalog/tests/step6.test.mjs
+++ b/scripts/catalog/tests/step6.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { runStep6 } from '../step6_llm_augment.mjs';
+
+const dataDir = path.resolve(process.cwd(), 'data/catalog');
+const step5Path = path.join(dataDir, 'step5_canonical_drafts.jsonl');
+const step6Path = path.join(dataDir, 'step6_augmented_catalog.jsonl');
+const progressPath = path.join(dataDir, 'step6_progress.json');
+
+test('step6 augments eligible records and leaves excluded unchanged', async () => {
+  await fs.mkdir(dataDir, { recursive: true });
+  await fs.rm(step5Path, { force: true });
+  await fs.rm(step6Path, { force: true });
+  await fs.rm(progressPath, { force: true });
+
+  const step5 = [
+    { canonical_id: '1', catalog_status: 'core', review_status: 'auto_approved', scientific_name: 'A', common_name: 'A', field_sources: {} },
+    { canonical_id: '2', catalog_status: 'excluded', review_status: 'rejected', scientific_name: 'B', common_name: 'B', field_sources: {} },
+  ];
+  await fs.writeFile(step5Path, `${step5.map((x) => JSON.stringify(x)).join('\n')}\n`);
+
+  const summary = await runStep6({
+    invoke: async ({ record }) => ({ result: { description: `Desc ${record.canonical_id}`, display_notes: 'note' }, apiCalls: 1 }),
+  });
+
+  const outRaw = await fs.readFile(step6Path, 'utf8');
+  const out = outRaw.trim().split('\n').map((line) => JSON.parse(line));
+
+  assert.equal(summary.augmentedCount, 1);
+  assert.equal(summary.failedCount, 0);
+  assert.equal(summary.apiCallCount, 1);
+  assert.equal(out.length, 2);
+  assert.equal(out.find((r) => r.canonical_id === '1').description, 'Desc 1');
+  assert.equal(out.find((r) => r.canonical_id === '2').description, undefined);
+});


### PR DESCRIPTION
## Summary
- add Bedrock runtime helper with retry, batching, and augmentation schema filtering
- implement Step 6 LLM presentation augmentation with failure passthrough and provenance tagging
- add step6 test coverage for eligible augmentation + excluded passthrough

## Smoke Result
- npm ci
- node --test PASS (12 passed, 0 failed)
