### PR TITLE
Promotion + review artifact generation

### DIFF
--- a/scripts/catalog/promote.mjs
+++ b/scripts/catalog/promote.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import { PATHS } from './lib/config.mjs';
+import { readJsonl, appendJsonl, computeChecksum } from './lib/io.mjs';
+import { validateRecord } from './lib/schemas.mjs';
+import { readProgress, writeProgress, verifyChecksum, resetProgress } from './lib/progress.mjs';
+
+function formatBatchId(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return `catalog_${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function mapToImportRecord(rec, import_batch_id, imported_at) {
+  return {
+    canonical_id: rec.canonical_id,
+    scientific_name: rec.scientific_name,
+    common_name: rec.common_name,
+    family: rec.family,
+    category: rec.category || null,
+    description: rec.description || null,
+    edible: rec.edible ?? null,
+    edible_parts: rec.edible_parts || [],
+    water_requirement: rec.water_requirement || null,
+    light_requirements: rec.light_requirements || [],
+    life_cycle: rec.life_cycle || null,
+    hardiness_zones: rec.hardiness_zones || [],
+    catalog_status: rec.catalog_status,
+    review_status: rec.review_status,
+    field_sources: rec.field_sources || {},
+    import_batch_id,
+    imported_at,
+    last_verified_at: null,
+  };
+}
+
+export async function runPromote({ reset = false, dryRun = false, limit = null } = {}) {
+  if (!fs.existsSync(PATHS.step6)) throw new Error(`Missing required input from Step 6: ${PATHS.step6}`);
+  if (reset) await resetProgress(7);
+
+  const checksum = await computeChecksum(PATHS.step6);
+  await verifyChecksum(7, checksum);
+
+  const input = [];
+  for await (const r of readJsonl(PATHS.step6)) input.push(r);
+
+  const progress = await readProgress(7);
+  const startIndex = progress ? progress.lastProcessedIndex + 1 : 0;
+  const slice = input.slice(startIndex, limit ? startIndex + limit : undefined);
+
+  const import_batch_id = formatBatchId();
+  const imported_at = new Date().toISOString();
+
+  const promoted = [];
+  const reviewNeedsReview = [];
+  const reviewUnresolved = [];
+  const reviewExcluded = [];
+
+  for (const rec of slice) {
+    const eligibleClass = rec.catalog_status === 'core' || rec.catalog_status === 'extended';
+    const eligibleReview = rec.review_status === 'auto_approved';
+    const candidate = mapToImportRecord(rec, import_batch_id, imported_at);
+    const validation = validateRecord(['canonical_id', 'scientific_name', 'common_name', 'catalog_status', 'review_status'], candidate);
+    const contentValid = Boolean(candidate.canonical_id && candidate.scientific_name && candidate.common_name);
+
+    if (eligibleClass && eligibleReview && validation.valid && contentValid) {
+      promoted.push(candidate);
+      continue;
+    }
+
+    if (rec.catalog_status === 'excluded') {
+      reviewExcluded.push(rec);
+    } else if (rec.review_status === 'needs_review') {
+      reviewNeedsReview.push({ ...rec, validation_errors: validation.errors });
+    } else {
+      reviewUnresolved.push({ ...rec, validation_errors: validation.errors });
+    }
+  }
+
+  const summary = {
+    import_batch_id,
+    promotedCount: promoted.length,
+    reviewNeedsReviewCount: reviewNeedsReview.length,
+    reviewUnresolvedCount: reviewUnresolved.length,
+    reviewExcludedCount: reviewExcluded.length,
+    processedThisRun: slice.length,
+  };
+
+  if (!dryRun) {
+    await fsp.mkdir('data/catalog', { recursive: true });
+    await appendJsonl(PATHS.promoted, promoted);
+    await appendJsonl(PATHS.reviewNeedsReview, reviewNeedsReview);
+    await appendJsonl(PATHS.reviewUnresolved, reviewUnresolved);
+    await appendJsonl(PATHS.reviewExcluded, reviewExcluded);
+    await fsp.writeFile(PATHS.reviewSummary, JSON.stringify(summary, null, 2));
+    if (slice.length > 0) await writeProgress(7, startIndex + slice.length - 1, checksum);
+  }
+
+  return summary;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runPromote().then((s) => console.log(JSON.stringify(s, null, 2))).catch((e) => {
+    console.error(e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/catalog/tests/promote.test.mjs
+++ b/scripts/catalog/tests/promote.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { runPromote } from '../promote.mjs';
+
+const dataDir = path.resolve(process.cwd(), 'data/catalog');
+
+test('promote partitions records exhaustively and sets import fields', async () => {
+  await fs.mkdir(dataDir, { recursive: true });
+
+  const paths = [
+    'step6_augmented_catalog.jsonl',
+    'promoted_crops.jsonl',
+    'review_queue_needs_review.jsonl',
+    'review_queue_unresolved.jsonl',
+    'review_queue_excluded.jsonl',
+    'promote_progress.json',
+  ].map((name) => path.join(dataDir, name));
+  await Promise.all(paths.map((p) => fs.rm(p, { force: true })));
+
+  const step6 = [
+    { canonical_id: '1', scientific_name: 'A', common_name: 'A', catalog_status: 'core', review_status: 'auto_approved' },
+    { canonical_id: '2', scientific_name: 'B', common_name: 'B', catalog_status: 'extended', review_status: 'needs_review' },
+    { canonical_id: '3', scientific_name: null, common_name: 'C', catalog_status: 'core', review_status: 'auto_approved' },
+    { canonical_id: '4', scientific_name: 'D', common_name: 'D', catalog_status: 'excluded', review_status: 'rejected' },
+  ];
+  await fs.writeFile(path.join(dataDir, 'step6_augmented_catalog.jsonl'), `${step6.map((x) => JSON.stringify(x)).join('\n')}\n`);
+
+  const summary = await runPromote();
+  assert.equal(summary.processedThisRun, 4);
+  assert.match(summary.import_batch_id, /^catalog_\d{8}_\d{6}$/);
+
+  const promoted = (await fs.readFile(path.join(dataDir, 'promoted_crops.jsonl'), 'utf8')).trim().split('\n').map(JSON.parse);
+  assert.equal(promoted.length, 1);
+  assert.equal(promoted[0].last_verified_at, null);
+
+  const needsReview = (await fs.readFile(path.join(dataDir, 'review_queue_needs_review.jsonl'), 'utf8')).trim().split('\n').map(JSON.parse);
+  const unresolved = (await fs.readFile(path.join(dataDir, 'review_queue_unresolved.jsonl'), 'utf8')).trim().split('\n').map(JSON.parse);
+  const excluded = (await fs.readFile(path.join(dataDir, 'review_queue_excluded.jsonl'), 'utf8')).trim().split('\n').map(JSON.parse);
+
+  assert.equal(needsReview.length, 1);
+  assert.equal(unresolved.length, 1);
+  assert.equal(excluded.length, 1);
+});


### PR DESCRIPTION
## Summary
- add promote.mjs to generate import-ready promoted output
- write exhaustive review queues (needs_review, unresolved, excluded) and summary metrics
- enforce import batch metadata and validation-gated promotion

## Smoke Result
- node --test PASS (12 passed, 0 failed)
