### PR TITLE
Test suite + fixtures + E2E golden validation

### DIFF
--- a/scripts/catalog/tests/e2e.fixture.test.mjs
+++ b/scripts/catalog/tests/e2e.fixture.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { runPromote } from '../promote.mjs';
+
+const root = process.cwd();
+const dataDir = path.join(root, 'data/catalog');
+const fixturePath = path.join(root, 'tests/fixtures/step6_happy_path.jsonl');
+
+async function readJsonl(filePath) {
+  const txt = await fs.readFile(filePath, 'utf8');
+  return txt.trim().split('\n').filter(Boolean).map(JSON.parse);
+}
+
+test('fixture E2E promotion preserves partition invariants', async () => {
+  await fs.mkdir(dataDir, { recursive: true });
+  const outputs = [
+    'step6_augmented_catalog.jsonl',
+    'promoted_crops.jsonl',
+    'review_queue_needs_review.jsonl',
+    'review_queue_unresolved.jsonl',
+    'review_queue_excluded.jsonl',
+    'promote_progress.json',
+  ];
+  await Promise.all(outputs.map((name) => fs.rm(path.join(dataDir, name), { force: true })));
+
+  await fs.copyFile(fixturePath, path.join(dataDir, 'step6_augmented_catalog.jsonl'));
+  const summary = await runPromote();
+
+  const promoted = await readJsonl(path.join(dataDir, 'promoted_crops.jsonl'));
+  const needsReview = await readJsonl(path.join(dataDir, 'review_queue_needs_review.jsonl'));
+  const unresolvedTxt = await fs.readFile(path.join(dataDir, 'review_queue_unresolved.jsonl'), 'utf8').catch(() => '');
+  const unresolved = unresolvedTxt.trim() ? unresolvedTxt.trim().split('\n').map(JSON.parse) : [];
+  const excluded = await readJsonl(path.join(dataDir, 'review_queue_excluded.jsonl'));
+
+  assert.equal(promoted.length, 1);
+  assert.equal(needsReview.length, 1);
+  assert.equal(unresolved.length, 0);
+  assert.equal(excluded.length, 1);
+  assert.equal(promoted.length + needsReview.length + unresolved.length + excluded.length, 3);
+  assert.equal(summary.processedThisRun, 3);
+});

--- a/scripts/catalog/tests/fixtures/step6_happy_path.jsonl
+++ b/scripts/catalog/tests/fixtures/step6_happy_path.jsonl
@@ -1,0 +1,3 @@
+{"canonical_id":"crop-1","scientific_name":"Solanum lycopersicum","common_name":"Tomato","catalog_status":"core","review_status":"auto_approved"}
+{"canonical_id":"crop-2","scientific_name":"Ocimum basilicum","common_name":"Basil","catalog_status":"extended","review_status":"needs_review"}
+{"canonical_id":"crop-3","scientific_name":"Rosa canina","common_name":"Dog Rose","catalog_status":"excluded","review_status":"rejected"}

--- a/scripts/catalog/tests/promotion.property.test.mjs
+++ b/scripts/catalog/tests/promotion.property.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fc from 'fast-check';
+
+function partition(records) {
+  let promoted = 0;
+  let review = 0;
+  let unresolved = 0;
+  let excluded = 0;
+  for (const rec of records) {
+    const valid = Boolean(rec.canonical_id && rec.scientific_name && rec.common_name);
+    if ((rec.catalog_status === 'core' || rec.catalog_status === 'extended') && rec.review_status === 'auto_approved' && valid) promoted += 1;
+    else if (rec.catalog_status === 'excluded') excluded += 1;
+    else if (rec.review_status === 'needs_review') review += 1;
+    else unresolved += 1;
+  }
+  return { promoted, review, unresolved, excluded };
+}
+
+test('promotion partition is exhaustive', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      fc.array(
+        fc.record({
+          canonical_id: fc.option(fc.string({ minLength: 1, maxLength: 5 }), { nil: undefined }),
+          scientific_name: fc.option(fc.string({ minLength: 1, maxLength: 5 }), { nil: undefined }),
+          common_name: fc.option(fc.string({ minLength: 1, maxLength: 5 }), { nil: undefined }),
+          catalog_status: fc.constantFrom('core', 'extended', 'excluded', 'hidden'),
+          review_status: fc.constantFrom('auto_approved', 'needs_review', 'rejected'),
+        }),
+        { maxLength: 80 },
+      ),
+      async (records) => {
+        const r = partition(records);
+        assert.equal(r.promoted + r.review + r.unresolved + r.excluded, records.length);
+      },
+    ),
+  );
+});


### PR DESCRIPTION
## Summary
- add property-based partition invariant test for promotion routing
- add fixture-backed E2E test validating promoted/review/excluded artifact outputs
- add happy-path fixture data for reproducible golden-style validation

## Smoke Result
- node --test PASS (13 passed, 0 failed)
