### PR TITLE
fix(catalog): stabilize empty queue file handling in appendJsonl

### DIFF
--- a/scripts/catalog/lib/io.mjs
+++ b/scripts/catalog/lib/io.mjs
@@ -10,8 +10,12 @@ export async function* readJsonl(filePath) {
 }
 
 export async function appendJsonl(filePath, records) {
-  if (!records?.length) return;
   await fsp.mkdir(new URL('.', `file://${filePath}`), { recursive: true }).catch(() => {});
+  if (!records?.length) {
+    // Keep queue/report files present even when there are zero rows.
+    if (!fs.existsSync(filePath)) await fsp.writeFile(filePath, '', 'utf8');
+    return;
+  }
   const payload = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
   await fsp.appendFile(filePath, payload, 'utf8');
 }


### PR DESCRIPTION
## Summary
- update `appendJsonl` to create an empty file when called with zero records
- prevents missing review queue JSONL files in smoke/e2e scenarios with empty partitions

## Linked work
Follow-up stabilization from smoke test pass

## Smoke Result
- ✅ `node --test --test-concurrency=1` passes (13/13)
- ✅ no ENOENT for empty review queue outputs during promotion tests

## Validation
- `node --test --test-concurrency=1`