### PR TITLE
test(catalog): make file-backed tests parallel-safe

### DIFF
--- a/scripts/catalog/tests/e2e.fixture.test.mjs
+++ b/scripts/catalog/tests/e2e.fixture.test.mjs
@@ -2,19 +2,44 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import { runPromote } from '../promote.mjs';
+import { PATHS, PROGRESS_PATHS } from '../lib/config.mjs';
 
 const root = process.cwd();
-const dataDir = path.join(root, 'data/catalog');
 const fixturePath = path.join(root, 'tests/fixtures/step6_happy_path.jsonl');
+
+async function withTempCatalogPaths(fn) {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'catalog-e2e-test-'));
+  const dataDir = path.join(tmpRoot, 'data', 'catalog');
+  await fs.mkdir(dataDir, { recursive: true });
+
+  const oldPaths = { ...PATHS };
+  const oldProgress = { ...PROGRESS_PATHS };
+
+  PATHS.step6 = path.join(dataDir, 'step6_augmented_catalog.jsonl');
+  PATHS.promoted = path.join(dataDir, 'promoted_crops.jsonl');
+  PATHS.reviewNeedsReview = path.join(dataDir, 'review_queue_needs_review.jsonl');
+  PATHS.reviewUnresolved = path.join(dataDir, 'review_queue_unresolved.jsonl');
+  PATHS.reviewExcluded = path.join(dataDir, 'review_queue_excluded.jsonl');
+  PATHS.reviewSummary = path.join(dataDir, 'review_summary.json');
+  PROGRESS_PATHS[7] = path.join(dataDir, 'promote_progress.json');
+
+  try {
+    await fn(dataDir);
+  } finally {
+    Object.assign(PATHS, oldPaths);
+    Object.assign(PROGRESS_PATHS, oldProgress);
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  }
+}
 
 async function readJsonl(filePath) {
   const txt = await fs.readFile(filePath, 'utf8');
   return txt.trim().split('\n').filter(Boolean).map(JSON.parse);
 }
 
-test('fixture E2E promotion preserves partition invariants', async () => {
-  await fs.mkdir(dataDir, { recursive: true });
+test('fixture E2E promotion preserves partition invariants', async () => withTempCatalogPaths(async (dataDir) => {
   const outputs = [
     'step6_augmented_catalog.jsonl',
     'promoted_crops.jsonl',
@@ -40,4 +65,4 @@ test('fixture E2E promotion preserves partition invariants', async () => {
   assert.equal(excluded.length, 1);
   assert.equal(promoted.length + needsReview.length + unresolved.length + excluded.length, 3);
   assert.equal(summary.processedThisRun, 3);
-});
+}));

--- a/scripts/catalog/tests/promote.test.mjs
+++ b/scripts/catalog/tests/promote.test.mjs
@@ -2,13 +2,36 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import { runPromote } from '../promote.mjs';
+import { PATHS, PROGRESS_PATHS } from '../lib/config.mjs';
 
-const dataDir = path.resolve(process.cwd(), 'data/catalog');
-
-test('promote partitions records exhaustively and sets import fields', async () => {
+async function withTempCatalogPaths(fn) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'catalog-promote-test-'));
+  const dataDir = path.join(root, 'data', 'catalog');
   await fs.mkdir(dataDir, { recursive: true });
 
+  const oldPaths = { ...PATHS };
+  const oldProgress = { ...PROGRESS_PATHS };
+
+  PATHS.step6 = path.join(dataDir, 'step6_augmented_catalog.jsonl');
+  PATHS.promoted = path.join(dataDir, 'promoted_crops.jsonl');
+  PATHS.reviewNeedsReview = path.join(dataDir, 'review_queue_needs_review.jsonl');
+  PATHS.reviewUnresolved = path.join(dataDir, 'review_queue_unresolved.jsonl');
+  PATHS.reviewExcluded = path.join(dataDir, 'review_queue_excluded.jsonl');
+  PATHS.reviewSummary = path.join(dataDir, 'review_summary.json');
+  PROGRESS_PATHS[7] = path.join(dataDir, 'promote_progress.json');
+
+  try {
+    await fn(dataDir);
+  } finally {
+    Object.assign(PATHS, oldPaths);
+    Object.assign(PROGRESS_PATHS, oldProgress);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test('promote partitions records exhaustively and sets import fields', async () => withTempCatalogPaths(async (dataDir) => {
   const paths = [
     'step6_augmented_catalog.jsonl',
     'promoted_crops.jsonl',
@@ -42,4 +65,4 @@ test('promote partitions records exhaustively and sets import fields', async () 
   assert.equal(needsReview.length, 1);
   assert.equal(unresolved.length, 1);
   assert.equal(excluded.length, 1);
-});
+}));

--- a/scripts/catalog/tests/step6.test.mjs
+++ b/scripts/catalog/tests/step6.test.mjs
@@ -2,15 +2,36 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
 import { runStep6 } from '../step6_llm_augment.mjs';
+import { PATHS, PROGRESS_PATHS } from '../lib/config.mjs';
 
-const dataDir = path.resolve(process.cwd(), 'data/catalog');
-const step5Path = path.join(dataDir, 'step5_canonical_drafts.jsonl');
-const step6Path = path.join(dataDir, 'step6_augmented_catalog.jsonl');
-const progressPath = path.join(dataDir, 'step6_progress.json');
-
-test('step6 augments eligible records and leaves excluded unchanged', async () => {
+async function withTempCatalogPaths(fn) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'catalog-step6-test-'));
+  const dataDir = path.join(root, 'data', 'catalog');
   await fs.mkdir(dataDir, { recursive: true });
+
+  const oldPaths = { ...PATHS };
+  const oldProgress = { ...PROGRESS_PATHS };
+
+  PATHS.step5 = path.join(dataDir, 'step5_canonical_drafts.jsonl');
+  PATHS.step6 = path.join(dataDir, 'step6_augmented_catalog.jsonl');
+  PROGRESS_PATHS[6] = path.join(dataDir, 'step6_progress.json');
+
+  try {
+    await fn({
+      step5Path: PATHS.step5,
+      step6Path: PATHS.step6,
+      progressPath: PROGRESS_PATHS[6],
+    });
+  } finally {
+    Object.assign(PATHS, oldPaths);
+    Object.assign(PROGRESS_PATHS, oldProgress);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test('step6 augments eligible records and leaves excluded unchanged', async () => withTempCatalogPaths(async ({ step5Path, step6Path, progressPath }) => {
   await fs.rm(step5Path, { force: true });
   await fs.rm(step6Path, { force: true });
   await fs.rm(progressPath, { force: true });
@@ -34,4 +55,4 @@ test('step6 augments eligible records and leaves excluded unchanged', async () =
   assert.equal(out.length, 2);
   assert.equal(out.find((r) => r.canonical_id === '1').description, 'Desc 1');
   assert.equal(out.find((r) => r.canonical_id === '2').description, undefined);
-});
+}));


### PR DESCRIPTION
## Summary
- isolate file-backed tests to per-test temp catalog directories
- avoid cross-test collisions in parallel Node test execution
- update promote/e2e/step6 tests to temporarily rebind PATHS/PROGRESS_PATHS during test scope

## Smoke Result
- ✅ `node --test` passes under default parallel execution (13/13)
- ✅ no shared `data/catalog` race failures

## Validation
- `node --test`