### PR TITLE
feat(catalog): matcher hardening with safe fuzzy fallback

### DIFF
--- a/scripts/catalog/lib/config.mjs
+++ b/scripts/catalog/lib/config.mjs
@@ -32,7 +32,7 @@ export const PROGRESS_PATHS = {
 };
 
 export const ENUMS = {
-  matchType: ['exact_scientific', 'normalized_scientific', 'synonym_match', 'common_name_fallback', 'ambiguous_common_name', 'unresolved'],
+  matchType: ['exact_scientific', 'normalized_scientific', 'synonym_match', 'common_name_fallback', 'fuzzy_fallback', 'ambiguous_common_name', 'unresolved'],
   relevanceClass: ['food_crop_core', 'food_crop_niche', 'edible_ornamental', 'medicinal_only', 'industrial_crop', 'weed_or_invasive', 'non_food'],
 };
 
@@ -41,6 +41,7 @@ export const MATCH_SCORES = {
   normalized_scientific: 0.95,
   synonym_match: 0.85,
   common_name_fallback: 0.7,
+  fuzzy_fallback: 0.55,
   ambiguous_common_name: 0.4,
   unresolved: 0,
 };

--- a/scripts/catalog/step2_match_sources.mjs
+++ b/scripts/catalog/step2_match_sources.mjs
@@ -6,10 +6,92 @@ import { normalizeToNull } from './lib/normalize.mjs';
 import { searchPlant, searchPlantByCommonName, getCacheStats, updateManifest } from './lib/permapeople.mjs';
 import { readProgress, writeProgress, verifyChecksum, resetProgress } from './lib/progress.mjs';
 
-function normSci(name) {
-  const v = normalizeToNull(name);
+function cleanToken(value) {
+  const v = normalizeToNull(value);
   if (!v) return null;
-  return v.toLowerCase().split(/\s+/).slice(0, 2).join(' ');
+  return v
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\b(var\.?|subsp\.?|ssp\.?|f\.?|forma|cv\.?|cultivar)\b/g, ' ')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normSci(name) {
+  const cleaned = cleanToken(name);
+  if (!cleaned) return null;
+  return cleaned.split(' ').slice(0, 2).join(' ');
+}
+
+function normCommon(name) {
+  return cleanToken(name);
+}
+
+function editDistance(a, b) {
+  if (a === b) return 0;
+  if (!a) return b.length;
+  if (!b) return a.length;
+
+  const dp = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+  for (let i = 0; i <= a.length; i += 1) dp[i][0] = i;
+  for (let j = 0; j <= b.length; j += 1) dp[0][j] = j;
+
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+    }
+  }
+
+  return dp[a.length][b.length];
+}
+
+function similarity(a, b) {
+  const maxLen = Math.max(a.length, b.length, 1);
+  return 1 - (editDistance(a, b) / maxLen);
+}
+
+function fuzzyPick(query, candidates, threshold = 0.92) {
+  if (!query || candidates.length === 0) return null;
+
+  let best = null;
+  let secondBest = null;
+
+  for (const candidate of candidates) {
+    const score = similarity(query, candidate.normalized);
+    if (!best || score > best.score) {
+      secondBest = best;
+      best = { ...candidate, score };
+    } else if (!secondBest || score > secondBest.score) {
+      secondBest = { ...candidate, score };
+    }
+  }
+
+  if (!best || best.score < threshold) return null;
+
+  if (secondBest && Math.abs(best.score - secondBest.score) < 0.03) {
+    return { ambiguous: true, candidates: [best.canonical_id, secondBest.canonical_id], score: best.score };
+  }
+
+  return { ambiguous: false, canonical_id: best.canonical_id, score: best.score };
+}
+
+function stableSlug(value) {
+  const cleaned = cleanToken(value);
+  return cleaned ? cleaned.replace(/\s+/g, '-') : 'unknown';
+}
+
+function buildOpenFarmSourceId(row, index) {
+  const sci = stableSlug(row.scientific_name);
+  const common = stableSlug(row.common_name);
+  return `openfarm:${sci}:${common}:${index}`;
 }
 
 function buildIndexes(canonicalRows) {
@@ -17,17 +99,31 @@ function buildIndexes(canonicalRows) {
   const normalized = new Map();
   const synonym = new Map();
   const common = new Map();
+  const fuzzyScientific = [];
+  const fuzzyCommon = [];
+
   for (const c of canonicalRows) {
-    exact.set(c.accepted_scientific_name, c.canonical_id);
-    normalized.set(c.scientific_name_normalized, c.canonical_id);
-    for (const s of c.synonyms || []) synonym.set(normSci(s), c.canonical_id);
+    if (c.accepted_scientific_name) exact.set(c.accepted_scientific_name, c.canonical_id);
+    if (c.scientific_name_normalized) {
+      normalized.set(c.scientific_name_normalized, c.canonical_id);
+      fuzzyScientific.push({ normalized: c.scientific_name_normalized, canonical_id: c.canonical_id });
+    }
+    for (const s of c.synonyms || []) {
+      const k = normSci(s);
+      if (k) {
+        synonym.set(k, c.canonical_id);
+        fuzzyScientific.push({ normalized: k, canonical_id: c.canonical_id });
+      }
+    }
     for (const n of c.common_names || []) {
-      const k = String(n).trim().toLowerCase();
+      const k = normCommon(n);
+      if (!k) continue;
       if (!common.has(k)) common.set(k, []);
       common.get(k).push(c.canonical_id);
+      fuzzyCommon.push({ normalized: k, canonical_id: c.canonical_id });
     }
   }
-  return { exact, normalized, synonym, common };
+  return { exact, normalized, synonym, common, fuzzyScientific, fuzzyCommon };
 }
 
 export function matchRecord(record, indexes) {
@@ -45,7 +141,7 @@ export function matchRecord(record, indexes) {
     return { canonical_id: indexes.synonym.get(normalizedName), match_type: 'synonym_match', match_score: MATCH_SCORES.synonym_match };
   }
   if (commonName) {
-    const k = commonName.toLowerCase();
+    const k = normCommon(commonName);
     const candidates = indexes.common.get(k) || [];
     if (candidates.length === 1) {
       return { canonical_id: candidates[0], match_type: 'common_name_fallback', match_score: MATCH_SCORES.common_name_fallback };
@@ -54,6 +150,44 @@ export function matchRecord(record, indexes) {
       return { canonical_id: null, match_type: 'ambiguous_common_name', match_score: MATCH_SCORES.ambiguous_common_name, ambiguous_candidates: candidates };
     }
   }
+
+  const fuzzyScientific = fuzzyPick(normalizedName, indexes.fuzzyScientific || [], 0.92);
+  if (fuzzyScientific) {
+    if (fuzzyScientific.ambiguous) {
+      return {
+        canonical_id: null,
+        match_type: 'ambiguous_common_name',
+        match_score: MATCH_SCORES.ambiguous_common_name,
+        ambiguous_candidates: fuzzyScientific.candidates,
+      };
+    }
+    return {
+      canonical_id: fuzzyScientific.canonical_id,
+      match_type: 'fuzzy_fallback',
+      match_score: MATCH_SCORES.fuzzy_fallback,
+      needs_review: true,
+    };
+  }
+
+  const normalizedCommon = normCommon(commonName);
+  const fuzzyCommon = fuzzyPick(normalizedCommon, indexes.fuzzyCommon || [], 0.82);
+  if (fuzzyCommon) {
+    if (fuzzyCommon.ambiguous) {
+      return {
+        canonical_id: null,
+        match_type: 'ambiguous_common_name',
+        match_score: MATCH_SCORES.ambiguous_common_name,
+        ambiguous_candidates: fuzzyCommon.candidates,
+      };
+    }
+    return {
+      canonical_id: fuzzyCommon.canonical_id,
+      match_type: 'fuzzy_fallback',
+      match_score: MATCH_SCORES.fuzzy_fallback,
+      needs_review: true,
+    };
+  }
+
   return { canonical_id: null, match_type: 'unresolved', match_score: MATCH_SCORES.unresolved };
 }
 
@@ -80,7 +214,7 @@ export async function runStep2({ reset = false, dryRun = false, limit = null } =
   openfarmForFetch.forEach((r, i) => {
     allRecords.push({
       source_provider: 'openfarm',
-      source_record_id: `openfarm:${i}`,
+      source_record_id: buildOpenFarmSourceId(r, i),
       scientific_name: r.scientific_name ?? null,
       common_name: r.common_name ?? null,
       raw_payload: r,
@@ -136,6 +270,7 @@ export async function runStep2({ reset = false, dryRun = false, limit = null } =
       match_score: m.match_score,
       matched_at: new Date().toISOString(),
       ...(m.ambiguous_candidates ? { ambiguous_candidates: m.ambiguous_candidates } : {}),
+      ...(m.needs_review ? { needs_review: true } : {}),
     };
   });
 

--- a/scripts/catalog/step4_classify.mjs
+++ b/scripts/catalog/step4_classify.mjs
@@ -66,14 +66,18 @@ export function classifyCanonical(records) {
   const source_confidence = Math.max(0, Math.min(1, ...records.map((r) => Number(r.match_score ?? 0)), 0));
   const source_agreement_score = providers.size > 0 ? edibleEvidenceSources.size / providers.size : 0;
 
+  const hasFuzzyFallback = records.some((r) => r.match_type === 'fuzzy_fallback' || r.needs_review === true);
+
   const review_status =
     catalog_status === 'excluded'
       ? 'rejected'
-      : (!hasOpenFarmSupport
+      : (hasFuzzyFallback
         ? 'needs_review'
-        : ((hasOpenFarmSupport || strongFoodEvidence) && source_confidence >= 0.65 && source_agreement_score >= 0.5
-          ? 'auto_approved'
-          : 'needs_review'));
+        : (!hasOpenFarmSupport
+          ? 'needs_review'
+          : ((hasOpenFarmSupport || strongFoodEvidence) && source_confidence >= 0.65 && source_agreement_score >= 0.5
+            ? 'auto_approved'
+            : 'needs_review')));
 
   const lead = records[0] || {};
 

--- a/scripts/catalog/tests/step2.test.mjs
+++ b/scripts/catalog/tests/step2.test.mjs
@@ -7,6 +7,8 @@ const indexes = {
   normalized: new Map([['solanum lycopersicum', 'LYCO2']]),
   synonym: new Map([['lycopersicon esculentum', 'LYCO2']]),
   common: new Map([['tomato', ['LYCO2']], ['mint', ['A', 'B']]]),
+  fuzzyScientific: [{ normalized: 'solanum lycopersicum', canonical_id: 'LYCO2' }],
+  fuzzyCommon: [{ normalized: 'tomato', canonical_id: 'LYCO2' }],
 };
 
 test('step2 cascade exact -> unresolved', () => {
@@ -23,7 +25,20 @@ test('step2 cascade exact -> unresolved', () => {
   const amb = matchRecord({ common_name: 'mint' }, indexes);
   assert.equal(amb.match_type, 'ambiguous_common_name');
 
+  const fuzzySci = matchRecord({ scientific_name: 'Solanum lycoperscum' }, indexes);
+  assert.equal(fuzzySci.match_type, 'fuzzy_fallback');
+  assert.equal(fuzzySci.needs_review, true);
+
+  const fuzzyCommon = matchRecord({ common_name: 'tomat0' }, indexes);
+  assert.equal(fuzzyCommon.match_type, 'fuzzy_fallback');
+  assert.equal(fuzzyCommon.needs_review, true);
+
   const un = matchRecord({ scientific_name: 'Unknown plant' }, indexes);
   assert.equal(un.match_type, 'unresolved');
   assert.equal(un.match_score, 0);
+});
+
+test('step2 normalization tolerates cultivar punctuation', () => {
+  const normalized = matchRecord({ scientific_name: 'Solanum lycopersicum cv. Roma' }, indexes);
+  assert.equal(normalized.match_type, 'normalized_scientific');
 });

--- a/scripts/catalog/tests/step4.test.mjs
+++ b/scripts/catalog/tests/step4.test.mjs
@@ -31,4 +31,18 @@ test('step4 enforces openfarm-first and guardrails', () => {
   assert.equal(openFarmSupported.relevance_class, 'food_crop_core');
   assert.equal(openFarmSupported.catalog_status, 'core');
   assert.equal(openFarmSupported.has_openfarm_support, true);
+
+  const fuzzyMatched = classifyCanonical([
+    {
+      canonical_id: 'C',
+      source_provider: 'openfarm',
+      source_record_id: 'o2',
+      match_type: 'fuzzy_fallback',
+      match_score: 0.55,
+      needs_review: true,
+      normalized: { scientific_name: 'Ocimum basilicum', common_names: ['basil'], edible: true, edible_parts: ['leaf'] },
+    },
+  ]);
+
+  assert.equal(fuzzyMatched.review_status, 'needs_review');
 });


### PR DESCRIPTION
## Summary
- improve Step 2 name normalization and matching tolerance
- add safe fuzzy fallback path that never auto-approves (routes to review path)
- tighten Step 4 handling for fuzzy matches via confidence score/needs-review behavior
- extend step tests for fuzzy + guardrail behavior

## Smoke Result (400-sample)
| Metric | Before (`crop-data-pipeline`) | After (`feat/matcher-hardening-182b`) |
|---|---:|---:|
| unresolved matches | 212 | 210 |
| ambiguous common-name matches | 8 | 10 |
| normalized scientific matches | 173 | 173 |
| synonym matches | 7 | 7 |
| promotedCount | 0 | 0 |
| reviewNeedsReviewCount | 2 | 2 |
| reviewExcludedCount | 200 | 200 |

Notes: this pass improves matcher behavior slightly and safely; it does not widen promotion yet (intended).

## Validation
- `node --test scripts/catalog/tests/step2.test.mjs scripts/catalog/tests/step4.test.mjs`