### PR TITLE
ci: add public catalog smoke Postman collection and CI job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -724,6 +724,27 @@ jobs:
           HTTP_CODE=$(curl --silent --show-error --output /tmp/catalog.json --write-out "%{http_code}" "$API_URL/catalog/crops")
           test "$HTTP_CODE" = "401"
 
+  postman-public-smoke:
+    name: Public Catalog Smoke Test
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    needs: [deploy-staging-backend, staging-public-api-smoke]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Postman CLI
+        run: curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh
+
+      - name: Login to Postman CLI
+        run: postman login --with-api-key ${{ secrets.POSTMAN_API_KEY }}
+
+      - name: Run public catalog smoke collection
+        run: |
+          postman collection run "postman/collections/Public Catalog Smoke" \
+            --env-var "baseUrl=${{ needs.deploy-staging-backend.outputs.api-url }}"
+
   contract-api-tests:
     name: Staging Contract API Tests
     if: github.event.action != 'closed'
@@ -981,6 +1002,7 @@ jobs:
       - deploy-staging-backend
       - deploy-staging-frontend
       - staging-public-api-smoke
+      - postman-public-smoke
       - contract-api-tests
       - utility-api-tests
       - e2e-api-tests
@@ -1001,6 +1023,7 @@ jobs:
           check_result "deploy-staging-backend" "${{ needs.deploy-staging-backend.result }}"
           check_result "deploy-staging-frontend" "${{ needs.deploy-staging-frontend.result }}"
           check_result "staging-public-api-smoke" "${{ needs.staging-public-api-smoke.result }}"
+          check_result "postman-public-smoke" "${{ needs.postman-public-smoke.result }}"
           check_result "contract-api-tests" "${{ needs.contract-api-tests.result }}"
           check_result "utility-api-tests" "${{ needs.utility-api-tests.result }}"
           check_result "e2e-api-tests" "${{ needs.e2e-api-tests.result }}"

--- a/postman/collections/Public Catalog Smoke/.resources/definition.yaml
+++ b/postman/collections/Public Catalog Smoke/.resources/definition.yaml
@@ -1,0 +1,21 @@
+$kind: collection
+name: Public Catalog Smoke
+description: |-
+  No-auth smoke test for the public catalog API.
+
+  Verifies that the catalog crops endpoint returns data and that
+  a variety lookup succeeds for the first returned crop.
+
+  ## Steps
+  1. List catalog crops — assert 200, non-empty array, valid crop shape
+  2. List varieties for the first crop — assert 200, array response
+
+  ## Authentication
+  None required. Both endpoints are public.
+variables:
+  - key: baseUrl
+    value: 'https://api.example.com'
+    description: API base URL
+  - key: catalogCropId
+    value: ''
+    description: Captured from Step 1 response

--- a/postman/collections/Public Catalog Smoke/Step 1 - List Catalog Crops.request.yaml
+++ b/postman/collections/Public Catalog Smoke/Step 1 - List Catalog Crops.request.yaml
@@ -1,0 +1,42 @@
+$kind: http-request
+name: Step 1 - List Catalog Crops
+description: |-
+  Fetch the public catalog of crops. No authentication required.
+  Captures the first crop ID for the variety lookup in Step 2.
+method: GET
+url: '{{baseUrl}}/catalog/crops'
+order: 1000
+auth:
+  type: none
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      const uuidV4Like = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Response is JSON", function () {
+          pm.response.to.have.header("Content-Type", /application\/json/);
+      });
+
+      const crops = pm.response.json();
+
+      pm.test("Response is a non-empty array", function () {
+          pm.expect(Array.isArray(crops)).to.be.true;
+          pm.expect(crops.length).to.be.greaterThan(0);
+      });
+
+      pm.test("First crop has valid id and common_name", function () {
+          const first = crops[0];
+          pm.expect(first).to.have.property("id");
+          pm.expect(first.id).to.match(uuidV4Like);
+          pm.expect(first).to.have.property("common_name");
+          pm.expect(first.common_name).to.be.a("string").and.not.empty;
+      });
+
+      if (crops.length > 0) {
+          pm.collectionVariables.set("catalogCropId", crops[0].id);
+      }

--- a/postman/collections/Public Catalog Smoke/Step 2 - List Crop Varieties.request.yaml
+++ b/postman/collections/Public Catalog Smoke/Step 2 - List Crop Varieties.request.yaml
@@ -1,0 +1,30 @@
+$kind: http-request
+name: Step 2 - List Crop Varieties
+description: |-
+  Fetch varieties for the crop captured in Step 1. No authentication required.
+method: GET
+url: '{{baseUrl}}/catalog/crops/:cropId/varieties'
+order: 2000
+auth:
+  type: none
+pathVariables:
+  - key: cropId
+    value: '{{catalogCropId}}'
+    description: UUID of the catalog crop from Step 1
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Response is JSON", function () {
+          pm.response.to.have.header("Content-Type", /application\/json/);
+      });
+
+      const varieties = pm.response.json();
+
+      pm.test("Response is an array", function () {
+          pm.expect(Array.isArray(varieties)).to.be.true;
+      });


### PR DESCRIPTION
## Summary

Adds a no-auth public catalog smoke test that runs on every PR, catching basic API/catalog regressions fast.

Closes #98

## What changed

**New Postman collection**: \postman/collections/Public Catalog Smoke\
- Step 1: \GET /catalog/crops\ — asserts 200, non-empty JSON array, valid UUID on first crop, captures \catalogCropId\
- Step 2: \GET /catalog/crops/:cropId/varieties\ — asserts 200, JSON array response

**New CI job**: \postman-public-smoke\ in \pr-checks.yml\
- Runs after staging deploy + unauthorized smoke gate
- No AWS credentials or auth tokens needed — only \POSTMAN_API_KEY\ and \aseUrl\
- Added to \staging-validation-summary\ as a blocking gate

## No secrets required beyond existing

Only uses \POSTMAN_API_KEY\ (already configured) and the staging \pi-url\ output.