### PR TITLE
Prerender head tags, CloudFront rewrite, and polish Contact/Get-Involved/Donate

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && npm run prerender:head",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "images:generate": "node ./scripts/generate-responsive-images.mjs"
+    "images:generate": "node ./scripts/generate-responsive-images.mjs",
+    "prerender:head": "node ./scripts/prerender-head.mjs"
   },
   "dependencies": {
     "@olivias/ui": "file:../../packages/ui",

--- a/apps/web/scripts/prerender-head.mjs
+++ b/apps/web/scripts/prerender-head.mjs
@@ -1,0 +1,215 @@
+// Head-only prerender: walks a list of public routes, clones dist/index.html,
+// and rewrites the <head> tags so that crawlers and unfurl bots see per-route
+// titles, descriptions, OG images, canonical URLs, and JSON-LD metadata.
+//
+// This does NOT pre-render the React tree — modern text crawlers (Google, Bing,
+// Claude, ChatGPT) run JS and see the hydrated body; unfurl scrapers
+// (Facebook, Twitter, Slack, LinkedIn, Discord) only read <head>, which is
+// what this script populates.
+//
+// Output layout:
+//   dist/index.html           -> home page head tags
+//   dist/about/index.html     -> About page head tags
+//   dist/get-involved/index.html
+//   ...
+//
+// For this to actually serve per-route files on CloudFront, the distribution
+// needs a viewer-request function (or equivalent) that rewrites `/about` to
+// `/about/index.html`. See infra/foundation-web/template.yaml.
+//
+// ⚠ Route metadata below is duplicated from src/site/routes.ts. If you add a
+//    route with `prerender: true` there, mirror it here.
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, '..', 'dist');
+const siteUrl = (process.env.VITE_SITE_URL ?? 'https://oliviasgarden.org').replace(/\/+$/, '');
+const instagramUrl = 'https://instagram.com/oliviasgardentx';
+const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
+const defaultImage = '/images/home/garden-landscaping.jpg';
+
+/** @typedef {{ path: string, title: string, description: string, seoImage?: string, allowIndex?: boolean }} PrerenderRoute */
+/** @type {PrerenderRoute[]} */
+const prerenderRoutes = [
+  {
+    path: '/',
+    title: "Olivia's Garden Foundation",
+    description: "Olivia's Garden Foundation is a Texas nonprofit teaching families to grow food, care for animals, preserve harvests, and build practical self-sufficiency.",
+    seoImage: '/images/home/garden-landscaping.jpg',
+  },
+  {
+    path: '/about',
+    title: "About Olivia's Garden",
+    description: "Read Olivia's story, the foundation's mission, and the family-led work behind practical food-growing education in McKinney, Texas.",
+    seoImage: '/images/about/luffa-trellis.jpg',
+  },
+  {
+    path: '/get-involved',
+    title: 'Get involved',
+    description: "Find ways to support Olivia's Garden Foundation through volunteering, seed sharing, workshops, and community participation.",
+    seoImage: '/images/home/watering-seedlings.jpg',
+  },
+  {
+    path: '/seeds',
+    title: 'Request free okra seeds',
+    description: "Request free okra seeds from Olivia's Garden Foundation and join a growing food project rooted in Olivia's seed line.",
+    seoImage: '/images/okra/olivia-okra.jpg',
+  },
+  {
+    path: '/impact',
+    title: "What we're building",
+    description: "See what Olivia's Garden Foundation is growing now, from garden beds and animals to the next phase of community programs.",
+    seoImage: '/images/home/produce-basket.jpg',
+  },
+  {
+    path: '/contact',
+    title: 'Get in touch',
+    description: "Contact Olivia's Garden Foundation for volunteering, seeds, donations, partnerships, and general questions.",
+    seoImage: '/images/home/bee-suit.jpg',
+  },
+];
+
+function buildPageTitle(route) {
+  return route.path === '/'
+    ? `${route.title} | Grow Food, Learn Skills, Build Community`
+    : `${route.title} | Olivia's Garden Foundation`;
+}
+
+function absoluteUrl(path) {
+  return path.startsWith('http://') || path.startsWith('https://') ? path : `${siteUrl}${path}`;
+}
+
+function escapeAttr(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function buildHeadFragment(route) {
+  const pageTitle = buildPageTitle(route);
+  const pageUrl = absoluteUrl(route.path === '/' ? '/' : route.path);
+  const pageImage = absoluteUrl(route.seoImage ?? defaultImage);
+  const robots = route.allowIndex === false
+    ? 'noindex, nofollow, noarchive'
+    : 'index, follow, max-image-preview:large';
+
+  const jsonLdOrg = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'NonprofitOrganization',
+    name: "Olivia's Garden Foundation",
+    url: siteUrl,
+    sameAs: [instagramUrl, facebookUrl],
+  });
+
+  const jsonLdPage = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: pageTitle,
+    description: route.description,
+    url: pageUrl,
+    isPartOf: {
+      '@type': 'WebSite',
+      name: "Olivia's Garden Foundation",
+      url: siteUrl,
+    },
+  });
+
+  return {
+    pageTitle,
+    pageUrl,
+    pageImage,
+    robots,
+    jsonLdOrg,
+    jsonLdPage,
+  };
+}
+
+function applyHead(templateHtml, route) {
+  const { pageTitle, pageUrl, pageImage, robots, jsonLdOrg, jsonLdPage } = buildHeadFragment(route);
+  const desc = escapeAttr(route.description);
+  const title = escapeAttr(pageTitle);
+
+  let html = templateHtml;
+
+  // <title>
+  html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${title}</title>`);
+
+  // Simple meta replacers (by attribute); each one is present in the base
+  // index.html so we're rewriting values, not inserting new tags.
+  const replaceMeta = (matcher, content) => {
+    const regex = new RegExp(`(<meta\\s+${matcher}[^>]*\\scontent=")[^"]*(")`, 'i');
+    if (regex.test(html)) {
+      html = html.replace(regex, `$1${escapeAttr(content)}$2`);
+    } else {
+      // Fall back: inject before </head>
+      html = html.replace('</head>', `    <meta ${matcher} content="${escapeAttr(content)}" />\n  </head>`);
+    }
+  };
+
+  replaceMeta('name="description"', route.description);
+  replaceMeta('name="robots"', robots);
+  replaceMeta('property="og:title"', pageTitle);
+  replaceMeta('property="og:description"', route.description);
+  replaceMeta('property="og:image"', pageImage);
+  replaceMeta('name="twitter:title"', pageTitle);
+  replaceMeta('name="twitter:description"', route.description);
+  replaceMeta('name="twitter:image"', pageImage);
+
+  // og:url is not in the base template; inject it.
+  if (/property="og:url"/i.test(html)) {
+    html = html.replace(/(<meta\s+property="og:url"[^>]*\scontent=")[^"]*(")/i, `$1${escapeAttr(pageUrl)}$2`);
+  } else {
+    html = html.replace('<meta property="og:type"', `<meta property="og:url" content="${escapeAttr(pageUrl)}" />\n    <meta property="og:type"`);
+  }
+
+  // Canonical link
+  html = html.replace(/<link\s+rel="canonical"[^>]*\/?>/i, `<link rel="canonical" href="${escapeAttr(pageUrl)}" />`);
+
+  // JSON-LD blocks (inject once, before </head>)
+  const jsonLdScripts =
+    `    <script type="application/ld+json" data-seo-id="organization">${jsonLdOrg}</script>\n` +
+    `    <script type="application/ld+json" data-seo-id="webpage">${jsonLdPage}</script>\n  `;
+
+  // Remove any previous prerender JSON-LD so reruns are idempotent.
+  html = html.replace(/\s*<script type="application\/ld\+json" data-seo-id="(organization|webpage)">[\s\S]*?<\/script>/g, '');
+  html = html.replace('</head>', `${jsonLdScripts}</head>`);
+
+  return html;
+}
+
+async function writeRoute(templateHtml, route) {
+  const html = applyHead(templateHtml, route);
+  const outPath = route.path === '/'
+    ? join(distDir, 'index.html')
+    : join(distDir, route.path.replace(/^\//, ''), 'index.html');
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, html, 'utf8');
+  return outPath;
+}
+
+async function main() {
+  const templatePath = join(distDir, 'index.html');
+  const templateHtml = await readFile(templatePath, 'utf8');
+
+  const written = [];
+  for (const route of prerenderRoutes) {
+    const out = await writeRoute(templateHtml, route);
+    written.push(out);
+  }
+
+  console.log(`prerender-head: wrote ${written.length} files`);
+  for (const file of written) {
+    console.log(`  - ${file.replace(distDir + '\\', '').replace(distDir + '/', '')}`);
+  }
+}
+
+main().catch((error) => {
+  console.error('prerender-head failed:', error);
+  process.exit(1);
+});

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -694,6 +694,32 @@ html {
   background: rgba(255, 252, 246, 0.95);
   padding: 0.9rem 1rem;
   color: var(--site-ink);
+  font: inherit;
+}
+
+.contact-form input:focus-visible,
+.contact-form textarea:focus-visible {
+  outline: none;
+  border-color: var(--color-primary-600, #3f7d3a);
+  box-shadow: 0 0 0 3px rgba(63, 125, 58, 0.18);
+}
+
+.contact-form button[type="submit"]:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.contact-meta__link {
+  color: var(--site-leaf);
+  font-weight: 700;
+}
+
+.contact-card__list {
+  margin-top: 0.25rem;
+}
+.contact-card__list a {
+  color: var(--site-leaf);
+  font-weight: 600;
 }
 
 @media (max-width: 759px) {

--- a/apps/web/src/site/pages/DonatePage.tsx
+++ b/apps/web/src/site/pages/DonatePage.tsx
@@ -364,7 +364,7 @@ export function DonatePage({
       <PageHero
         eyebrow="Donate"
         title="Plant something permanent in Olivia's Garden."
-        body="Every gift becomes something visible in the memorial garden itself. Each donor's name is placed on a permanent acrylic marker."
+        body="Every gift lives somewhere you can point to. Each donor gets a named acrylic marker placed in the memorial garden — a small, visible reminder that you are part of the year this garden is holding."
         className="donate-hero"
         titleClassName="donate-hero__title"
         backgroundImage={buildResponsiveBackgroundImage('/images/home/sunset-garden.jpg')}

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -1,8 +1,11 @@
 import { Card } from '@olivias/ui';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useState, type FormEvent } from 'react';
 import type { AuthSession } from '../../auth/session';
 import { CtaButton, PageHero, Section, WorkIcon } from '../chrome';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
+import { facebookUrl, instagramUrl } from '../routes';
+
+const CONTACT_EMAIL = 'allen@oliviasgarden.org';
 
 const OkraExperience = lazy(async () => {
   const module = await import('../../okra/OkraExperience');
@@ -355,13 +358,18 @@ export function GetInvolvedPage({ onNavigate }: { onNavigate: (path: string) => 
           }}>Sign up to volunteer</CtaButton>
         </Card>
 
-        <Card title="Hands-on workshops -- coming soon." className="get-involved-card">
+        <Card title="Hands-on workshops — coming soon." className="get-involved-card">
           <p className="get-involved-card__eyebrow">Coming soon</p>
           <p>
             Workshops are planned, but they are not active yet. When they launch, they will be
             built around real tasks and hands-on learning, not classroom-style theory.
           </p>
-          <CtaButton variant="secondary">Notify me when workshops open</CtaButton>
+          <CtaButton
+            variant="secondary"
+            href={`mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent('Notify me when workshops open')}`}
+          >
+            Notify me when workshops open
+          </CtaButton>
         </Card>
 
         <Card title="Help us map where food is growing." className="get-involved-card">
@@ -382,7 +390,23 @@ export function GetInvolvedPage({ onNavigate }: { onNavigate: (path: string) => 
         title="Follow along."
         body="We post what is actually happening in the work: harvests, setbacks, animals, systems, and the day-to-day reality of learning by doing."
       >
-        <CtaButton variant="secondary">Follow us on Instagram</CtaButton>
+        <CtaButton variant="secondary" href={instagramUrl}>Follow us on Instagram</CtaButton>
+      </Section>
+
+      <Section
+        title="Something else in mind?"
+        body="Press, partnerships, speaking requests, or something we haven't thought of yet — send a note and we'll figure it out together."
+      >
+        <CtaButton
+          variant="secondary"
+          href="/contact"
+          onClick={(event) => {
+            event?.preventDefault?.();
+            onNavigate('/contact');
+          }}
+        >
+          Get in touch
+        </CtaButton>
       </Section>
     </>
   );
@@ -508,41 +532,124 @@ export function ImpactPage({ onNavigate }: { onNavigate: (path: string) => void;
 }
 
 export function ContactPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [referral, setReferral] = useState('');
+
+  const canSend = message.trim().length > 0;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSend) {
+      return;
+    }
+
+    const subject = name.trim()
+      ? `Message from ${name.trim()} via oliviasgarden.org`
+      : 'Message from oliviasgarden.org';
+
+    const bodyLines = [
+      message.trim(),
+      '',
+      '—',
+      name.trim() ? `From: ${name.trim()}` : null,
+      email.trim() ? `Reply to: ${email.trim()}` : null,
+      referral.trim() ? `Heard about us via: ${referral.trim()}` : null,
+    ].filter(Boolean);
+
+    const href = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(bodyLines.join('\n'))}`;
+    window.location.href = href;
+  };
+
   return (
     <>
-      <PageHero title="Get in touch" body="We'd love to hear from you." />
+      <PageHero
+        eyebrow="Contact"
+        title="Get in touch"
+        body="We're a real family running a real garden. Seeds, volunteering, partnerships, or just a note — we actually read everything that comes in."
+      />
 
       <div className="contact-grid">
-        <Card title="Reach out directly" className="contact-card">
-          <p className="contact-card__eyebrow">Direct contact</p>
+        <Card title="Reach us directly" className="contact-card">
+          <p className="contact-card__eyebrow">Quickest way</p>
           <p>
-            Whether you want seeds, have questions about the Okra Project, want to help with the
-            work, or just want to say what you&apos;re growing, reach out.
+            Email is the fastest path to us. If you're sharing photos of your garden or a long
+            story, it's also the easiest format for us to reply to carefully.
           </p>
-          <p className="page-text">We&apos;re real people and we actually respond.</p>
-          <p className="contact-meta">Email: allen@oliviasgarden.org</p>
+          <p className="contact-meta">
+            Email:{' '}
+            <a className="contact-meta__link" href={`mailto:${CONTACT_EMAIL}`}>
+              {CONTACT_EMAIL}
+            </a>
+          </p>
+          <ul className="site-list contact-card__list">
+            <li>
+              <a href={instagramUrl} target="_blank" rel="noreferrer">Instagram</a> — day-to-day work, harvests, animals
+            </li>
+            <li>
+              <a href={facebookUrl} target="_blank" rel="noreferrer">Facebook</a> — events and community posts
+            </li>
+          </ul>
+          <p className="page-text">
+            We try to respond within a few days. If it has been longer than that, a second note
+            is welcome — things occasionally slip during busy weeks on the land.
+          </p>
         </Card>
 
         <Card title="Send a message" className="contact-card">
-          <p className="contact-card__eyebrow">Send a note</p>
-          <form className="contact-form">
+          <p className="contact-card__eyebrow">Prefer a form</p>
+          <p className="page-text">
+            This opens your email app with your message pre-filled so you can send it from your
+            own inbox — easier for us to reply to you directly.
+          </p>
+          <form className="contact-form" onSubmit={handleSubmit} noValidate>
             <label>
               <span>Name</span>
-              <input type="text" placeholder="Your name" />
+              <input
+                type="text"
+                placeholder="Your name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                autoComplete="name"
+              />
             </label>
             <label>
               <span>Email</span>
-              <input type="email" placeholder="Your email" />
+              <input
+                type="email"
+                placeholder="Your email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+              />
             </label>
             <label>
               <span>Message</span>
-              <textarea rows={6} placeholder="How can we help?" />
+              <textarea
+                rows={6}
+                placeholder="How can we help?"
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                required
+              />
             </label>
             <label>
               <span>How did you hear about us? (optional)</span>
-              <input type="text" placeholder="Instagram, friend, work day, etc." />
+              <input
+                type="text"
+                placeholder="Instagram, friend, work day, etc."
+                value={referral}
+                onChange={(event) => setReferral(event.target.value)}
+              />
             </label>
-            <CtaButton>Send message</CtaButton>
+            <button
+              type="submit"
+              className="site-cta og-button og-button--primary og-button--md"
+              disabled={!canSend}
+            >
+              Open email to send
+            </button>
           </form>
         </Card>
       </div>

--- a/infra/foundation-web/template.yaml
+++ b/infra/foundation-web/template.yaml
@@ -275,6 +275,39 @@ Resources:
         SigningBehavior: always
         SigningProtocol: sigv4
 
+  # Rewrites /<path> to /<path>/index.html so per-route prerendered HTML
+  # snapshots (see apps/web/scripts/prerender-head.mjs) are served to
+  # crawlers and unfurl bots. Requests that already reference a static
+  # asset (anything with a dot in the final segment) pass through
+  # unchanged so /assets/*, /images/*, robots.txt, sitemap.xml etc. still
+  # resolve. When the rewritten path has no snapshot in S3 the existing
+  # 403/404 → /index.html fallback still delivers the SPA shell.
+  WebFrontendRewriteFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub '${AWS::StackName}-web-rewrite'
+      AutoPublish: true
+      FunctionConfig:
+        Comment: Rewrites clean URLs to their /index.html snapshot
+        Runtime: cloudfront-js-2.0
+      FunctionCode: |
+        function handler(event) {
+          var request = event.request;
+          var uri = request.uri;
+
+          if (uri.endsWith('/')) {
+            request.uri = uri + 'index.html';
+            return request;
+          }
+
+          var lastSegment = uri.slice(uri.lastIndexOf('/') + 1);
+          if (lastSegment.indexOf('.') === -1) {
+            request.uri = uri + '/index.html';
+          }
+
+          return request;
+        }
+
   SharedAssetsOriginAccessControl:
     Type: AWS::CloudFront::OriginAccessControl
     Properties:
@@ -320,6 +353,9 @@ Resources:
           Compress: true
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
           ResponseHeadersPolicyId: '67f7725c-6f97-4210-82d7-5512b31e9d03'
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt WebFrontendRewriteFunction.FunctionMetadata.FunctionARN
         CustomErrorResponses:
           - ErrorCode: 403
             ResponseCode: 200


### PR DESCRIPTION
Two somewhat-independent chunks landed on the same branch:

## 1. Per-route head-tag prerender + CloudFront clean-URL rewrite

Give unfurl scrapers (Facebook, Twitter, Slack, LinkedIn, Discord) and JS-less crawlers correct per-route `<title>`, `<meta name=description>`, OG, canonical, and JSON-LD tags without standing up full SSR.

- `apps/web/scripts/prerender-head.mjs` runs after `vite build`, clones `dist/index.html` into `dist/<path>/index.html` for every route flagged `prerender: true`, and rewrites the `<head>`. Six routes today: `/`, `/about`, `/get-involved`, `/seeds`, `/impact`, `/contact`.
- Body isn't server-rendered — modern text crawlers run JS.
- New CloudFront Function on the web distribution rewrites `/<path>` → `/<path>/index.html`. Paths with a dot in the last segment (`/assets/*`, `/images/*`, `robots.txt`, `sitemap.xml`) pass through. Unknown paths fall through to the existing 403/404 → `/index.html` rule and the SPA handles the 404 route.
- Infra + build changes are deploy-order independent: if the function activates before S3 has snapshots, the rewrite hits 404 and the existing fallback serves the SPA shell. No breakage window.

Route metadata is duplicated in `prerender-head.mjs` with a comment pointing at `src/site/routes.ts`. With 6 stable routes, cheaper than wiring `tsx`/`esbuild` into the build.

## 2. Contact / Get Involved / Donate polish

- **Contact**: replace placeholder form with a working `mailto:` flow. Fields are collected in React state; submit builds a `mailto:` URL with a descriptive subject and a body carrying the message plus name/email/referral footer, then opens the user's email client. Submit disabled until a message is typed. Left card now surfaces the email as a real link and adds Instagram + Facebook direct-reach links. Warmer hero copy.
- **Get Involved**: `--` → em dash in workshops card title. "Notify me when workshops open" CTA → prefilled `mailto:`. "Follow us on Instagram" CTA → real Instagram URL. New "Something else in mind?" closing section routes to `/contact`.
- **Donate**: warm up the hero body copy only. Structure and checkout flow untouched.

## Test plan
- [ ] `cd apps/web && npm run build` produces `dist/<route>/index.html` for every prerender route with per-route head tags
- [ ] Staging deploy: `curl -s https://<staging>/about | grep -E '<title>|og:title'` shows About page tags (not home)
- [ ] Facebook Sharing Debugger / Twitter Card Validator on staging `/about` shows correct preview
- [ ] Static assets (`/assets/*.js`, `/images/*.jpg`, `/sitemap.xml`) still serve 200
- [ ] Unknown path (`/xyz`) still loads SPA and renders HomePage catch-all
- [ ] `/contact`: typing a message then "Open email to send" opens mail client with subject + body prefilled
- [ ] `/contact`: submit disabled until message is non-empty
- [ ] `/get-involved`: Instagram CTA at bottom opens real IG link; "Notify me when workshops open" opens mail client; "Something else in mind?" routes to /contact
- [ ] `/donate`: hero copy reads right; checkout flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)