### PR TITLE
Improve okra submission review notifications

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -606,6 +606,7 @@ jobs:
           OKRA_DATABASE_URL: ${{ env.ENVIRONMENT == 'prod' && secrets.DATABASE_URL_PROD || secrets.DATABASE_URL_STAGING }}
           OKRA_CI_ADMIN_USERNAME: ${{ steps.okra-ci-auth.outputs.username }}
           OKRA_CI_ADMIN_PASSWORD: ${{ steps.okra-ci-auth.outputs.password }}
+          SIGNUP_SLACK_WEBHOOK_URL: ${{ env.ENVIRONMENT == 'prod' && secrets.FOUNDATION_SIGNUP_SLACK_WEBHOOK_URL_PROD || secrets.FOUNDATION_SIGNUP_SLACK_WEBHOOK_URL_STAGING }}
           FOUNDATION_DOMAIN_NAME: ${{ env.ENVIRONMENT == 'prod' && vars.FOUNDATION_WEB_DOMAIN_NAME_PROD || vars.FOUNDATION_WEB_DOMAIN_NAME_STAGING || '' }}
         run: |
           sam build
@@ -614,6 +615,9 @@ jobs:
             "CiAdminUsername=$OKRA_CI_ADMIN_USERNAME"
             "CiAdminPassword=$OKRA_CI_ADMIN_PASSWORD"
           )
+          if [ -n "$SIGNUP_SLACK_WEBHOOK_URL" ]; then
+            PARAM_OVERRIDES+=("SignupSlackWebhookUrl=$SIGNUP_SLACK_WEBHOOK_URL")
+          fi
           if [ -n "$FOUNDATION_DOMAIN_NAME" ]; then
             PARAM_OVERRIDES+=("DomainName=$FOUNDATION_DOMAIN_NAME")
           fi

--- a/.github/workflows/foundation-web-deploy-reusable.yml
+++ b/.github/workflows/foundation-web-deploy-reusable.yml
@@ -352,6 +352,7 @@ jobs:
           OKRA_DATABASE_URL: ${{ secrets.database_url }}
           OKRA_CI_ADMIN_USERNAME: ${{ steps.okra-ci-auth.outputs.username }}
           OKRA_CI_ADMIN_PASSWORD: ${{ steps.okra-ci-auth.outputs.password }}
+          SIGNUP_SLACK_WEBHOOK_URL: ${{ secrets.signup_slack_webhook_url }}
           FOUNDATION_DOMAIN_NAME: ${{ inputs.domain_name }}
         run: |
           sam build
@@ -360,6 +361,9 @@ jobs:
             "CiAdminUsername=$OKRA_CI_ADMIN_USERNAME"
             "CiAdminPassword=$OKRA_CI_ADMIN_PASSWORD"
           )
+          if [ -n "$SIGNUP_SLACK_WEBHOOK_URL" ]; then
+            PARAM_OVERRIDES+=("SignupSlackWebhookUrl=$SIGNUP_SLACK_WEBHOOK_URL")
+          fi
           if [ -n "$FOUNDATION_DOMAIN_NAME" ]; then
             PARAM_OVERRIDES+=("DomainName=$FOUNDATION_DOMAIN_NAME")
           fi

--- a/.github/workflows/pull-request-staging-validation-reusable.yml
+++ b/.github/workflows/pull-request-staging-validation-reusable.yml
@@ -220,6 +220,7 @@ jobs:
           OKRA_DATABASE_URL: ${{ secrets.database_url_staging }}
           OKRA_CI_ADMIN_USERNAME: ${{ steps.okra-ci-auth.outputs.username }}
           OKRA_CI_ADMIN_PASSWORD: ${{ steps.okra-ci-auth.outputs.password }}
+          SIGNUP_SLACK_WEBHOOK_URL: ${{ secrets.foundation_signup_slack_webhook_url_staging }}
           FOUNDATION_DOMAIN_NAME: ${{ vars.FOUNDATION_WEB_DOMAIN_NAME_STAGING || '' }}
         run: |
           sam build
@@ -228,6 +229,9 @@ jobs:
             "CiAdminUsername=$OKRA_CI_ADMIN_USERNAME"
             "CiAdminPassword=$OKRA_CI_ADMIN_PASSWORD"
           )
+          if [ -n "$SIGNUP_SLACK_WEBHOOK_URL" ]; then
+            PARAM_OVERRIDES+=("SignupSlackWebhookUrl=$SIGNUP_SLACK_WEBHOOK_URL")
+          fi
           if [ -n "$FOUNDATION_DOMAIN_NAME" ]; then
             PARAM_OVERRIDES+=("DomainName=$FOUNDATION_DOMAIN_NAME")
           fi

--- a/services/okra-api/src/handlers/api.mjs
+++ b/services/okra-api/src/handlers/api.mjs
@@ -14,9 +14,10 @@ import {
   insertPendingSubmissionWithPhotos,
   submissionSchema
 } from '../services/submissions.mjs';
+import { publishSubmissionCreatedEvent } from '../services/submission-notifications.mjs';
 import { errorResponse, corsHeaders } from '../services/pagination.mjs';
 import { fuzzCoordinates } from '../services/privacy-fuzzing.mjs';
-import { createHttpRouterHandler } from '../services/http-handler.mjs';
+import { createHttpRouterHandler, getCorrelationId } from '../services/http-handler.mjs';
 
 const app = new Router();
 
@@ -108,6 +109,29 @@ app.post('/submissions', async ({ req, event }) => {
     );
 
     await enqueuePhotoProcessing(created.claimedPhotoIds);
+    await publishSubmissionCreatedEvent(
+      {
+        id: created.id,
+        status: created.status,
+        createdAt: created.created_at,
+        contributorName: payload.contributorName ?? authResult.contributor?.name ?? null,
+        contributorEmail: payload.contributorEmail ?? authResult.contributor?.email ?? null,
+        storyText: payload.storyText ?? null,
+        rawLocationText: payload.rawLocationText,
+        privacyMode: payload.privacyMode ?? 'city',
+        displayLat: payload.displayLat,
+        displayLng: payload.displayLng,
+        photoUrls: created.claimedPhotos.map((photo) => {
+          const cdnDomain = process.env.MEDIA_CDN_DOMAIN;
+          if (!cdnDomain || !photo.original_s3_key) {
+            return null;
+          }
+
+          return `https://${cdnDomain}/${photo.original_s3_key}`;
+        }).filter(Boolean)
+      },
+      getCorrelationId(event)
+    );
 
     return {
       statusCode: 201,
@@ -150,7 +174,7 @@ app.get('/okra', async () => {
   if (!cdnDomain) {
     console.error(JSON.stringify({
       level: 'warn',
-      message: 'MEDIA_CDN_DOMAIN not set — photo URLs will be empty',
+      message: 'MEDIA_CDN_DOMAIN not set â€” photo URLs will be empty',
       endpoint: 'GET /okra'
     }));
   }

--- a/services/okra-api/src/handlers/submission-notifier.mjs
+++ b/services/okra-api/src/handlers/submission-notifier.mjs
@@ -1,0 +1,187 @@
+function truncate(text, limit) {
+  if (typeof text !== 'string') {
+    return null;
+  }
+
+  const normalized = text.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, limit - 3)}...`;
+}
+
+function formatCoordinate(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(5) : 'n/a';
+}
+
+function buildAdminReviewUrl(submissionId) {
+  const baseUrl = process.env.OKRA_ADMIN_FRONTEND_URL?.trim();
+  if (!baseUrl) {
+    return null;
+  }
+
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  return `${normalizedBase}/?submission=${encodeURIComponent(submissionId)}`;
+}
+
+function buildSlackPayload(detail) {
+  const contributorName = truncate(detail.contributorName, 120) ?? 'Anonymous contributor';
+  const contributorEmail = truncate(detail.contributorEmail, 160) ?? 'No email provided';
+  const storyText = truncate(detail.storyText, 1500) ?? 'No story provided.';
+  const rawLocationText = truncate(detail.rawLocationText, 300) ?? 'No location provided.';
+  const createdAt = detail.createdAt ? new Date(detail.createdAt).toISOString() : null;
+  const reviewUrl = buildAdminReviewUrl(detail.submissionId);
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: 'New okra submission awaiting review',
+        emoji: true
+      }
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*Contributor*\n${contributorName}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Email*\n${contributorEmail}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Submitted*\n${createdAt ?? 'Unknown'}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Privacy*\n${detail.privacyMode ?? 'city'}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Raw location*\n${rawLocationText}`
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Coordinates*\n${formatCoordinate(detail.displayLat)}, ${formatCoordinate(detail.displayLng)}`
+        }
+      ]
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Story*\n${storyText}`
+      }
+    }
+  ];
+
+  if (Array.isArray(detail.photoUrls)) {
+    for (const [index, photoUrl] of detail.photoUrls.entries()) {
+      if (typeof photoUrl !== 'string' || !photoUrl.trim()) {
+        continue;
+      }
+
+      blocks.push({
+        type: 'image',
+        image_url: photoUrl,
+        alt_text: `Okra submission photo ${index + 1}`
+      });
+    }
+  }
+
+  const photoCount = Array.isArray(detail.photoUrls) ? detail.photoUrls.length : 0;
+  blocks.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: `Submission ID: \`${detail.submissionId}\` - Photos included: ${photoCount}`
+      }
+    ]
+  });
+
+  if (reviewUrl) {
+    blocks.push({
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: 'Open review queue',
+            emoji: true
+          },
+          url: reviewUrl,
+          style: 'primary'
+        }
+      ]
+    });
+  }
+
+  return {
+    text: `New okra submission from ${contributorName}`,
+    blocks
+  };
+}
+
+export async function handler(event) {
+  const webhookUrl = process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL?.trim();
+  const detail = event?.detail ?? {};
+  const correlationId = detail.correlationId ?? event?.id ?? 'unknown';
+
+  if (!webhookUrl) {
+    console.info(JSON.stringify({
+      level: 'info',
+      message: 'Okra submission Slack webhook is not configured; skipping notification',
+      correlationId,
+      submissionId: detail.submissionId ?? null
+    }));
+    return;
+  }
+
+  const payload = buildSlackPayload(detail);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      console.error(JSON.stringify({
+        level: 'error',
+        message: 'Okra submission Slack webhook returned non-success',
+        correlationId,
+        submissionId: detail.submissionId ?? null,
+        status: response.status
+      }));
+      return;
+    }
+
+    console.info(JSON.stringify({
+      level: 'info',
+      message: 'Delivered okra submission Slack notification',
+      correlationId,
+      submissionId: detail.submissionId ?? null
+    }));
+  } catch (error) {
+    console.error(JSON.stringify({
+      level: 'error',
+      message: 'Okra submission Slack webhook request failed',
+      correlationId,
+      submissionId: detail.submissionId ?? null,
+      error: error instanceof Error ? error.message : String(error)
+    }));
+  }
+}

--- a/services/okra-api/src/handlers/submission-notifier.mjs
+++ b/services/okra-api/src/handlers/submission-notifier.mjs
@@ -133,7 +133,7 @@ function buildSlackPayload(detail) {
 }
 
 export async function handler(event) {
-  const webhookUrl = process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL?.trim();
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL?.trim();
   const detail = event?.detail ?? {};
   const correlationId = detail.correlationId ?? event?.id ?? 'unknown';
 

--- a/services/okra-api/src/services/submission-notifications.mjs
+++ b/services/okra-api/src/services/submission-notifications.mjs
@@ -1,0 +1,42 @@
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+
+const eventBridge = new EventBridgeClient({});
+
+function notificationDetail(submission, correlationId) {
+  return {
+    submissionId: submission.id,
+    status: submission.status,
+    createdAt: submission.createdAt,
+    contributorName: submission.contributorName ?? null,
+    contributorEmail: submission.contributorEmail ?? null,
+    storyText: submission.storyText ?? null,
+    rawLocationText: submission.rawLocationText,
+    privacyMode: submission.privacyMode,
+    displayLat: submission.displayLat,
+    displayLng: submission.displayLng,
+    photoUrls: Array.isArray(submission.photoUrls) ? submission.photoUrls.slice(0, 3) : [],
+    correlationId
+  };
+}
+
+export async function publishSubmissionCreatedEvent(submission, correlationId) {
+  try {
+    await eventBridge.send(new PutEventsCommand({
+      Entries: [
+        {
+          Source: 'okra.submissions',
+          DetailType: 'submission.created',
+          Detail: JSON.stringify(notificationDetail(submission, correlationId))
+        }
+      ]
+    }));
+  } catch (error) {
+    console.error(JSON.stringify({
+      level: 'warn',
+      message: 'Failed to publish okra submission notification event',
+      submissionId: submission?.id ?? null,
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    }));
+  }
+}

--- a/services/okra-api/src/services/submissions.mjs
+++ b/services/okra-api/src/services/submissions.mjs
@@ -90,6 +90,7 @@ export async function insertPendingSubmissionWithPhotos(client, payload) {
         where id = any($2::uuid[])
           and submission_id is null
           and (expires_at is null or expires_at > now())
+        returning id, original_s3_key
       `,
       [created.id, payload.photoIds]
     );
@@ -103,7 +104,8 @@ export async function insertPendingSubmissionWithPhotos(client, payload) {
     await client.query('commit');
     return {
       ...created,
-      claimedPhotoIds: payload.photoIds
+      claimedPhotoIds: payload.photoIds,
+      claimedPhotos: claimResult.rows
     };
   } catch (error) {
     await client.query('rollback');

--- a/services/okra-api/template.yaml
+++ b/services/okra-api/template.yaml
@@ -6,6 +6,11 @@ Parameters:
   DatabaseUrl:
     Type: String
     Description: PostgreSQL connection string (e.g., from Neon)
+  OkraSubmissionSlackWebhookUrl:
+    Type: String
+    Default: ''
+    NoEcho: true
+    Description: Optional Slack webhook URL for rich okra submission review notifications.
   CiAdminUsername:
     Type: String
     Default: ''
@@ -64,7 +69,7 @@ Resources:
       StageName: api
       Cors:
         AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
-        AllowHeaders: "'Content-Type,Authorization,Idempotency-Key,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+        AllowHeaders: "'Content-Type,Authorization,Idempotency-Key,X-Correlation-Id,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
         AllowOrigin: "'*'"
 
   AdminApiGateway:
@@ -74,7 +79,7 @@ Resources:
       StageName: admin
       Cors:
         AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
-        AllowHeaders: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+        AllowHeaders: "'Content-Type,Authorization,X-Correlation-Id,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
         AllowOrigin: "'*'"
       Auth:
         DefaultAuthorizer: AdminTokenAuthorizer
@@ -119,6 +124,34 @@ Resources:
                 - okra.photos
               detail-type:
                 - photo.claimed
+
+  SubmissionNotifierFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        <<: *esbuild-properties
+        EntryPoints:
+          - ././src/handlers/submission-notifier.mjs
+    Properties:
+      CodeUri: ./
+      Handler: src/handlers/submission-notifier.handler
+      Environment:
+        Variables:
+          OKRA_SUBMISSION_SLACK_WEBHOOK_URL: !Ref OkraSubmissionSlackWebhookUrl
+          OKRA_ADMIN_FRONTEND_URL: !If
+            - DeploySharedApiBasePathMapping
+            - !Sub 'https://admin.${DomainName}'
+            - ''
+      Events:
+        SubmissionCreatedEvent:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source:
+                - okra.submissions
+              detail-type:
+                - submission.created
 
   ApiFunction:
     Type: AWS::Serverless::Function

--- a/services/okra-api/template.yaml
+++ b/services/okra-api/template.yaml
@@ -6,11 +6,11 @@ Parameters:
   DatabaseUrl:
     Type: String
     Description: PostgreSQL connection string (e.g., from Neon)
-  OkraSubmissionSlackWebhookUrl:
+  SignupSlackWebhookUrl:
     Type: String
     Default: ''
     NoEcho: true
-    Description: Optional Slack webhook URL for rich okra submission review notifications.
+    Description: Optional Slack webhook URL reused for rich okra submission review notifications.
   CiAdminUsername:
     Type: String
     Default: ''
@@ -138,7 +138,7 @@ Resources:
       Handler: src/handlers/submission-notifier.handler
       Environment:
         Variables:
-          OKRA_SUBMISSION_SLACK_WEBHOOK_URL: !Ref OkraSubmissionSlackWebhookUrl
+          SLACK_WEBHOOK_URL: !Ref SignupSlackWebhookUrl
           OKRA_ADMIN_FRONTEND_URL: !If
             - DeploySharedApiBasePathMapping
             - !Sub 'https://admin.${DomainName}'

--- a/services/okra-api/test/api/api-submissions.test.ts
+++ b/services/okra-api/test/api/api-submissions.test.ts
@@ -8,10 +8,12 @@ const mockClient = {
 
 const {
   mockEnqueuePhotoProcessing,
-  mockResolveOptionalContributor
+  mockResolveOptionalContributor,
+  mockPublishSubmissionCreatedEvent
 } = vi.hoisted(() => ({
   mockEnqueuePhotoProcessing: vi.fn(),
-  mockResolveOptionalContributor: vi.fn()
+  mockResolveOptionalContributor: vi.fn(),
+  mockPublishSubmissionCreatedEvent: vi.fn()
 }));
 
 vi.mock('../../scripts/db-client.mjs', () => ({
@@ -20,6 +22,10 @@ vi.mock('../../scripts/db-client.mjs', () => ({
 
 vi.mock('../../src/services/photo-processing-queue.mjs', () => ({
   enqueuePhotoProcessing: mockEnqueuePhotoProcessing
+}));
+
+vi.mock('../../src/services/submission-notifications.mjs', () => ({
+  publishSubmissionCreatedEvent: mockPublishSubmissionCreatedEvent
 }));
 
 vi.mock('../../src/services/auth.mjs', async () => {
@@ -75,7 +81,13 @@ function mockSubmissionInsertSuccess() {
     }
 
     if (text.includes('update submission_photos')) {
-      return Promise.resolve({ rows: [], rowCount: 1 });
+      return Promise.resolve({
+        rows: [{
+          id: '550e8400-e29b-41d4-a716-446655440001',
+          original_s3_key: 'temp-photos/550e8400-e29b-41d4-a716-446655440001/original'
+        }],
+        rowCount: 1
+      });
     }
 
     return Promise.resolve({ rows: [], rowCount: 0 });
@@ -84,6 +96,7 @@ function mockSubmissionInsertSuccess() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.MEDIA_CDN_DOMAIN = 'assets.oliviasgarden.test';
   mockResolveOptionalContributor.mockResolvedValue({ ok: true, contributor: null });
   mockSubmissionInsertSuccess();
 });
@@ -123,6 +136,16 @@ describe('submit endpoint optional auth enrichment', () => {
     expect(insertCall[1][1]).toBeNull();
     expect(insertCall[1][2]).toBeNull();
     expect(mockEnqueuePhotoProcessing).toHaveBeenCalledWith(['550e8400-e29b-41d4-a716-446655440001']);
+    expect(mockPublishSubmissionCreatedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sub-123',
+        status: 'pending_review',
+        contributorName: 'Guest',
+        rawLocationText: 'Austin, TX',
+        photoUrls: ['https://assets.oliviasgarden.test/temp-photos/550e8400-e29b-41d4-a716-446655440001/original']
+      }),
+      'req-submit'
+    );
   });
 
   it('enriches submissions from an authenticated contributor when form fields are omitted', async () => {

--- a/services/okra-api/test/api/submission-notifier.test.ts
+++ b/services/okra-api/test/api/submission-notifier.test.ts
@@ -4,7 +4,7 @@ import { handler } from '../../src/handlers/submission-notifier.mjs';
 describe('submission notifier', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/services/okra';
+    process.env.SLACK_WEBHOOK_URL = 'https://hooks.slack.test/services/okra';
     process.env.OKRA_ADMIN_FRONTEND_URL = 'https://admin.oliviasgarden.test';
   });
 
@@ -61,7 +61,7 @@ describe('submission notifier', () => {
   });
 
   it('returns without calling Slack when the webhook is not configured', async () => {
-    delete process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL;
+    delete process.env.SLACK_WEBHOOK_URL;
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 

--- a/services/okra-api/test/api/submission-notifier.test.ts
+++ b/services/okra-api/test/api/submission-notifier.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handler } from '../../src/handlers/submission-notifier.mjs';
+
+describe('submission notifier', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL = 'https://hooks.slack.test/services/okra';
+    process.env.OKRA_ADMIN_FRONTEND_URL = 'https://admin.oliviasgarden.test';
+  });
+
+  it('posts a rich Slack payload with image previews and review link', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handler({
+      id: 'evt-123',
+      detail: {
+        submissionId: 'sub-123',
+        contributorName: 'Okra Grower',
+        contributorEmail: 'okra@example.com',
+        storyText: 'A beautiful patch in the backyard.',
+        rawLocationText: 'Austin, TX',
+        privacyMode: 'city',
+        displayLat: 30.2672,
+        displayLng: -97.7431,
+        createdAt: '2026-04-21T12:00:00.000Z',
+        photoUrls: [
+          'https://assets.oliviasgarden.test/temp-photos/photo-1/original',
+          'https://assets.oliviasgarden.test/temp-photos/photo-2/original'
+        ],
+        correlationId: 'corr-123'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://hooks.slack.test/services/okra',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'content-type': 'application/json' }
+      })
+    );
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.text).toContain('Okra Grower');
+    expect(payload.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'header' }),
+        expect.objectContaining({ type: 'image', image_url: 'https://assets.oliviasgarden.test/temp-photos/photo-1/original' }),
+        expect.objectContaining({
+          type: 'actions',
+          elements: [
+            expect.objectContaining({
+              text: expect.objectContaining({ text: 'Open review queue' }),
+              url: 'https://admin.oliviasgarden.test/?submission=sub-123'
+            })
+          ]
+        })
+      ])
+    );
+  });
+
+  it('returns without calling Slack when the webhook is not configured', async () => {
+    delete process.env.OKRA_SUBMISSION_SLACK_WEBHOOK_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handler({
+      id: 'evt-123',
+      detail: {
+        submissionId: 'sub-123',
+        rawLocationText: 'Austin, TX'
+      }
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- allow `X-Correlation-Id` in okra API and admin API CORS preflight config so photo upload and submission requests can complete from the browser
- publish an `okra.submissions` event when a submission is created and handle it in a dedicated notifier Lambda
- send a richer Slack Block Kit message with contributor details, story, coordinates, image previews, and a deep link into the admin review queue
- add focused tests for submission event publishing and Slack payload generation

## Verification
- `npm run lint` in `services/okra-api`
- `npm test` in `services/okra-api`

## Notes
- True in-Slack approve/reject actions are not implemented here. This change uses an incoming webhook plus an admin deep link. Interactive buttons would require a Slack app with interactivity, request signing verification, and an action endpoint.
- Repo-wide frontend/backend/unit/format gates outside `services/okra-api` were not run from this pass.