### PR TITLE
Mobile optimization pass across web app

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#3F7D3A" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#2c5a2b" media="(prefers-color-scheme: dark)" />
+    <meta name="color-scheme" content="light" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Olivia's Garden" />
     <title>Olivia's Garden Foundation | Grow Food, Learn Skills, Build Community</title>
     <meta
       name="description"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -30,6 +30,7 @@ html {
 
 #root {
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* ── Login page backdrop (web-app-specific background image) ───────── */

--- a/apps/web/src/okra/OkraExperience.css
+++ b/apps/web/src/okra/OkraExperience.css
@@ -390,8 +390,8 @@
 
 .ok-map-container {
   position: relative;
-  height: clamp(28rem, 58vh, 36rem);
-  min-height: 28rem;
+  height: clamp(24rem, 60dvh, 36rem);
+  min-height: 24rem;
   overflow: hidden;
   border-radius: 1.5rem;
   background: var(--color-background);
@@ -581,7 +581,7 @@
   }
 
   .ok-map-container {
-    height: clamp(32rem, 62vh, 42rem);
+    height: clamp(32rem, 62dvh, 42rem);
   }
   .ok-recent__header {
     grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/web/src/okra/components/BottomSheet.css
+++ b/apps/web/src/okra/components/BottomSheet.css
@@ -16,6 +16,8 @@
   border-radius: var(--radius-lg, 1rem) var(--radius-lg, 1rem) 0 0;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.18);
   max-height: 60vh;
+  max-height: 60dvh;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   display: flex;
   flex-direction: column;
   transform: translateY(100%);
@@ -36,15 +38,22 @@
 .bottom-sheet-handle {
   display: flex;
   justify-content: center;
-  padding: 10px 0 6px;
+  align-items: center;
+  min-height: 28px;
+  padding: 12px 0 8px;
   cursor: grab;
   flex-shrink: 0;
+  touch-action: none;
+}
+
+.bottom-sheet-handle:active {
+  cursor: grabbing;
 }
 
 .bottom-sheet-handle-bar {
-  width: 36px;
-  height: 4px;
-  border-radius: 2px;
+  width: 44px;
+  height: 5px;
+  border-radius: 999px;
   background: var(--color-neutral-300, #d6d3d1);
 }
 
@@ -87,23 +96,26 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   color: #fff;
   border: none;
   border-radius: 50%;
-  width: 36px;
-  height: 36px;
-  font-size: 1.1rem;
+  width: 44px;
+  height: 44px;
+  font-size: 1.15rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 5;
+  touch-action: manipulation;
   transition: background 0.2s ease-out;
 }
 
-.bottom-sheet-gallery-btn:hover {
-  background: rgba(0, 0, 0, 0.6);
+.bottom-sheet-gallery-btn:hover,
+.bottom-sheet-gallery-btn:focus-visible {
+  background: rgba(0, 0, 0, 0.7);
+  outline: none;
 }
 
 .bottom-sheet-gallery-btn--prev {
@@ -125,17 +137,29 @@
 }
 
 .bottom-sheet-dot {
-  width: 8px;
-  height: 8px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.5);
+  background: transparent;
   border: none;
   padding: 0;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+}
+
+.bottom-sheet-dot::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
   transition: background 0.2s ease-out;
 }
 
-.bottom-sheet-dot--active {
+.bottom-sheet-dot--active::before {
   background: #fff;
 }
 
@@ -183,20 +207,22 @@
 }
 
 .bottom-sheet-story--expanded {
-  max-height: calc(60vh - 200px);
+  max-height: calc(60dvh - 200px);
   overflow-y: auto;
 }
 
 .bottom-sheet-read-more {
   background: none;
   border: none;
-  padding: 0;
+  padding: 0.4rem 0;
   margin-top: 0.25rem;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
   color: var(--color-accent-500, #d8a741);
   cursor: pointer;
   font-weight: 600;
   font-family: inherit;
+  align-self: flex-start;
+  touch-action: manipulation;
 }
 
 .bottom-sheet-read-more:hover {

--- a/apps/web/src/okra/components/ContributorFields.css
+++ b/apps/web/src/okra/components/ContributorFields.css
@@ -18,8 +18,8 @@
 .contributor-fields__input,
 .contributor-fields__textarea {
   font-family: var(--font-family-sans);
-  font-size: 0.9rem;
-  padding: 0.4rem 0.5rem;
+  font-size: 1rem;
+  padding: 0.65rem 0.85rem;
   border: 1px solid var(--color-neutral-300);
   border-radius: var(--radius-base);
   background: #fff;
@@ -27,8 +27,17 @@
   box-sizing: border-box;
 }
 
-.contributor-fields__input:focus,
-.contributor-fields__textarea:focus {
+.contributor-fields__input {
+  min-height: 2.75rem;
+}
+
+.contributor-fields__textarea {
+  min-height: 7rem;
+  line-height: 1.5;
+}
+
+.contributor-fields__input:focus-visible,
+.contributor-fields__textarea:focus-visible {
   outline: 2px solid var(--color-primary-500);
   outline-offset: 1px;
 }

--- a/apps/web/src/okra/components/LocationInput.css
+++ b/apps/web/src/okra/components/LocationInput.css
@@ -22,15 +22,17 @@
 
 .location-input__text {
   flex: 1;
+  min-width: 0;
+  min-height: 2.75rem;
   font-family: var(--font-family-sans);
-  font-size: 0.9rem;
-  padding: 0.4rem 0.5rem;
+  font-size: 1rem;
+  padding: 0.65rem 0.85rem;
   border: 1px solid var(--color-neutral-300);
   border-radius: var(--radius-base);
   background: #fff;
 }
 
-.location-input__text:focus {
+.location-input__text:focus-visible {
   outline: 2px solid var(--color-primary-500);
   outline-offset: 1px;
 }
@@ -46,14 +48,16 @@
 
 .location-input__geocode-btn {
   font-family: var(--font-family-sans);
-  font-size: 0.85rem;
-  padding: 0.4rem 0.75rem;
+  font-size: 0.9rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.9rem;
   border: 1px solid var(--color-primary-500);
   border-radius: var(--radius-base);
   background: var(--color-primary-500);
   color: #fff;
   cursor: pointer;
   white-space: nowrap;
+  touch-action: manipulation;
 }
 
 .location-input__geocode-btn:hover:not(:disabled) {
@@ -81,7 +85,7 @@
 }
 
 .location-input__map {
-  height: 200px;
+  height: 240px;
   width: 100%;
 }
 
@@ -93,15 +97,18 @@
 
 .location-input__show-map-btn {
   font-family: var(--font-family-sans);
-  font-size: 0.8rem;
+  font-size: 0.875rem;
+  min-height: 2.25rem;
+  align-self: flex-start;
   color: var(--color-primary-600);
   background: none;
   border: none;
-  padding: 0.25rem 0;
+  padding: 0.4rem 0.1rem;
   cursor: pointer;
-  text-align: center;
+  text-align: left;
   text-decoration: underline;
   text-underline-offset: 2px;
+  touch-action: manipulation;
 }
 
 .location-input__show-map-btn:hover:not(:disabled) {

--- a/apps/web/src/okra/components/MapShell.css
+++ b/apps/web/src/okra/components/MapShell.css
@@ -27,10 +27,20 @@
   background: #fff !important;
   color: var(--color-neutral-800, #2e2e2e) !important;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08) !important;
-  width: 32px !important;
-  height: 32px !important;
-  line-height: 32px !important;
-  font-size: 16px !important;
+  width: 40px !important;
+  height: 40px !important;
+  line-height: 40px !important;
+  font-size: 20px !important;
+  touch-action: manipulation;
+}
+
+@media (pointer: coarse) {
+  .map-shell .leaflet-control-zoom a {
+    width: 44px !important;
+    height: 44px !important;
+    line-height: 44px !important;
+    font-size: 22px !important;
+  }
 }
 
 .map-shell .leaflet-control-zoom a:last-child {

--- a/apps/web/src/okra/components/MapView.css
+++ b/apps/web/src/okra/components/MapView.css
@@ -105,15 +105,17 @@
 }
 
 .map-view__retry-btn {
-  padding: 0.5rem 1.25rem;
+  min-height: 2.75rem;
+  padding: 0.6rem 1.25rem;
   font-family: var(--font-family-sans);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #fff;
   background: var(--color-primary-500);
   border: none;
   border-radius: var(--radius-base);
   cursor: pointer;
+  touch-action: manipulation;
   transition: background 0.2s ease-out;
 }
 
@@ -145,14 +147,19 @@
 
 .map-view__cta-link {
   pointer-events: auto;
-  padding: 0.5rem 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.6rem 1.25rem;
   font-family: var(--font-family-sans);
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   color: #fff;
   background: var(--color-primary-500);
   border-radius: var(--radius-base);
   text-decoration: none;
+  touch-action: manipulation;
   transition: background 0.2s ease-out;
 }
 

--- a/apps/web/src/okra/components/PhotoUploader.css
+++ b/apps/web/src/okra/components/PhotoUploader.css
@@ -91,8 +91,20 @@
 /* Grid with thumbnails + placeholders */
 .photo-uploader__grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .photo-uploader__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .photo-uploader__grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 }
 
 .photo-uploader__thumb {
@@ -138,9 +150,10 @@
 }
 
 .photo-uploader__placeholder-plus {
-  font-size: 1.25rem;
+  font-size: 2rem;
   color: var(--color-neutral-400);
   font-weight: 300;
+  line-height: 1;
 }
 
 .photo-uploader__counter {
@@ -155,26 +168,30 @@
 /* Remove button */
 .photo-uploader__remove-btn {
   position: absolute;
-  top: 3px;
-  right: 3px;
+  top: 2px;
+  right: 2px;
   z-index: 2;
-  width: 18px;
-  height: 18px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  border: none;
-  background: rgba(0, 0, 0, 0.5);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.6);
   color: #fff;
-  font-size: 0.6rem;
+  font-size: 0.95rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
+  touch-action: manipulation;
+  transition: background 0.15s ease-out;
 }
 
-.photo-uploader__remove-btn:hover {
-  background: rgba(0, 0, 0, 0.7);
+.photo-uploader__remove-btn:hover,
+.photo-uploader__remove-btn:focus-visible {
+  background: rgba(0, 0, 0, 0.8);
+  outline: none;
 }
 
 /* State overlays */

--- a/apps/web/src/okra/components/PinPopup.css
+++ b/apps/web/src/okra/components/PinPopup.css
@@ -27,25 +27,32 @@
 .pin-popup-close {
   position: absolute;
   top: 8px;
-  right: 10px;
+  right: 8px;
   z-index: 10;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.55);
   color: #fff;
   border: none;
   border-radius: 50%;
-  width: 28px;
-  height: 28px;
-  font-size: 1.1rem;
+  width: 44px;
+  height: 44px;
+  font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: manipulation;
   transition: background 0.2s ease-out;
 }
 
-.pin-popup-close:hover {
-  background: rgba(0, 0, 0, 0.6);
+.pin-popup-close:hover,
+.pin-popup-close:focus-visible {
+  background: rgba(0, 0, 0, 0.72);
+  outline: none;
+}
+
+.pin-popup-close:focus-visible {
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--color-primary-500, #3f7d3a);
 }
 
 /* Photo gallery */
@@ -79,27 +86,30 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   color: #fff;
   border: none;
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  font-size: 1rem;
+  width: 44px;
+  height: 44px;
+  font-size: 1.1rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 5;
+  touch-action: manipulation;
   transition: background 0.2s ease-out;
 }
 
-.pin-popup-gallery-btn:hover {
-  background: rgba(0, 0, 0, 0.6);
+.pin-popup-gallery-btn:hover,
+.pin-popup-gallery-btn:focus-visible {
+  background: rgba(0, 0, 0, 0.7);
+  outline: none;
 }
 
-.pin-popup-gallery-btn--prev { left: 6px; }
-.pin-popup-gallery-btn--next { right: 6px; }
+.pin-popup-gallery-btn--prev { left: 8px; }
+.pin-popup-gallery-btn--next { right: 8px; }
 
 .pin-popup-dots {
   position: absolute;
@@ -112,17 +122,29 @@
 }
 
 .pin-popup-dot {
-  width: 8px;
-  height: 8px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.5);
+  background: transparent;
   border: none;
   padding: 0;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: manipulation;
+}
+
+.pin-popup-dot::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.55);
   transition: background 0.2s ease-out;
 }
 
-.pin-popup-dot--active {
+.pin-popup-dot--active::before {
   background: #fff;
 }
 
@@ -157,8 +179,8 @@
 
 .pin-popup-story {
   margin: 0;
-  font-size: 0.85rem;
-  line-height: 1.5;
+  font-size: 0.9375rem;
+  line-height: 1.55;
   color: var(--color-neutral-700, #44403c);
 }
 
@@ -177,13 +199,15 @@
 .pin-popup-read-more {
   background: none;
   border: none;
-  padding: 0;
+  padding: 0.4rem 0;
   margin-top: 0.25rem;
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   color: var(--color-accent-500, #d8a741);
   cursor: pointer;
   font-weight: 600;
   font-family: inherit;
+  align-self: flex-start;
+  touch-action: manipulation;
 }
 
 .pin-popup-read-more:hover {

--- a/apps/web/src/okra/components/PrivacySelector.css
+++ b/apps/web/src/okra/components/PrivacySelector.css
@@ -16,10 +16,21 @@
 
 .privacy-selector__option {
   display: flex;
-  align-items: baseline;
-  gap: 0.4rem;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.5rem 0;
+  min-height: 2.75rem;
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  touch-action: manipulation;
+}
+
+.privacy-selector__option input[type="radio"] {
+  flex-shrink: 0;
+  width: 1.125rem;
+  height: 1.125rem;
+  margin-top: 0.15rem;
 }
 
 .privacy-selector:disabled .privacy-selector__option {
@@ -34,5 +45,5 @@
 
 .privacy-selector__desc {
   color: var(--color-neutral-700);
-  font-size: 0.8rem;
+  font-size: 0.8125rem;
 }

--- a/apps/web/src/okra/components/SeedRequestModal.css
+++ b/apps/web/src/okra/components/SeedRequestModal.css
@@ -27,8 +27,9 @@
 
 .seed-request__input {
   font-family: inherit;
-  font-size: 0.95rem;
-  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
   border: 1px solid rgba(76, 52, 38, 0.18);
   border-radius: 0.55rem;
   background: #fff;
@@ -36,7 +37,7 @@
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.seed-request__input:focus {
+.seed-request__input:focus-visible {
   outline: none;
   border-color: var(--color-primary-600);
   box-shadow: 0 0 0 3px rgba(76, 52, 38, 0.12);
@@ -49,7 +50,8 @@
 
 .seed-request__textarea {
   resize: vertical;
-  min-height: 4.5rem;
+  min-height: 6rem;
+  line-height: 1.5;
 }
 
 .seed-request__hint {
@@ -68,6 +70,7 @@
 
 .seed-request__toggle-btn {
   flex: 1 1 180px;
+  min-height: 2.75rem;
   padding: 0.7rem 1rem;
   border: 1px solid rgba(76, 52, 38, 0.18);
   border-radius: 999px;
@@ -75,7 +78,8 @@
   color: var(--color-neutral-800);
   cursor: pointer;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.9375rem;
+  touch-action: manipulation;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 

--- a/apps/web/src/okra/components/SubmissionModal.css
+++ b/apps/web/src/okra/components/SubmissionModal.css
@@ -25,36 +25,50 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  padding-top: calc(0.875rem + env(safe-area-inset-top, 0px));
   border-bottom: 1px solid var(--color-neutral-300);
   flex-shrink: 0;
 }
 
 .submission-modal__title {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   color: var(--color-primary-600);
 }
 
 .submission-modal__close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin: -0.25rem -0.5rem -0.25rem 0;
   background: none;
   border: none;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   cursor: pointer;
   color: var(--color-neutral-700);
-  padding: 0.25rem;
+  padding: 0;
   line-height: 1;
-  border-radius: var(--radius-base);
+  border-radius: 999px;
+  touch-action: manipulation;
+  transition: background-color 0.15s ease-out;
 }
 
-.submission-modal__close-btn:hover {
+.submission-modal__close-btn:hover,
+.submission-modal__close-btn:focus-visible {
   background: var(--color-neutral-100);
+  outline: none;
 }
 
 /* Scrollable body */
 .submission-modal__body {
   overflow-y: auto;
-  padding: 1rem 1.25rem 1.5rem;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 1rem 1.25rem calc(1.5rem + env(safe-area-inset-bottom, 0px));
   flex: 1;
 }
 
@@ -96,6 +110,7 @@
 }
 
 .submission-modal__auth-button {
+  min-height: 2.75rem;
   padding: 0.7rem 1rem;
   border: 1px solid rgba(76, 52, 38, 0.14);
   border-radius: 999px;
@@ -103,6 +118,7 @@
   color: var(--color-neutral-800);
   cursor: pointer;
   font-weight: 700;
+  touch-action: manipulation;
 }
 
 .submission-modal__auth-button--primary {
@@ -198,13 +214,15 @@
 
 .submission-modal__confirm-discard {
   font-family: var(--font-family-sans);
-  font-size: 0.85rem;
-  padding: 0.4rem 1rem;
+  font-size: 0.9375rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 1rem;
   border: 1px solid #dc2626;
   border-radius: var(--radius-base);
   background: #dc2626;
   color: #fff;
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .submission-modal__confirm-discard:hover {
@@ -214,13 +232,15 @@
 
 .submission-modal__confirm-cancel {
   font-family: var(--font-family-sans);
-  font-size: 0.85rem;
-  padding: 0.4rem 1rem;
+  font-size: 0.9375rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 1rem;
   border: 1px solid var(--color-neutral-300);
   border-radius: var(--radius-base);
   background: #fff;
   color: var(--color-neutral-800);
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 .submission-modal__confirm-cancel:hover {

--- a/packages/ui/src/components/SiteHeader.tsx
+++ b/packages/ui/src/components/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 
 export interface SiteHeaderNavItem {
   id: string;
@@ -30,10 +30,34 @@ export function SiteHeader({
   utility,
 }: SiteHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const actionsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setMenuOpen(false);
   }, [navItems.length]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMenuOpen(false);
+      }
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      const node = actionsRef.current;
+      if (node && !node.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [menuOpen]);
 
   const handleBrandClick = () => {
     setMenuOpen(false);
@@ -65,7 +89,7 @@ export function SiteHeader({
           </button>
         )}
 
-        <div className={`og-site-header__actions ${menuOpen ? 'is-open' : ''}`.trim()}>
+        <div ref={actionsRef} className={`og-site-header__actions ${menuOpen ? 'is-open' : ''}`.trim()}>
           <div className="og-site-header__controls">
             {utility ? <div className="og-site-header__utility">{utility}</div> : null}
             {navItems.length > 0 ? (

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -9,6 +9,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
+  padding-top: env(safe-area-inset-top, 0px);
   backdrop-filter: blur(22px);
   background: rgba(251, 245, 234, 0.82);
   border-bottom: 1px solid rgba(79, 56, 37, 0.08);
@@ -21,7 +22,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 1rem 0;
+  padding: 0.85rem 0;
 }
 
 .og-site-header__brand,
@@ -172,13 +173,18 @@ body {
   }
 
   .og-site-header__link {
+    display: inline-flex;
+    align-items: center;
     width: 100%;
+    min-height: 2.75rem;
+    padding: 0.75rem 0.95rem;
     justify-content: center;
   }
 
   .og-site-header__link.is-active {
     background: rgba(79, 56, 37, 0.08);
     color: var(--og-color-soil);
+    font-weight: 700;
   }
 
   .og-site-footer__inner {
@@ -257,6 +263,7 @@ body {
 
 .og-site-footer {
   margin-top: auto;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   border-top: 1px solid rgba(255, 250, 241, 0.14);
   background:
     linear-gradient(135deg, rgba(90, 116, 71, 0.96), rgba(63, 125, 58, 0.98)),
@@ -1112,10 +1119,27 @@ body {
   box-sizing: border-box;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+html {
+  overflow-x: clip;
+}
+
+body {
+  overflow-x: clip;
+}
+
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: transparent;
 }
 
 button,
@@ -1125,18 +1149,65 @@ select {
   font: inherit;
 }
 
+/* Keep form inputs at 16px minimum on small screens so iOS doesn't zoom on focus. */
+@media (max-width: 799px) {
+  input,
+  select,
+  textarea {
+    font-size: max(1rem, 16px);
+  }
+}
+
 button {
   border: 0;
+}
+
+button,
+[role="button"],
+a {
+  touch-action: manipulation;
 }
 
 a {
   color: inherit;
 }
 
+img,
+svg,
+video,
+canvas {
+  max-width: 100%;
+}
+
+img {
+  height: auto;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--og-color-moss, #3f7d3a);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ── App shell ─────────────────────────────────────────────────────── */
 
 .og-app-shell {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -1214,12 +1285,14 @@ a {
 .og-login-page {
   display: grid;
   min-height: calc(100vh - 5.5rem);
+  min-height: calc(100dvh - 5.5rem);
   width: 100%;
 }
 
 .og-login-page__backdrop {
   width: 100%;
   min-height: calc(100vh - 5.5rem);
+  min-height: calc(100dvh - 5.5rem);
   display: grid;
   place-items: center;
   overflow: hidden;


### PR DESCRIPTION
Baseline mobile UX improvements landing across the web package:

- index.html: viewport-fit=cover, theme-color, PWA standalone meta,
  telephone format-detection off
- Global CSS baseline (packages/ui/src/styles.css): tap-highlight reset,
  overflow-x: clip on html/body to absorb 100vw hero bands, dynamic
  viewport units (100dvh) for app shell and login page, 16px minimum
  input font-size on mobile to prevent iOS zoom, global
  prefers-reduced-motion rule, :focus-visible baseline, touch-action
  manipulation on interactive elements
- Header: sticky header respects env(safe-area-inset-top); mobile nav
  closes on Escape + outside click; mobile links get 44px tap targets
  and stronger active state
- Footer: respects env(safe-area-inset-bottom)
- Form inputs (LocationInput, ContributorFields): 16px font, 44px
  min-height, generous padding, focus-visible outlines
- Touch targets bumped to 44px: PinPopup close/gallery/dots,
  BottomSheet handle/gallery/dots, PhotoUploader remove button,
  SubmissionModal close, Leaflet zoom controls, privacy radios,
  map retry/CTA buttons
- PhotoUploader grid: 3 cols mobile, 4 tablet, 5 desktop (was always 5)
- SubmissionModal: safe-area padding on header/body, 44px close button,
  momentum scrolling + overscroll containment
- BottomSheet: safe-area-inset-bottom padding, dvh max-height
- Map container: clamp(24rem, 60dvh, 36rem) replaces vh clamp