### PR TITLE
Profile page polish + new shared form primitives in @olivias/ui

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -987,6 +987,46 @@ html {
     width: 100%;
   }
 
+  .profile-hero h1 {
+    font-size: clamp(1.6rem, 7vw, 2rem);
+  }
+
+  .profile-form {
+    gap: 1.1rem;
+  }
+
+  .profile-form-panel.og-panel--padding-md {
+    padding: 1.15rem;
+  }
+
+  .profile-form-panel {
+    border-radius: 1.15rem;
+  }
+
+  .profile-form__avatar-row {
+    gap: 0.85rem;
+    padding-bottom: 1rem;
+  }
+
+  .profile-form__avatar-preview {
+    width: 3.75rem;
+    height: 3.75rem;
+    font-size: 1.3rem;
+  }
+
+  .profile-form__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .profile-form__actions .site-cta {
+    width: 100%;
+  }
+
+  .profile-activity__item {
+    padding: 1rem 1.05rem;
+  }
+
   .og-login-page__backdrop {
     place-items: start center;
     padding: 1rem 0;
@@ -1755,10 +1795,7 @@ html {
 }
 
 .og-auth-menu .og-auth-utility__avatar {
-  border: none;
-  background: inherit;
   cursor: pointer;
-  font: inherit;
 }
 
 .og-auth-menu__popover {
@@ -1799,6 +1836,11 @@ html {
   min-height: auto;
 }
 
+.profile-hero h1 {
+  font-size: clamp(1.9rem, 3.2vw, 2.6rem);
+  line-height: 1.05;
+}
+
 .profile-empty {
   display: flex;
   justify-content: center;
@@ -1806,34 +1848,36 @@ html {
 
 .profile-form {
   display: grid;
-  gap: 1.25rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(76, 52, 38, 0.12);
+  gap: 1.5rem;
+}
+
+.profile-form-panel {
   border-radius: 1.4rem;
-  background: rgba(255, 250, 241, 0.94);
-  box-shadow: 0 16px 34px rgba(38, 23, 15, 0.07);
 }
 
 .profile-form__avatar-row {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 1rem;
+  gap: 1.1rem;
   align-items: center;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--site-border);
 }
 
 .profile-form__avatar-preview {
   width: 4.5rem;
   height: 4.5rem;
   border-radius: 50%;
-  border: 1px solid rgba(76, 52, 38, 0.18);
-  background: rgba(241, 204, 130, 0.28);
+  border: 1px solid var(--site-border);
+  background: linear-gradient(180deg, rgba(90, 116, 71, 0.18), rgba(210, 157, 47, 0.22));
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
+  font-family: var(--site-display);
   font-weight: 600;
-  color: var(--site-muted, #6c5540);
-  font-size: 1.4rem;
+  color: var(--site-branch);
+  font-size: 1.6rem;
 }
 
 .profile-form__avatar-preview img {
@@ -1849,64 +1893,22 @@ html {
 }
 
 .profile-form__hint {
-  color: var(--site-muted, #6c5540);
+  color: var(--site-muted);
   font-size: 0.85rem;
+  line-height: 1.5;
   margin: 0;
 }
 
 .profile-form__grid {
   display: grid;
-  gap: 0.85rem;
-}
-
-.profile-form__field {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.95rem;
-  color: var(--site-muted, #6c5540);
-}
-
-.profile-form__field > span {
-  font-weight: 600;
-  color: #3a2a1d;
-}
-
-.profile-form__field input,
-.profile-form__field textarea {
-  padding: 0.65rem 0.8rem;
-  border: 1px solid rgba(76, 52, 38, 0.2);
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.92);
-  font: inherit;
-  color: #3a2a1d;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.profile-form__field input:focus,
-.profile-form__field textarea:focus {
-  outline: 2px solid rgba(241, 204, 130, 0.8);
-  outline-offset: 1px;
-}
-
-.profile-form__field textarea {
-  resize: vertical;
-  min-height: 5rem;
+  gap: 1rem;
 }
 
 .profile-form__actions {
   display: flex;
   justify-content: flex-end;
-}
-
-.profile-error {
-  color: #a33;
-  margin: 0;
-}
-
-.profile-success {
-  color: #2f7a3b;
-  margin: 0;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--site-border);
 }
 
 .profile-activity {
@@ -1918,38 +1920,42 @@ html {
 }
 
 .profile-activity__item {
-  padding: 1.1rem 1.2rem;
-  border: 1px solid rgba(76, 52, 38, 0.12);
+  padding: 1.2rem 1.35rem;
+  border: 1px solid var(--site-border);
   border-radius: 1rem;
-  background: rgba(255, 250, 241, 0.94);
+  background: var(--site-paper);
+  box-shadow: var(--site-shadow);
   display: grid;
-  gap: 0.55rem;
+  gap: 0.6rem;
 }
 
 .profile-activity__meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.85rem;
-  color: var(--site-muted, #6c5540);
+  gap: 0.75rem;
+  font-size: 0.82rem;
+  color: var(--site-muted);
 }
 
 .profile-activity__badge {
   display: inline-block;
-  padding: 0.15rem 0.65rem;
+  padding: 0.2rem 0.7rem;
   border-radius: 999px;
-  background: rgba(241, 204, 130, 0.35);
-  color: #5a3e1a;
-  font-weight: 600;
-  font-size: 0.75rem;
-  letter-spacing: 0.02em;
+  background: rgba(210, 157, 47, 0.18);
+  color: var(--site-branch);
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .profile-activity__title {
   margin: 0;
+  font-family: var(--site-display);
   font-weight: 600;
-  color: #3a2a1d;
+  font-size: 1.05rem;
+  color: var(--site-ink);
 }
 
 .profile-activity__photos {
@@ -1966,7 +1972,7 @@ html {
   border: 1px solid rgba(76, 52, 38, 0.12);
 }
 
-@media (min-width: 720px) {
+@media (min-width: 760px) {
   .profile-form__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/apps/web/src/site/pages/ProfilePage.tsx
+++ b/apps/web/src/site/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
-import { Button } from '@olivias/ui';
+import { Button, FormFeedback, Input, Panel, Textarea } from '@olivias/ui';
 import type { AuthSession } from '../../auth/session';
 import { createOkraHeaders, okraApiUrl } from '../../okra/api';
 import { PageHero, Section } from '../chrome';
@@ -361,8 +361,17 @@ export function ProfilePage({
     return combined;
   }, [donations, submissions, seedRequests]);
 
-  const handleChange = useCallback(
-    (field: keyof EditableProfile) => (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleInputChange = useCallback(
+    (field: keyof EditableProfile) => (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setForm((prev) => ({ ...prev, [field]: value }));
+      setSaveSuccess(false);
+    },
+    [],
+  );
+
+  const handleTextareaChange = useCallback(
+    (field: keyof EditableProfile) => (event: ChangeEvent<HTMLTextAreaElement>) => {
       const { value } = event.target;
       setForm((prev) => ({ ...prev, [field]: value }));
       setSaveSuccess(false);
@@ -486,118 +495,123 @@ export function ProfilePage({
         ) : loadError ? (
           <p className="profile-error" role="alert">{loadError}</p>
         ) : (
-          <form className="profile-form" onSubmit={handleSubmit}>
-            <div className="profile-form__avatar-row">
-              <div className="profile-form__avatar-preview" aria-hidden="true">
-                {profile?.avatarUrl ? (
-                  <img src={profile.avatarUrl} alt="" />
-                ) : (
-                  <span>{(displayName[0] ?? '?').toUpperCase()}</span>
-                )}
+          <Panel tone="paper" className="profile-form-panel">
+            <form className="profile-form" onSubmit={handleSubmit}>
+              <div className="profile-form__avatar-row">
+                <div className="profile-form__avatar-preview" aria-hidden="true">
+                  {profile?.avatarUrl ? (
+                    <img src={profile.avatarUrl} alt="" />
+                  ) : (
+                    <span>{(displayName[0] ?? '?').toUpperCase()}</span>
+                  )}
+                </div>
+                <div className="profile-form__avatar-actions">
+                  <input
+                    ref={avatarInputRef}
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    onChange={handleAvatarFile}
+                    hidden
+                  />
+                  <Button
+                    className="site-cta"
+                    type="button"
+                    variant="secondary"
+                    onClick={() => avatarInputRef.current?.click()}
+                    disabled={avatarUploading || profile?.avatarStatus === 'processing'}
+                  >
+                    {avatarUploading
+                      ? 'Uploading…'
+                      : profile?.avatarStatus === 'processing'
+                        ? 'Processing…'
+                        : profile?.avatarUrl
+                          ? 'Replace avatar'
+                          : 'Upload avatar'}
+                  </Button>
+                  <p className="profile-form__hint">JPEG, PNG, or WebP — up to 8 MB. We&apos;ll resize and optimize it automatically.</p>
+                  {profile?.avatarStatus === 'failed' && profile.avatarProcessingError ? (
+                    <FormFeedback tone="error">Avatar failed: {profile.avatarProcessingError}</FormFeedback>
+                  ) : null}
+                  {avatarError ? <FormFeedback tone="error">{avatarError}</FormFeedback> : null}
+                </div>
               </div>
-              <div className="profile-form__avatar-actions">
-                <input
-                  ref={avatarInputRef}
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp"
-                  onChange={handleAvatarFile}
-                  hidden
-                />
-                <Button
-                  className="site-cta"
-                  type="button"
-                  variant="secondary"
-                  onClick={() => avatarInputRef.current?.click()}
-                  disabled={avatarUploading || profile?.avatarStatus === 'processing'}
-                >
-                  {avatarUploading
-                    ? 'Uploading…'
-                    : profile?.avatarStatus === 'processing'
-                      ? 'Processing…'
-                      : profile?.avatarUrl
-                        ? 'Replace avatar'
-                        : 'Upload avatar'}
-                </Button>
-                <p className="profile-form__hint">JPEG, PNG, or WebP — up to 8 MB. We&apos;ll resize and optimize it automatically.</p>
-                {profile?.avatarStatus === 'failed' && profile.avatarProcessingError ? (
-                  <p className="profile-error" role="alert">Avatar failed: {profile.avatarProcessingError}</p>
-                ) : null}
-                {avatarError ? <p className="profile-error" role="alert">{avatarError}</p> : null}
-              </div>
-            </div>
 
-            <div className="profile-form__grid">
-              <label className="profile-form__field">
-                <span>First name</span>
-                <input type="text" value={form.firstName} onChange={handleChange('firstName')} maxLength={120} />
-              </label>
-              <label className="profile-form__field">
-                <span>Last name</span>
-                <input type="text" value={form.lastName} onChange={handleChange('lastName')} maxLength={120} />
-              </label>
-              <label className="profile-form__field profile-form__field--wide">
-                <span>Display name</span>
-                <input
-                  type="text"
+              <div className="profile-form__grid">
+                <Input
+                  label="First name"
+                  value={form.firstName}
+                  onChange={handleInputChange('firstName')}
+                  maxLength={120}
+                />
+                <Input
+                  label="Last name"
+                  value={form.lastName}
+                  onChange={handleInputChange('lastName')}
+                  maxLength={120}
+                />
+                <Input
+                  className="profile-form__field--wide"
+                  label="Display name"
                   value={form.displayName}
-                  onChange={handleChange('displayName')}
+                  onChange={handleInputChange('displayName')}
                   maxLength={120}
                   placeholder="How your name appears on the site"
                 />
-              </label>
-              <label className="profile-form__field">
-                <span>City</span>
-                <input type="text" value={form.city} onChange={handleChange('city')} maxLength={120} />
-              </label>
-              <label className="profile-form__field">
-                <span>State / region</span>
-                <input type="text" value={form.region} onChange={handleChange('region')} maxLength={120} />
-              </label>
-              <label className="profile-form__field">
-                <span>Country</span>
-                <input type="text" value={form.country} onChange={handleChange('country')} maxLength={120} />
-              </label>
-              <label className="profile-form__field">
-                <span>Timezone</span>
-                <input
-                  type="text"
+                <Input
+                  label="City"
+                  value={form.city}
+                  onChange={handleInputChange('city')}
+                  maxLength={120}
+                />
+                <Input
+                  label="State / region"
+                  value={form.region}
+                  onChange={handleInputChange('region')}
+                  maxLength={120}
+                />
+                <Input
+                  label="Country"
+                  value={form.country}
+                  onChange={handleInputChange('country')}
+                  maxLength={120}
+                />
+                <Input
+                  label="Timezone"
                   value={form.timezone}
-                  onChange={handleChange('timezone')}
+                  onChange={handleInputChange('timezone')}
                   maxLength={120}
                   placeholder={detectBrowserTimezone() || 'e.g. America/Chicago'}
                 />
-              </label>
-              <label className="profile-form__field profile-form__field--wide">
-                <span>Website</span>
-                <input
+                <Input
+                  className="profile-form__field--wide"
                   type="url"
+                  label="Website"
                   value={form.websiteUrl}
-                  onChange={handleChange('websiteUrl')}
+                  onChange={handleInputChange('websiteUrl')}
                   maxLength={2000}
                   placeholder="https://…"
                 />
-              </label>
-              <label className="profile-form__field profile-form__field--wide">
-                <span>Bio</span>
-                <textarea
+                <Textarea
+                  className="profile-form__field--wide"
+                  label="Bio"
                   value={form.bio}
-                  onChange={handleChange('bio')}
+                  onChange={handleTextareaChange('bio')}
                   maxLength={2000}
                   rows={4}
                   placeholder="Tell other growers a little about yourself."
                 />
-              </label>
-            </div>
+              </div>
 
-            {saveError ? <p className="profile-error" role="alert">{saveError}</p> : null}
-            {saveSuccess ? <p className="profile-success">Profile saved.</p> : null}
+              {saveError ? <FormFeedback tone="error">{saveError}</FormFeedback> : null}
+              {saveSuccess ? <FormFeedback tone="success">Profile saved.</FormFeedback> : null}
 
-            <div className="profile-form__actions">
-              <Button className="site-cta" type="submit" disabled={isSaving}>
-                {isSaving ? 'Saving…' : 'Save profile'}
-              </Button>
-            </div>
-          </form>
+              <div className="profile-form__actions">
+                <Button className="site-cta" type="submit" disabled={isSaving}>
+                  {isSaving ? 'Saving…' : 'Save profile'}
+                </Button>
+              </div>
+            </form>
+          </Panel>
         )}
       </Section>
 

--- a/packages/ui/src/components/FormFeedback.tsx
+++ b/packages/ui/src/components/FormFeedback.tsx
@@ -1,0 +1,31 @@
+import type { HTMLAttributes, PropsWithChildren } from 'react';
+
+export type FormFeedbackTone = 'success' | 'error' | 'info';
+
+export interface FormFeedbackProps
+  extends Omit<HTMLAttributes<HTMLParagraphElement>, 'role'>,
+    PropsWithChildren {
+  tone: FormFeedbackTone;
+}
+
+/**
+ * Form-level feedback pill for success/error/info messages.
+ *
+ * For field-level errors, prefer the `error` prop on Input/Textarea/FormField.
+ */
+export function FormFeedback({
+  tone,
+  children,
+  className = '',
+  ...props
+}: FormFeedbackProps) {
+  return (
+    <p
+      className={`og-form-feedback og-form-feedback--${tone} ${className}`.trim()}
+      role={tone === 'error' ? 'alert' : 'status'}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,7 +1,7 @@
 import { type InputHTMLAttributes, useState } from 'react';
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
-  type?: 'text' | 'email' | 'password';
+  type?: 'text' | 'email' | 'password' | 'url' | 'tel' | 'number' | 'search';
   label?: string;
   error?: string;
 }

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,0 +1,58 @@
+import type { TextareaHTMLAttributes } from 'react';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  error?: string;
+}
+
+export function Textarea({
+  label,
+  placeholder,
+  value,
+  onChange,
+  error,
+  disabled = false,
+  required = false,
+  rows = 4,
+  className = '',
+  id,
+  ...props
+}: TextareaProps) {
+  const textareaId = id || (label ? `textarea-${label.toLowerCase().replace(/\s+/g, '-')}` : undefined);
+  const errorId = textareaId ? `${textareaId}-error` : undefined;
+
+  return (
+    <div className={`og-textarea ${error ? 'og-textarea--error' : ''} ${className}`.trim()}>
+      {label ? (
+        <label htmlFor={textareaId} className="og-textarea__label">
+          {label}
+          {required ? <span className="og-textarea__required" aria-label="required">*</span> : null}
+        </label>
+      ) : null}
+
+      <textarea
+        id={textareaId}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        required={required}
+        rows={rows}
+        className="og-textarea__field"
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        aria-required={required}
+        {...props}
+      />
+
+      {error ? (
+        <p id={errorId} className="og-textarea__error" role="alert">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="og-textarea__error-icon" aria-hidden="true">
+            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+          </svg>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { AvatarBadge } from './components/AvatarBadge.tsx';
 export { Button } from './components/Button.tsx';
 export { Card } from './components/Card.tsx';
+export { FormFeedback } from './components/FormFeedback.tsx';
 export { FormField } from './components/FormField.tsx';
 export { Input } from './components/Input.tsx';
 export { KeyValueList } from './components/KeyValueList.tsx';
@@ -10,6 +11,7 @@ export { Select } from './components/Select.tsx';
 export { SiteFooter } from './components/SiteFooter.tsx';
 export { SiteHeader } from './components/SiteHeader.tsx';
 export { SummaryChip } from './components/SummaryChip.tsx';
+export { Textarea } from './components/Textarea.tsx';
 export { brandTokens } from './tokens.ts';
 export {
   animation,
@@ -22,8 +24,10 @@ export {
   theme,
   typography,
 } from './theme.ts';
+export type { FormFeedbackProps, FormFeedbackTone } from './components/FormFeedback.tsx';
 export type { FormFieldProps } from './components/FormField.tsx';
 export type { InputProps } from './components/Input.tsx';
+export type { TextareaProps } from './components/Textarea.tsx';
 export type { ButtonProps } from './components/Button.tsx';
 export type { CardProps } from './components/Card.tsx';
 export type { SelectOption, SelectProps } from './components/Select.tsx';

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1089,6 +1089,106 @@ body {
   flex-shrink: 0;
 }
 
+/* ── Textarea ──────────────────────────────────────────────────────── */
+
+.og-textarea {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.og-textarea__label {
+  color: var(--og-color-soil);
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.og-textarea__required {
+  color: var(--color-error);
+  margin-left: 0.25rem;
+}
+
+.og-textarea__field {
+  width: 100%;
+  min-height: 6rem;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: 1rem;
+  background: rgba(255, 252, 246, 0.98);
+  padding: 0.9rem 1rem;
+  color: var(--og-color-ink);
+  font: inherit;
+  resize: vertical;
+  transition: border-color var(--duration-fast) var(--easing-out),
+              box-shadow var(--duration-fast) var(--easing-out);
+}
+
+.og-textarea__field::placeholder {
+  color: rgba(79, 56, 37, 0.42);
+}
+
+.og-textarea__field:focus {
+  outline: 2px solid rgba(66, 107, 63, 0.45);
+  outline-offset: 1px;
+  border-color: var(--og-color-moss);
+}
+
+.og-textarea__field:disabled {
+  cursor: wait;
+  opacity: 0.8;
+}
+
+.og-textarea--error .og-textarea__field {
+  border-color: var(--color-error);
+}
+
+.og-textarea--error .og-textarea__field:focus {
+  outline-color: rgba(239, 68, 68, 0.35);
+  border-color: var(--color-error);
+}
+
+.og-textarea__error {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  color: var(--color-error);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.og-textarea__error-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+/* ── FormFeedback ──────────────────────────────────────────────────── */
+
+.og-form-feedback {
+  margin: 0;
+  padding: 0.85rem 0.95rem;
+  border-radius: 0.95rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.og-form-feedback--success {
+  background: rgba(227, 244, 229, 0.92);
+  color: #29593b;
+}
+
+.og-form-feedback--error {
+  background: rgba(255, 232, 227, 0.92);
+  color: #8a2e24;
+}
+
+.og-form-feedback--info {
+  background: rgba(234, 238, 247, 0.92);
+  color: #2a3a6b;
+}
+
 /* ── Select ────────────────────────────────────────────────────────── */
 
 .og-select__field {


### PR DESCRIPTION
## Summary

- Polishes the profile page so it actually looks like the rest of the app: shrinks the oversized hero h1, restores the header avatar's gradient (an `og-auth-menu` rule was wiping it), and aligns the form's inputs / focus ring / feedback pills / mobile breakpoint with the conventions established by `.contact-form` and the `--site-*` token set.
- Promotes the form chrome into `@olivias/ui` so the next page doesn't re-derive it: adds `<Textarea>` and `<FormFeedback tone="success" | "error" | "info">`, widens `InputProps.type` to include `'url' | 'tel' | 'number' | 'search'`, and migrates `ProfilePage.tsx` to wrap in `<Panel tone="paper">` and use `<Input>` / `<Textarea>` / `<FormFeedback>` for every field and message.
- Net deletes ~60 lines of `.profile-form__field*`, `.profile-error`, and `.profile-success` from `apps/web/src/index.css`.

## Why

The profile page had drifted from the rest of the app — hand-rolled field styles, duplicated feedback-pill CSS, an oversized hero, a broken header avatar. The deeper cause was that the page wasn't reaching for `@olivias/ui`'s primitives even though `<Input>`, `<FormField>`, `<Panel>`, and friends already exist (and `apps/grn` consumes them heavily). The gaps blocking adoption were small: no `<Textarea>`, no form-level feedback component, no `type="url"` support. This PR closes those gaps and migrates one consumer, so the pattern is in place for the contact form and others.

## Reviewer notes

- **Visual shift on the profile form is intentional.** Inputs now use `<Input>`'s shape (`min-height: 3.2rem`, `border-radius: 1rem`) — slightly taller and rounder than the values I had briefly tuned during the polish pass. Treat the design-system value as authoritative.
- **Header avatar fix:** `.og-auth-menu .og-auth-utility__avatar` had `background: inherit; border: none; font: inherit` which clobbered the moss→soil gradient defined on the outer `.og-auth-utility__avatar`. Removed those overrides; only `cursor: pointer` remains.
- **`<FormFeedback>` is form-level only.** Field-level errors should keep using `<Input error="...">` / `<Textarea error="...">` / `<FormField error="...">`.
- **Worktree quirk during verification:** the worktree's `node_modules/@olivias/ui` symlinks back to the main repo's `packages/ui`, so `turbo run build` in the worktree resolves to the main copy and won't see new exports. I verified by temporarily syncing the changed files into the symlink target, running `turbo run build --filter=@olivias/web --force` (clean), then restoring. CI will see this branch's source directly, no action needed.

## Follow-ups (separate PR)

- Migrate the contact form in `apps/web/src/site/pages/content-pages.tsx` to `<Input>` / `<Textarea>` / `<FormFeedback>` and delete `.contact-form__feedback--*`.
- Migrate the donate and login inline error messages to `<FormFeedback tone="error">`.

## Test plan

- [ ] Profile page renders with the smaller hero h1 and the new panel/form treatment
- [ ] Header avatar shows the moss/soil gradient when signed in
- [ ] All profile fields submit correctly (firstName, lastName, displayName, city, region, country, timezone, websiteUrl, bio)
- [ ] Save success and error messages render as the green / red pill
- [ ] Avatar upload error renders as a red pill in the avatar row
- [ ] Mobile: form actions become a full-width button, hero h1 scales down

🤖 Generated with [Claude Code](https://claude.com/claude-code)