### PR TITLE
Migrate contact, login, and donate forms to shared UI primitives

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -676,57 +676,9 @@ html {
   gap: 0.9rem;
 }
 
-.contact-form label {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.contact-form span {
-  color: var(--site-branch);
-  font-size: 0.92rem;
-  font-weight: 700;
-}
-
-.contact-form input,
-.contact-form textarea {
-  width: 100%;
-  border: 1px solid rgba(76, 52, 38, 0.16);
-  border-radius: 0.9rem;
-  background: rgba(255, 252, 246, 0.95);
-  padding: 0.9rem 1rem;
-  color: var(--site-ink);
-  font: inherit;
-}
-
-.contact-form input:focus-visible,
-.contact-form textarea:focus-visible {
-  outline: none;
-  border-color: var(--color-primary-600, #3f7d3a);
-  box-shadow: 0 0 0 3px rgba(63, 125, 58, 0.18);
-}
-
 .contact-form button[type="submit"]:disabled {
   opacity: 0.55;
   cursor: not-allowed;
-}
-
-.contact-form__feedback {
-  margin: 0;
-  padding: 0.85rem 0.95rem;
-  border-radius: 0.95rem;
-  font-size: 0.95rem;
-  font-weight: 700;
-  line-height: 1.5;
-}
-
-.contact-form__feedback--success {
-  background: rgba(227, 244, 229, 0.92);
-  color: #29593b;
-}
-
-.contact-form__feedback--error {
-  background: rgba(255, 232, 227, 0.92);
-  color: #8a2e24;
 }
 
 .contact-meta__link {
@@ -972,15 +924,6 @@ html {
 
   .contact-form {
     gap: 0.8rem;
-  }
-
-  .contact-form input,
-  .contact-form textarea {
-    padding: 0.85rem 0.95rem;
-  }
-
-  .contact-form textarea {
-    min-height: 8.5rem;
   }
 
   .contact-form .site-cta {
@@ -1556,15 +1499,6 @@ html {
   font-size: 0.9rem;
   font-weight: 700;
   text-align: center;
-}
-
-.donate-form-card__error {
-  margin: 0;
-  padding: 0.9rem 1rem;
-  border-radius: 1rem;
-  background: rgba(255, 232, 227, 0.92);
-  color: #8a2e24;
-  font-weight: 700;
 }
 
 .donate-status-card,

--- a/apps/web/src/site/pages/DonatePage.tsx
+++ b/apps/web/src/site/pages/DonatePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { loadStripe, type StripeEmbeddedCheckout } from '@stripe/stripe-js';
-import { Button } from '@olivias/ui';
+import { Button, FormFeedback } from '@olivias/ui';
 import type { AuthSession } from '../../auth/session';
 import { CtaButton, PageHero } from '../chrome';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
@@ -625,7 +625,7 @@ export function DonatePage({
                   </div>
                 </div>
 
-                {error ? <p className="donate-form-card__error" role="alert">{error}</p> : null}
+                {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
               </>
             )}
           </div>

--- a/apps/web/src/site/pages/LoginPage.tsx
+++ b/apps/web/src/site/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useEffect, useRef, useState } from 'react';
-import { Input } from '@olivias/ui';
+import { FormFeedback, Input } from '@olivias/ui';
 import type { AuthSession } from '../../auth/session';
 import { getUserInitials } from '../chrome';
 
@@ -653,8 +653,8 @@ export function LoginPage({
             </>
           )}
 
-          {statusMessage ? <p className="og-login-page__success">{statusMessage}</p> : null}
-          {localError || authError ? <p className="og-login-page__error" role="alert">{localError ?? authError}</p> : null}
+          {statusMessage ? <FormFeedback tone="success">{statusMessage}</FormFeedback> : null}
+          {localError || authError ? <FormFeedback tone="error">{localError ?? authError}</FormFeedback> : null}
         </div>
       </div>
     </section>

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@olivias/ui';
+import { Card, FormFeedback, Input, Textarea } from '@olivias/ui';
 import { lazy, Suspense, useState, type FormEvent } from 'react';
 import type { AuthSession } from '../../auth/session';
 import { CtaButton, PageHero, Section, WorkIcon } from '../chrome';
@@ -591,57 +591,47 @@ export function ContactPage() {
             own inbox — easier for us to reply to you directly.
           </p>
           <form className="contact-form" onSubmit={handleSubmit} noValidate>
-            <label>
-              <span>Name</span>
-              <input
-                type="text"
-                placeholder="Your name"
-                value={name}
-                onChange={(event) => {
-                  clearFeedback();
-                  setName(event.target.value);
-                }}
-                autoComplete="name"
-              />
-            </label>
-            <label>
-              <span>Email</span>
-              <input
-                type="email"
-                placeholder="Your email"
-                value={email}
-                onChange={(event) => {
-                  clearFeedback();
-                  setEmail(event.target.value);
-                }}
-                autoComplete="email"
-              />
-            </label>
-            <label>
-              <span>Message</span>
-              <textarea
-                rows={6}
-                placeholder="How can we help?"
-                value={message}
-                onChange={(event) => {
-                  clearFeedback();
-                  setMessage(event.target.value);
-                }}
-                required
-              />
-            </label>
-            <label>
-              <span>How did you hear about us? (optional)</span>
-              <input
-                type="text"
-                placeholder="Instagram, friend, work day, etc."
-                value={referral}
-                onChange={(event) => {
-                  clearFeedback();
-                  setReferral(event.target.value);
-                }}
-              />
-            </label>
+            <Input
+              label="Name"
+              placeholder="Your name"
+              value={name}
+              onChange={(event) => {
+                clearFeedback();
+                setName(event.target.value);
+              }}
+              autoComplete="name"
+            />
+            <Input
+              type="email"
+              label="Email"
+              placeholder="Your email"
+              value={email}
+              onChange={(event) => {
+                clearFeedback();
+                setEmail(event.target.value);
+              }}
+              autoComplete="email"
+            />
+            <Textarea
+              label="Message"
+              rows={6}
+              placeholder="How can we help?"
+              value={message}
+              onChange={(event) => {
+                clearFeedback();
+                setMessage(event.target.value);
+              }}
+              required
+            />
+            <Input
+              label="How did you hear about us? (optional)"
+              placeholder="Instagram, friend, work day, etc."
+              value={referral}
+              onChange={(event) => {
+                clearFeedback();
+                setReferral(event.target.value);
+              }}
+            />
             <button
               type="submit"
               className="site-cta og-button og-button--primary og-button--md"
@@ -650,12 +640,7 @@ export function ContactPage() {
               Open email to send
             </button>
             {feedback ? (
-              <p
-                className={`contact-form__feedback contact-form__feedback--${feedback.type}`.trim()}
-                role={feedback.type === 'error' ? 'alert' : 'status'}
-              >
-                {feedback.message}
-              </p>
+              <FormFeedback tone={feedback.type}>{feedback.message}</FormFeedback>
             ) : null}
           </form>
         </Card>


### PR DESCRIPTION
## Summary

Follow-up to #238. With `<Input>`, `<Textarea>`, and `<FormFeedback>` now living in `@olivias/ui`, this swaps the remaining hand-rolled form chrome in the web app over to them and deletes the CSS those consumers were relying on.

- **Contact form** ([content-pages.tsx](apps/web/src/site/pages/content-pages.tsx)) — every field now renders through `<Input>` / `<Textarea>`, and the success/error pill renders through `<FormFeedback tone={feedback.type}>`.
- **LoginPage** — `statusMessage` and `localError || authError` render through `<FormFeedback tone="success" | "error">`.
- **DonatePage** — checkout `error` renders through `<FormFeedback tone="error">`.

With the last consumers gone, removed from [apps/web/src/index.css](apps/web/src/index.css):
- `.contact-form label`, `.contact-form span`, `.contact-form input`, `.contact-form textarea` (plus their focus and mobile padding overrides)
- `.contact-form__feedback`, `.contact-form__feedback--success`, `.contact-form__feedback--error`
- `.donate-form-card__error`

Net −81 lines.

## Why

These forms were the original reason `<FormFeedback>` existed — four near-identical pill blocks (contact/profile/login/donate) scattered across the codebase. Profile migrated in #238; this finishes the job so there's one source of truth for field and feedback styling across the web app.

## Reviewer notes

- **Not touched: `chrome.tsx:197`** still uses `.og-login-page__error` for the header-bar auth-error banner when `pathname === '/login'`. The header's utility slot isn't laid out for a full-width pill, so I left the banner on its existing class. That's the one remaining consumer of `.og-login-page__error` / `__success` in `packages/ui/src/styles.css`, so those rules stay. If you'd rather drop the banner entirely (it duplicates the error the LoginPage itself already shows below the form), happy to do that in a separate PR.
- **Visual shift on the contact form is intentional.** Fields now use `<Input>`'s / `<Textarea>`'s standard shape — `min-height: 3.2rem`, `border-radius: 1rem`, slightly larger label — matching the profile page after #238.
- **Worktree / build verification** used the same temporary-sync dance as #238 since `node_modules/@olivias/*` symlinks point at the main repo's copy. `turbo run build --filter=@olivias/web --force` was clean.

## Test plan

- [ ] Contact form: fill out, submit — success pill renders as the green `<FormFeedback>`, any error as the red one
- [ ] Login: incorrect creds show the red pill; password-reset confirmation shows the green pill
- [ ] Donate: a Stripe error on checkout shows the red pill
- [ ] Mobile: contact form submit button spans full width; pills wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)