### PR TITLE
Adopt @olivias/ui across the admin app

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -194,17 +194,14 @@ jobs:
         working-directory: services/admin-api
         run: npm run build
 
-      - name: Admin Frontend - Install dependencies
-        working-directory: apps/admin
-        run: npm install --workspaces=false --ignore-scripts
+      - name: Admin Frontend - Install workspace dependencies
+        run: npm ci
 
       - name: Admin Frontend - Run ESLint
-        working-directory: apps/admin
-        run: npm run lint
+        run: npm --workspace @olivias/admin run lint
 
       - name: Admin Frontend - Type check
-        working-directory: apps/admin
-        run: npm run typecheck
+        run: npm --workspace @olivias/admin run typecheck
 
   deploy-foundation:
     name: Deploy Foundation Stack
@@ -927,9 +924,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install admin dependencies
-        working-directory: apps/admin
-        run: npm install --workspaces=false --ignore-scripts
+      - name: Install workspace dependencies
+        run: npm ci
 
       - name: Get foundation web frontend URL
         id: get-foundation-url
@@ -955,8 +951,7 @@ jobs:
           EOF
 
       - name: Build admin frontend
-        working-directory: apps/admin
-        run: npm run build
+        run: npm --workspace @olivias/admin run build
 
       - name: Deploy admin frontend to S3
         run: |

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -71,6 +71,7 @@ jobs:
               - 'services/admin-api/**'
             admin_frontend:
               - 'apps/admin/**'
+              - 'packages/**'
             okra_backend:
               - 'services/okra-api/**'
 
@@ -325,9 +326,6 @@ jobs:
     if: github.event.action != 'closed' && (needs.changes.outputs.shared_all == 'true' || needs.changes.outputs.admin_frontend == 'true')
     needs: [changes]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/admin
 
     steps:
       - name: Checkout code
@@ -341,19 +339,16 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install --workspaces=false --ignore-scripts
+        run: npm ci
 
       - name: Run ESLint
-        run: npm run lint
+        run: npm --workspace @olivias/admin run lint
 
   admin-frontend-typecheck:
     name: Admin Frontend Type Check
     if: github.event.action != 'closed' && (needs.changes.outputs.shared_all == 'true' || needs.changes.outputs.admin_frontend == 'true')
     needs: [changes]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/admin
 
     steps:
       - name: Checkout code
@@ -367,19 +362,16 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install --workspaces=false --ignore-scripts
+        run: npm ci
 
       - name: Type check
-        run: npm run typecheck
+        run: npm --workspace @olivias/admin run typecheck
 
   admin-frontend-tests:
     name: Admin Frontend Tests
     if: github.event.action != 'closed' && (needs.changes.outputs.shared_all == 'true' || needs.changes.outputs.admin_frontend == 'true')
     needs: [changes]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/admin
 
     steps:
       - name: Checkout code
@@ -393,19 +385,16 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install --workspaces=false --ignore-scripts
+        run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: npm --workspace @olivias/admin run test
 
   admin-frontend-build:
     name: Admin Frontend Build Check
     if: github.event.action != 'closed' && (needs.changes.outputs.shared_all == 'true' || needs.changes.outputs.admin_frontend == 'true')
     needs: [changes]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/admin
 
     steps:
       - name: Checkout code
@@ -419,10 +408,10 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install --workspaces=false --ignore-scripts
+        run: npm ci
 
       - name: Build check
-        run: npm run build
+        run: npm --workspace @olivias/admin run build
 
   backend-functions-tests:
     name: GRN Backend Functions (Node.js) Lint & Tests

--- a/.github/workflows/pull-request-staging-validation-reusable.yml
+++ b/.github/workflows/pull-request-staging-validation-reusable.yml
@@ -689,9 +689,8 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install admin dependencies
-        working-directory: apps/admin
-        run: npm install --workspaces=false --ignore-scripts
+      - name: Install workspace dependencies
+        run: npm ci
 
       - name: Get foundation web frontend URL
         id: get-foundation-url
@@ -717,8 +716,7 @@ jobs:
           EOF
 
       - name: Build admin frontend
-        working-directory: apps/admin
-        run: npm run build
+        run: npm --workspace @olivias/admin run build
 
       - name: Deploy admin frontend to S3
         run: |

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@olivias/auth": "file:../../packages/auth",
+    "@olivias/ui": "file:../../packages/ui",
     "aws-amplify": "^6.16.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,4 +1,5 @@
 import { type FormEvent, useEffect, useState } from 'react';
+import { Button, Card, FormFeedback, Input, Select, Textarea } from '@olivias/ui';
 import {
   createStoreProduct,
   listOkraReviewQueue,
@@ -33,6 +34,27 @@ const emptyProductForm: UpsertStoreProductRequest = {
   image_url: '',
   metadata: {},
 };
+
+const statusOptions = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'active', label: 'Active' },
+  { value: 'archived', label: 'Archived' },
+];
+
+const kindOptions = [
+  { value: 'donation', label: 'Donation' },
+  { value: 'merchandise', label: 'Merchandise' },
+  { value: 'ticket', label: 'Ticket' },
+  { value: 'sponsorship', label: 'Sponsorship' },
+  { value: 'other', label: 'Other' },
+];
+
+const fulfillmentOptions = [
+  { value: 'none', label: 'None' },
+  { value: 'digital', label: 'Digital' },
+  { value: 'shipping', label: 'Shipping' },
+  { value: 'pickup', label: 'Pickup' },
+];
 
 function redirectToLogin() {
   const returnUrl = window.location.href;
@@ -92,11 +114,11 @@ export default function App() {
   if (!session.isAdmin) {
     return (
       <div className="admin-shell admin-shell--centered">
-        <div className="admin-card">
+        <Card className="admin-restricted">
           <p className="admin-eyebrow">Restricted</p>
           <h1>Administrator access is required.</h1>
           <p>This account is authenticated, but it does not carry the `admin` role in Cognito.</p>
-        </div>
+        </Card>
       </div>
     );
   }
@@ -221,15 +243,15 @@ export default function App() {
         </button>
       </div>
 
-      {loadError ? <p className="admin-error">{loadError}</p> : null}
+      {loadError ? <FormFeedback tone="error" className="admin-load-error">{loadError}</FormFeedback> : null}
 
       {activeTab === 'moderation' ? (
         <section className="admin-grid">
           {okraQueue.length === 0 ? (
-            <div className="admin-card"><p>No pending okra submissions.</p></div>
+            <Card><p>No pending okra submissions.</p></Card>
           ) : (
             okraQueue.map((submission) => (
-              <article key={submission.id} className="admin-card admin-card--submission">
+              <Card key={submission.id} className="admin-card--submission">
                 <div className="submission-meta">
                   <div>
                     <h2>{submission.contributor_name || 'Anonymous contributor'}</h2>
@@ -243,26 +265,26 @@ export default function App() {
                   <img className="submission-photo" src={submission.photos[0]} alt="Okra submission" />
                 ) : null}
                 <div className="submission-actions">
-                  <button type="button" onClick={() => void handleReview(submission, 'approved')}>
+                  <Button onClick={() => void handleReview(submission, 'approved')}>
                     Approve
-                  </button>
-                  <button type="button" className="danger" onClick={() => void handleReview(submission, 'denied')}>
+                  </Button>
+                  <Button variant="outline" onClick={() => void handleReview(submission, 'denied')}>
                     Deny
-                  </button>
+                  </Button>
                 </div>
-              </article>
+              </Card>
             ))
           )}
         </section>
       ) : (
         <section className="admin-store-layout">
-          <div className="admin-card">
+          <Card>
             <div className="store-header">
               <div>
                 <p className="admin-eyebrow">Store products</p>
                 <h2>Current catalog</h2>
               </div>
-              <button type="button" onClick={startCreate}>New product</button>
+              <Button variant="secondary" size="sm" onClick={startCreate}>New product</Button>
             </div>
             <div className="store-list">
               {products.map((product) => (
@@ -278,136 +300,103 @@ export default function App() {
                 </button>
               ))}
             </div>
-          </div>
+          </Card>
 
-          <form className="admin-card store-form" onSubmit={submitProduct}>
-            <div className="store-header">
-              <div>
-                <p className="admin-eyebrow">{activeProductId ? 'Edit product' : 'Create product'}</p>
-                <h2>{activeProductId ? 'Update store product' : 'Add store product'}</h2>
+          <Card className="store-form-card">
+            <form className="store-form" onSubmit={submitProduct}>
+              <div className="store-header">
+                <div>
+                  <p className="admin-eyebrow">{activeProductId ? 'Edit product' : 'Create product'}</p>
+                  <h2>{activeProductId ? 'Update store product' : 'Add store product'}</h2>
+                </div>
               </div>
-            </div>
-            <label>
-              Name
-              <input
+              <Input
+                label="Name"
                 value={productForm.name}
                 onChange={(event) => setProductForm((current) => ({ ...current, name: event.target.value }))}
               />
-            </label>
-            <label>
-              Slug
-              <input
+              <Input
+                label="Slug"
                 value={productForm.slug}
                 onChange={(event) => setProductForm((current) => ({ ...current, slug: event.target.value.toLowerCase() }))}
               />
-            </label>
-            <label>
-              Short description
-              <input
+              <Input
+                label="Short description"
                 value={productForm.short_description || ''}
                 onChange={(event) => setProductForm((current) => ({ ...current, short_description: event.target.value }))}
               />
-            </label>
-            <label>
-              Description
-              <textarea
+              <Textarea
+                label="Description"
                 value={productForm.description || ''}
                 onChange={(event) => setProductForm((current) => ({ ...current, description: event.target.value }))}
               />
-            </label>
-            <div className="store-grid">
-              <label>
-                Status
-                <select
+              <div className="store-grid">
+                <Select
+                  label="Status"
                   value={productForm.status}
-                  onChange={(event) => setProductForm((current) => ({ ...current, status: event.target.value as StoreProduct['status'] }))}
-                >
-                  <option value="draft">Draft</option>
-                  <option value="active">Active</option>
-                  <option value="archived">Archived</option>
-                </select>
-              </label>
-              <label>
-                Kind
-                <select
+                  onChange={(value) => setProductForm((current) => ({ ...current, status: value as StoreProduct['status'] }))}
+                  options={statusOptions}
+                />
+                <Select
+                  label="Kind"
                   value={productForm.kind}
-                  onChange={(event) => setProductForm((current) => ({ ...current, kind: event.target.value as StoreProduct['kind'] }))}
-                >
-                  <option value="donation">Donation</option>
-                  <option value="merchandise">Merchandise</option>
-                  <option value="ticket">Ticket</option>
-                  <option value="sponsorship">Sponsorship</option>
-                  <option value="other">Other</option>
-                </select>
-              </label>
-              <label>
-                Fulfillment
-                <select
+                  onChange={(value) => setProductForm((current) => ({ ...current, kind: value as StoreProduct['kind'] }))}
+                  options={kindOptions}
+                />
+                <Select
+                  label="Fulfillment"
                   value={productForm.fulfillment_type}
-                  onChange={(event) =>
-                    setProductForm((current) => ({ ...current, fulfillment_type: event.target.value as StoreProduct['fulfillment_type'] }))
-                  }
-                >
-                  <option value="none">None</option>
-                  <option value="digital">Digital</option>
-                  <option value="shipping">Shipping</option>
-                  <option value="pickup">Pickup</option>
-                </select>
-              </label>
-              <label>
-                Price (cents)
-                <input
+                  onChange={(value) => setProductForm((current) => ({ ...current, fulfillment_type: value as StoreProduct['fulfillment_type'] }))}
+                  options={fulfillmentOptions}
+                />
+                <Input
                   type="number"
+                  label="Price (cents)"
                   value={productForm.unit_amount_cents}
-                  onChange={(event) =>
-                    setProductForm((current) => ({ ...current, unit_amount_cents: Number(event.target.value) || 0 }))
-                  }
+                  onChange={(event) => setProductForm((current) => ({ ...current, unit_amount_cents: Number(event.target.value) || 0 }))}
                 />
-              </label>
-            </div>
-            <div className="store-grid">
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  checked={productForm.is_public}
-                  onChange={(event) => setProductForm((current) => ({ ...current, is_public: event.target.checked }))}
-                />
-                Publicly visible
-              </label>
-              <label className="checkbox">
-                <input
-                  type="checkbox"
-                  checked={productForm.is_featured}
-                  onChange={(event) => setProductForm((current) => ({ ...current, is_featured: event.target.checked }))}
-                />
-                Featured
-              </label>
-            </div>
-            <label>
-              Nonprofit program
-              <input
+              </div>
+              <div className="store-grid">
+                <label className="admin-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={productForm.is_public}
+                    onChange={(event) => setProductForm((current) => ({ ...current, is_public: event.target.checked }))}
+                  />
+                  Publicly visible
+                </label>
+                <label className="admin-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={productForm.is_featured}
+                    onChange={(event) => setProductForm((current) => ({ ...current, is_featured: event.target.checked }))}
+                  />
+                  Featured
+                </label>
+              </div>
+              <Input
+                label="Nonprofit program"
                 value={productForm.nonprofit_program || ''}
                 onChange={(event) => setProductForm((current) => ({ ...current, nonprofit_program: event.target.value }))}
               />
-            </label>
-            <label>
-              Impact summary
-              <textarea
+              <Textarea
+                label="Impact summary"
                 value={productForm.impact_summary || ''}
                 onChange={(event) => setProductForm((current) => ({ ...current, impact_summary: event.target.value }))}
               />
-            </label>
-            <label>
-              Image URL
-              <input
+              <Input
+                type="url"
+                label="Image URL"
                 value={productForm.image_url || ''}
                 onChange={(event) => setProductForm((current) => ({ ...current, image_url: event.target.value }))}
               />
-            </label>
-            <button type="submit" disabled={isSaving}>
-              {isSaving ? 'Saving...' : activeProductId ? 'Update product' : 'Create product'}
-            </button>
-          </form>
+              <div className="store-form__actions">
+                <Button type="submit" loading={isSaving} disabled={isSaving}>
+                  {isSaving ? 'Saving...' : activeProductId ? 'Update product' : 'Create product'}
+                </Button>
+              </div>
+            </form>
+          </Card>
         </section>
       )}
     </div>

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -1,30 +1,27 @@
-:root {
-  font-family: "Trebuchet MS", "Segoe UI", sans-serif;
-  color: #1b2118;
-  background:
-    radial-gradient(circle at top left, rgba(214, 164, 79, 0.22), transparent 30%),
-    radial-gradient(circle at top right, rgba(70, 118, 86, 0.18), transparent 28%),
-    linear-gradient(180deg, #f7f2e8 0%, #efe5d3 100%);
-}
+@import '@olivias/ui/styles.css';
 
-* {
-  box-sizing: border-box;
+html {
+  background:
+    radial-gradient(circle at top left, rgba(216, 167, 65, 0.18), transparent 30%),
+    radial-gradient(circle at top right, rgba(66, 107, 63, 0.14), transparent 28%),
+    linear-gradient(180deg, var(--og-color-cream) 0%, #efe5d3 100%);
+  color: var(--og-color-ink);
+  font-family: var(--og-font-body);
 }
 
 body {
   margin: 0;
 }
 
-button,
-input,
-textarea,
-select {
-  font: inherit;
+* {
+  box-sizing: border-box;
 }
 
 .admin-shell {
   min-height: 100vh;
   padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
 }
 
 .admin-shell--centered {
@@ -37,65 +34,77 @@ select {
   justify-content: space-between;
   gap: 1rem;
   align-items: flex-start;
-  margin-bottom: 1.5rem;
 }
 
 .admin-hero h1 {
   margin: 0.2rem 0 0.5rem;
   max-width: 12ch;
+  font-family: var(--og-font-display);
   font-size: clamp(2rem, 4vw, 3.75rem);
   line-height: 0.95;
+  letter-spacing: -0.02em;
 }
 
 .admin-eyebrow {
   margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
+  color: var(--og-color-moss);
   font-size: 0.75rem;
-  color: #5e684d;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .admin-subtitle {
   max-width: 42rem;
-  color: #46533e;
+  margin: 0.35rem 0 0;
+  color: var(--color-neutral-600);
+  line-height: 1.6;
 }
 
 .admin-pill {
-  border: 1px solid rgba(27, 33, 24, 0.15);
-  background: rgba(255, 255, 255, 0.75);
+  align-self: center;
   padding: 0.7rem 1rem;
-  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--og-color-soil);
+  font-weight: 600;
 }
 
 .admin-tabs {
   display: inline-flex;
-  gap: 0.5rem;
+  gap: 0.35rem;
   padding: 0.25rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.6);
-  margin-bottom: 1.5rem;
-}
-
-.admin-tabs button,
-.submission-actions button,
-.store-header button,
-.store-form button {
-  border: none;
-  border-radius: 999px;
-  padding: 0.8rem 1.1rem;
-  background: #274234;
-  color: #fffaf0;
-  cursor: pointer;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(79, 56, 37, 0.12);
+  width: fit-content;
 }
 
 .admin-tabs button {
+  border: none;
+  border-radius: var(--radius-full);
+  padding: 0.6rem 1.1rem;
   background: transparent;
-  color: #394634;
+  color: var(--og-color-soil);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--easing-out),
+              color var(--duration-fast) var(--easing-out);
+}
+
+.admin-tabs button:hover {
+  background: rgba(66, 107, 63, 0.08);
 }
 
 .admin-tabs button.is-active {
-  background: #274234;
-  color: #fffaf0;
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.admin-load-error {
+  margin: 0;
 }
 
 .admin-grid,
@@ -106,14 +115,7 @@ select {
 
 .admin-store-layout {
   grid-template-columns: minmax(18rem, 24rem) minmax(0, 1fr);
-}
-
-.admin-card {
-  background: rgba(255, 255, 255, 0.84);
-  border: 1px solid rgba(27, 33, 24, 0.1);
-  border-radius: 1.25rem;
-  padding: 1.2rem;
-  box-shadow: 0 24px 60px rgba(60, 49, 27, 0.08);
+  align-items: start;
 }
 
 .admin-card--submission {
@@ -121,94 +123,128 @@ select {
   gap: 0.9rem;
 }
 
+.admin-restricted h1 {
+  margin: 0.25rem 0 0.75rem;
+  font-family: var(--og-font-display);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  line-height: 1.1;
+}
+
 .submission-meta,
-.store-header,
-.store-row {
+.store-header {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   gap: 1rem;
 }
 
 .submission-meta h2,
 .store-header h2 {
   margin: 0.2rem 0;
+  font-family: var(--og-font-display);
+  font-size: 1.3rem;
+  line-height: 1.2;
+}
+
+.submission-meta p {
+  margin: 0.15rem 0 0;
+  color: var(--color-neutral-600);
+  font-size: 0.9rem;
+}
+
+.submission-meta > span {
+  color: var(--color-neutral-500);
+  font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 .submission-photo {
   width: 100%;
   max-height: 20rem;
   object-fit: cover;
-  border-radius: 0.9rem;
+  border-radius: var(--radius-lg);
 }
 
 .submission-actions {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.submission-actions .danger {
-  background: #7a2e1e;
-}
-
-.submission-location,
-.store-row small {
-  color: #6a705d;
+.submission-location {
+  color: var(--color-neutral-600);
+  margin: 0;
 }
 
 .store-list {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.6rem;
+  margin-top: 1rem;
 }
 
 .store-row {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  border: 1px solid rgba(27, 33, 24, 0.08);
-  border-radius: 1rem;
+  gap: 1rem;
   padding: 0.9rem 1rem;
-  background: #fffdfa;
-  cursor: pointer;
+  border: 1px solid rgba(79, 56, 37, 0.12);
+  border-radius: var(--radius-lg);
+  background: var(--og-color-paper);
+  color: inherit;
+  font: inherit;
   text-align: left;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--easing-out),
+              transform var(--duration-fast) var(--easing-out);
+}
+
+.store-row:hover {
+  border-color: var(--og-color-moss);
+  transform: translateY(-1px);
 }
 
 .store-row span {
   display: grid;
+  gap: 0.1rem;
 }
 
-.store-form,
-.store-form label {
+.store-row small {
+  color: var(--color-neutral-500);
+}
+
+.store-form {
   display: grid;
-  gap: 0.45rem;
+  gap: 1rem;
 }
 
 .store-grid {
   display: grid;
-  gap: 0.8rem;
+  gap: 0.9rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.store-form input,
-.store-form textarea,
-.store-form select {
-  border: 1px solid rgba(27, 33, 24, 0.14);
-  border-radius: 0.8rem;
-  padding: 0.85rem 0.9rem;
-  background: #fffcf6;
+.store-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.25rem;
 }
 
-.store-form textarea {
-  min-height: 6rem;
-  resize: vertical;
-}
-
-.checkbox {
-  grid-auto-flow: column;
-  justify-content: start;
+.admin-checkbox {
+  display: inline-flex;
   align-items: center;
+  gap: 0.5rem;
+  color: var(--og-color-soil);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.admin-error {
-  color: #7a2e1e;
-  margin: 0 0 1rem;
+.admin-checkbox input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--og-color-moss);
+  cursor: pointer;
 }
 
 @media (max-width: 900px) {
@@ -216,16 +252,20 @@ select {
     padding: 1rem;
   }
 
-  .admin-hero,
-  .admin-store-layout,
-  .submission-meta,
-  .store-header,
-  .store-row {
+  .admin-hero {
+    flex-direction: column;
+  }
+
+  .admin-store-layout {
     grid-template-columns: 1fr;
-    display: grid;
   }
 
   .store-grid {
     grid-template-columns: 1fr;
+  }
+
+  .submission-meta,
+  .store-header {
+    flex-direction: column;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@olivias/auth": "file:../../packages/auth",
+        "@olivias/ui": "file:../../packages/ui",
         "aws-amplify": "^6.16.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"


### PR DESCRIPTION
## Summary

The admin app had been living on its own island — a standalone `styles.css`, a bespoke palette, and zero dependency on `@olivias/ui`. This brings it onto the shared design system on the same footing as `@olivias/web` and `@olivias/grn`.

## What changed

- **Dependency:** added `@olivias/ui` to [apps/admin/package.json](apps/admin/package.json) (plus the one-line `package-lock.json` entry).
- **App.tsx** now uses `<Card>`, `<Button>`, `<Input>`, `<Textarea>`, `<Select>`, and `<FormFeedback>` for every form field, action button, card surface, and error pill. The store product form (10+ fields, 3 selects, 2 checkboxes), the okra review queue's approve/deny actions, and the "restricted" access card all flow through the shared primitives.
- **styles.css** drops the standalone theme and opens with `@import '@olivias/ui/styles.css'`. What's left is admin-specific layout only: shell, hero, tabs, store layout / list / row, submission meta, checkbox wrapper, and the mobile breakpoint — all rewritten against the `--og-*` / `--color-*` / `--radius-*` / `--duration-*` tokens so the admin palette is no longer bespoke.

## Why

`@olivias/ui` exists so every app — web, grn, admin — can share one set of form primitives, card treatments, and color tokens. Keeping admin on a parallel palette and hand-rolled inputs defeated the point. This is the last of the three apps to move onto the shared system.

## Visual shift is intentional

The admin used to have a darker green button (`#274234`), Trebuchet MS everywhere, and its own card/input shapes. It now matches the Foundation theme: moss/soil buttons, paper cards with the standard shadow, Georgia display font on headings, the shared 1rem-radius inputs, and moss-green focus rings. The store-row, tabs, hero, and checkbox wrapper are still custom because they're admin-specific layouts — but they consume shared tokens instead of hard-coded hexes.

## Reviewer notes

- **Denied button** in the okra queue was `<button className="danger">` with a dark-red background. I used `<Button variant="outline">` to keep it visually distinct from approve without introducing a "danger" variant the UI package doesn't have yet. If you'd rather a real destructive look, happy to add `<Button variant="danger">` to `@olivias/ui` in a separate PR.
- **Checkboxes** stay as plain `<input type="checkbox">` in a styled `<label className="admin-checkbox">`. `@olivias/ui` doesn't expose a checkbox primitive yet; only two use it, so this isn't worth introducing one for.
- **Store-row list** in the catalog panel is still a custom button element — that's a tap-target card row, not something the generic `<Card>` primitive covers. It was already theme-aligned by the style rewrite.
- **Build verified** via the same sync-to-main-repo dance used in #238 / #240 (worktree symlinks resolve to the main repo's `packages/ui`). `npx turbo run build --filter=@olivias/admin --force` was clean end-to-end including tsc and vite.

## Test plan

- [ ] `/` renders the admin hero with Georgia display font and the new moss tab styling
- [ ] Okra queue: a pending submission renders as a `<Card>`, Approve uses primary moss button, Deny uses outline
- [ ] Store catalog: product list rows hover cleanly; "New product" is the secondary button
- [ ] Store product form submits; Save button goes into loading state
- [ ] Error from `listStoreProducts` / `listOkraReviewQueue` / `updateStoreProduct` renders as the red `<FormFeedback>` pill at top
- [ ] Non-admin users see the "Restricted" card using the shared `<Card>` surface
- [ ] Mobile (<900px): hero stacks, store layout collapses to one column, checkbox row wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)