### PR TITLE
Add Button danger variant and Checkbox primitive to @olivias/ui

### DIFF
--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
-type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost';
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, PropsWithChildren {

--- a/packages/ui/src/components/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox.tsx
@@ -1,0 +1,59 @@
+import { useId, type InputHTMLAttributes, type ReactNode } from 'react';
+
+export interface CheckboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'children'> {
+  label: ReactNode;
+  description?: ReactNode;
+  error?: string;
+}
+
+export function Checkbox({
+  label,
+  description,
+  error,
+  className = '',
+  id,
+  disabled = false,
+  ...props
+}: CheckboxProps) {
+  const generatedId = useId();
+  const inputId = id || `checkbox-${generatedId}`;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const descriptionId = description ? `${inputId}-description` : undefined;
+  const describedBy = [errorId, descriptionId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <div
+      className={
+        `og-checkbox${error ? ' og-checkbox--error' : ''}${disabled ? ' og-checkbox--disabled' : ''}` +
+        `${className ? ` ${className}` : ''}`
+      }
+    >
+      <label htmlFor={inputId} className="og-checkbox__label">
+        <input
+          {...props}
+          id={inputId}
+          type="checkbox"
+          disabled={disabled}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className="og-checkbox__input"
+        />
+        <span className="og-checkbox__text">
+          <span className="og-checkbox__title">{label}</span>
+          {description ? (
+            <span id={descriptionId} className="og-checkbox__description">
+              {description}
+            </span>
+          ) : null}
+        </span>
+      </label>
+
+      {error ? (
+        <p id={errorId} className="og-checkbox__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { AvatarBadge } from './components/AvatarBadge.tsx';
 export { Button } from './components/Button.tsx';
 export { Card } from './components/Card.tsx';
+export { Checkbox } from './components/Checkbox.tsx';
 export { FormFeedback } from './components/FormFeedback.tsx';
 export { FormField } from './components/FormField.tsx';
 export { Input } from './components/Input.tsx';
@@ -30,6 +31,7 @@ export type { InputProps } from './components/Input.tsx';
 export type { TextareaProps } from './components/Textarea.tsx';
 export type { ButtonProps } from './components/Button.tsx';
 export type { CardProps } from './components/Card.tsx';
+export type { CheckboxProps } from './components/Checkbox.tsx';
 export type { SelectOption, SelectProps } from './components/Select.tsx';
 export type { SiteFooterLink, SiteFooterProps } from './components/SiteFooter.tsx';
 export type { SiteHeaderNavItem, SiteHeaderProps } from './components/SiteHeader.tsx';

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -744,6 +744,16 @@ body {
   background: rgba(79, 56, 37, 0.06);
 }
 
+.og-button--danger {
+  background: var(--color-error);
+  color: var(--og-color-paper);
+  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.22);
+}
+
+.og-button--danger:hover {
+  background: #dc2f2f;
+}
+
 /* Sizes */
 
 .og-button--sm {
@@ -1209,6 +1219,77 @@ body {
 .og-form-feedback--info {
   background: rgba(234, 238, 247, 0.92);
   color: #2a3a6b;
+}
+
+/* ── Checkbox ──────────────────────────────────────────────────────── */
+
+.og-checkbox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.og-checkbox__label {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  cursor: pointer;
+  color: var(--og-color-soil);
+  line-height: 1.4;
+}
+
+.og-checkbox__input {
+  flex-shrink: 0;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin: 0.15rem 0 0;
+  accent-color: var(--og-color-moss);
+  cursor: pointer;
+  transition: box-shadow var(--duration-fast) var(--easing-out);
+}
+
+.og-checkbox__input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(63, 125, 58, 0.28);
+  border-radius: 0.25rem;
+}
+
+.og-checkbox__input:disabled {
+  cursor: not-allowed;
+}
+
+.og-checkbox__text {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.og-checkbox__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.og-checkbox__description {
+  color: var(--color-neutral-600);
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+.og-checkbox--disabled .og-checkbox__label {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.og-checkbox--error .og-checkbox__input {
+  accent-color: var(--color-error);
+}
+
+.og-checkbox__error {
+  margin: 0;
+  padding-left: 1.75rem;
+  color: var(--color-error);
+  font-size: 0.86rem;
+  line-height: 1.4;
 }
 
 /* ── Select ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Prep work ahead of the storefront. Landing two primitives the storefront will want on day one so the storefront PRs can stay focused on storefront logic instead of re-litigating button variants and hand-rolling checkbox a11y.

## What changed

- **`<Button variant=\"danger\">`** — adds `.og-button--danger`: red background (`var(--color-error)`), matching hover (`#dc2f2f`), and a red-tinted shadow. Inherits every existing Button transition (hover lift, disabled dim, loading spinner) — no new motion code since danger is a color variant, not a behavior change.
- **`<Checkbox>`** — native `<input type=\"checkbox\">` with `accent-color: var(--og-color-moss)` and a focus ring that matches the `<Input>` / `<Textarea>` treatment (`box-shadow: 0 0 0 3px rgba(63, 125, 58, 0.28)` on `:focus-visible`). API: `label` (required, `ReactNode`), optional `description`, `error`, and every native `<input>` attribute forwarded. Disabled state dims and blocks the cursor. Error state flips the accent color to red.

## Why native checkbox, not a custom-styled one

A custom-styled checkbox (hidden input + SVG checkmark with `stroke-dashoffset` animation) looks nicer but pays a real tax: you re-implement keyboard handling, focus management, and screen-reader semantics that the native control gives you for free. Storefront checkboxes (terms agreement, shipping=billing, save card) are exactly the places where a11y failures hurt most. Shipping the native version means we get correct behavior immediately and can upgrade the visual in place — the primitive's API doesn't change.

## Animations

Kept tight and scoped to what a primitive genuinely owns. Button already had the right hover/transition system; danger inherits it. Checkbox gets a focus-ring transition that matches the other form fields. The bigger animations the storefront will want — cart item add/remove (FLIP layout), price-change flash, toast enter/exit, drawer/modal transitions — are page-level orchestration and belong in storefront code where they have context, not in a shared primitive.

## No consumers migrated

Deliberately kept the diff to the UI package. The admin app's two existing checkboxes will move to `<Checkbox>` alongside the [admin-ui-migration PR](https://github.com/allenheltondev/olivias-garden-foundation/pull/241) merge, and tomorrow's storefront work will be the first real use of `<Button variant=\"danger\">` (remove-from-cart, cancel-order).

## Reviewer notes

- **Build verified** across all three consumers (`@olivias/web`, `@olivias/grn`, `@olivias/admin`) via the usual sync-to-main-repo dance — `turbo run build --filter=...` was clean end-to-end for each.
- **Stacking:** this branch is cut from `main`, not from the admin-ui-migration branch, so it can merge independently. When admin-ui-migration rebases on top of this, its two raw `<input type=\"checkbox\">` usages can be swapped to `<Checkbox>` trivially.

## Test plan

- [ ] Render a `<Button variant=\"danger\">` — red fill, red-tinted shadow, hover lift works
- [ ] Render a `<Checkbox label=\"I agree\" />` — keyboard: Tab focuses (moss ring), Space toggles, click toggles
- [ ] `<Checkbox description=\"Optional context here\" />` shows the muted description under the label
- [ ] `<Checkbox error=\"Required to continue\" />` flips the box accent to red and shows the error line
- [ ] `<Checkbox disabled />` doesn't toggle on click/Space and the label dims

🤖 Generated with [Claude Code](https://claude.com/claude-code)