### PR TITLE
Fix admin access check, polish restricted screen, add app launcher to avatar menu

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -12,9 +12,10 @@ import {
 } from './api';
 import { loadAdminSession, type AdminSession } from './auth/session';
 
-const foundationLoginUrl = import.meta.env.VITE_FOUNDATION_URL
-  ? `${import.meta.env.VITE_FOUNDATION_URL.replace(/\/+$/, '')}/login`
-  : 'https://oliviasgarden.org/login';
+const foundationHomeUrl = import.meta.env.VITE_FOUNDATION_URL
+  ? import.meta.env.VITE_FOUNDATION_URL.replace(/\/+$/, '')
+  : 'https://oliviasgarden.org';
+const foundationLoginUrl = `${foundationHomeUrl}/login`;
 
 const emptyProductForm: UpsertStoreProductRequest = {
   slug: '',
@@ -117,7 +118,11 @@ export default function App() {
         <Card className="admin-restricted">
           <p className="admin-eyebrow">Restricted</p>
           <h1>Administrator access is required.</h1>
-          <p>This account is authenticated, but it does not carry the `admin` role in Cognito.</p>
+          <div className="admin-restricted__actions">
+            <Button onClick={() => window.location.assign(foundationHomeUrl)}>
+              Back to Olivia&apos;s Garden
+            </Button>
+          </div>
         </Card>
       </div>
     );

--- a/apps/admin/src/auth/session.ts
+++ b/apps/admin/src/auth/session.ts
@@ -7,31 +7,63 @@ export interface AdminSession {
   isAdmin: boolean;
 }
 
+function collectGroups(payload: Record<string, unknown>): unknown[] {
+  const raw = payload['cognito:groups'];
+  return Array.isArray(raw) ? raw : [];
+}
+
+function hasAdminGroup(groups: unknown[]): boolean {
+  return groups.some((group) => String(group).toLowerCase() === 'admin');
+}
+
+async function readSessionTokens(forceRefresh: boolean) {
+  const session = await fetchAuthSession(forceRefresh ? { forceRefresh: true } : undefined);
+  return {
+    accessToken: session.tokens?.accessToken?.toString(),
+    accessPayload: (session.tokens?.accessToken?.payload ?? {}) as Record<string, unknown>,
+    idPayload: (session.tokens?.idToken?.payload ?? {}) as Record<string, unknown>,
+  };
+}
+
 export async function loadAdminSession(): Promise<AdminSession | null> {
   try {
     await getCurrentUser();
-    const session = await fetchAuthSession();
-    const accessToken = session.tokens?.accessToken?.toString();
-    const payload = (session.tokens?.accessToken?.payload ?? {}) as Record<string, unknown>;
+    let tokens = await readSessionTokens(false);
 
-    if (!accessToken) {
+    if (!tokens.accessToken) {
       return null;
     }
 
-    const groups = Array.isArray(payload['cognito:groups']) ? payload['cognito:groups'] : [];
+    let groups = [...collectGroups(tokens.accessPayload), ...collectGroups(tokens.idPayload)];
+
+    // If the token was minted before the user was added to the admin group,
+    // retry once with a forced refresh so recent role changes take effect.
+    if (!hasAdminGroup(groups)) {
+      try {
+        tokens = await readSessionTokens(true);
+        if (tokens.accessToken) {
+          groups = [...collectGroups(tokens.accessPayload), ...collectGroups(tokens.idPayload)];
+        }
+      } catch {
+        // fall through with the original token state
+      }
+    }
+
+    const payload = tokens.accessPayload;
     const email =
       typeof payload.email === 'string'
         ? payload.email
         : typeof payload.username === 'string'
           ? payload.username
-          : null;
+          : typeof tokens.idPayload.email === 'string'
+            ? (tokens.idPayload.email as string)
+            : null;
 
     return {
-      accessToken,
+      accessToken: tokens.accessToken!,
       email,
       isAdmin:
-        readRoleFromClaims({ 'cognito:groups': groups }) === 'admin' ||
-        groups.some((group) => String(group).toLowerCase() === 'admin'),
+        readRoleFromClaims({ 'cognito:groups': groups }) === 'admin' || hasAdminGroup(groups),
     };
   } catch {
     return null;

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -130,6 +130,12 @@ body {
   line-height: 1.1;
 }
 
+.admin-restricted__actions {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: flex-start;
+}
+
 .submission-meta,
 .store-header {
   display: flex;

--- a/apps/web/src/auth/session.ts
+++ b/apps/web/src/auth/session.ts
@@ -5,6 +5,7 @@ export interface AuthUser {
   firstName: string | null;
   lastName: string | null;
   tier: string | null;
+  isAdmin: boolean;
 }
 
 export interface AuthSession {
@@ -48,6 +49,12 @@ function deriveTier(claims: Record<string, unknown> | null): string | null {
   return firstString(claims.tier);
 }
 
+function deriveIsAdmin(claims: Record<string, unknown> | null): boolean {
+  if (!claims) return false;
+  const groups = claims['cognito:groups'];
+  return Array.isArray(groups) && groups.some((group) => String(group).toLowerCase() === 'admin');
+}
+
 export function buildAuthSession(tokens: {
   access_token: string;
   id_token: string;
@@ -69,6 +76,7 @@ export function buildAuthSession(tokens: {
       firstName: firstString(claims?.given_name),
       lastName: firstString(claims?.family_name),
       tier: deriveTier(claims),
+      isAdmin: deriveIsAdmin(claims),
     },
   };
 }
@@ -80,12 +88,14 @@ export function readStoredSession(): AuthSession | null {
     const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as AuthSession;
+    const claims = decodeJwtPayload(parsed.idToken);
     return {
       ...parsed,
       user: {
         ...parsed.user,
         firstName: parsed.user?.firstName ?? null,
         lastName: parsed.user?.lastName ?? null,
+        isAdmin: parsed.user?.isAdmin ?? deriveIsAdmin(claims),
       },
     };
   } catch {

--- a/apps/web/src/auth/vite-env.d.ts
+++ b/apps/web/src/auth/vite-env.d.ts
@@ -3,6 +3,7 @@ interface ImportMetaEnv {
   readonly VITE_AUTH_USER_POOL_CLIENT_ID?: string;
   readonly VITE_AUTH_USER_POOL_DOMAIN?: string;
   readonly VITE_GRN_URL?: string;
+  readonly VITE_ADMIN_URL?: string;
   readonly VITE_SITE_URL?: string;
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   readonly VITE_WEB_API_BASE?: string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1778,6 +1778,25 @@ html {
   outline: none;
 }
 
+.og-auth-menu__item--link {
+  display: block;
+  text-decoration: none;
+}
+
+.og-auth-menu__section-label {
+  padding: 0.55rem 0.85rem 0.2rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8a6a4a;
+}
+
+.og-auth-menu__divider {
+  height: 1px;
+  margin: 0.35rem 0.5rem;
+  background: rgba(58, 42, 29, 0.12);
+}
+
 .profile-hero {
   min-height: auto;
 }

--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -2,20 +2,43 @@ import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from 're
 import { Button, SiteFooter as SharedSiteFooter, SiteHeader as SharedSiteHeader } from '@olivias/ui';
 import type { AuthSession } from '../auth/session';
 import type { AppRoute } from './routes';
-import { facebookUrl, footerRoutes, goodRootsNetworkUrl, instagramUrl, navRoutes } from './routes';
+import { adminUrl, facebookUrl, footerRoutes, goodRootsNetworkUrl, instagramUrl, navRoutes } from './routes';
+
+function buildCrossAppUrl(targetUrl: string, session: AuthSession) {
+  try {
+    const target = new URL(targetUrl);
+    const payload = btoa(JSON.stringify({
+      accessToken: session.accessToken,
+      idToken: session.idToken,
+      refreshToken: session.refreshToken,
+      expiresAt: session.expiresAt,
+    }));
+    return `${target.origin}${target.pathname}${target.search}#session=${payload}`;
+  } catch {
+    return targetUrl;
+  }
+}
 
 const foundationLogo = '/images/icons/logo.svg';
+
+interface AvatarAppLink {
+  id: string;
+  label: string;
+  href: string;
+}
 
 function AvatarMenu({
   initials,
   label,
   avatarUrl,
+  appLinks,
   onNavigate,
   onLogout,
 }: {
   initials: string;
   label: string;
   avatarUrl?: string | null;
+  appLinks: AvatarAppLink[];
   onNavigate: (path: string) => void;
   onLogout?: () => void;
 }) {
@@ -74,6 +97,23 @@ function AvatarMenu({
           >
             Profile
           </button>
+          {appLinks.length > 0 ? (
+            <>
+              <div className="og-auth-menu__section-label" role="presentation">Apps</div>
+              {appLinks.map((link) => (
+                <a
+                  key={link.id}
+                  className="og-auth-menu__item og-auth-menu__item--link"
+                  role="menuitem"
+                  href={link.href}
+                  onClick={() => setOpen(false)}
+                >
+                  {link.label}
+                </a>
+              ))}
+              <div className="og-auth-menu__divider" role="separator" />
+            </>
+          ) : null}
           {onLogout ? (
             <button
               type="button"
@@ -182,6 +222,12 @@ export function SiteHeader({
               initials={initials}
               label={avatarLabel}
               avatarUrl={avatarUrl}
+              appLinks={[
+                { id: 'grn', label: 'Good Roots Network', href: buildCrossAppUrl(goodRootsNetworkUrl, authSession) },
+                ...(authSession.user.isAdmin
+                  ? [{ id: 'admin', label: 'Admin', href: buildCrossAppUrl(adminUrl, authSession) }]
+                  : []),
+              ]}
               onNavigate={onNavigate}
               onLogout={onLogout}
             />

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -104,6 +104,7 @@ export const prerenderRoutes = routes.filter((route) => route.prerender);
 export const internalPaths = new Set(routes.map((route) => route.path));
 
 export const goodRootsNetworkUrl = import.meta.env.VITE_GRN_URL || 'https://goodroots.network';
+export const adminUrl = import.meta.env.VITE_ADMIN_URL || 'https://admin.oliviasgarden.org';
 export const instagramUrl = 'https://instagram.com/oliviasgardentx';
 export const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
 export const siteUrl = (import.meta.env.VITE_SITE_URL ?? 'https://oliviasgarden.org').replace(/\/+$/, '');


### PR DESCRIPTION
## Summary
- Admin app: read `cognito:groups` from both the access and ID token, with a one-shot `forceRefresh` retry so a user newly added to the admin group isn't blocked by a stale cached token.
- Admin app: the "Administrator access is required" screen no longer leaks the Cognito implementation detail and now shows a themed "Back to Olivia's Garden" button that routes to `VITE_FOUNDATION_URL`.
- Web app: avatar menu gains an **Apps** section with **Good Roots Network** (any signed-in user) and **Admin** (admin group only). Both links embed the current session via the existing `#session=<payload>` fragment so the target app lands authenticated without a round-trip through `/login`.
- `AuthUser` now carries an `isAdmin` flag derived from `cognito:groups`; stored sessions are upgraded lazily on read, and a new `VITE_ADMIN_URL` env (defaults to `https://admin.oliviasgarden.org`) drives the admin link target.

## Why
Allen reported that his admin-group user was hitting the restricted screen on `admin.oliviasgarden.org` in prod, and the message was leaking Cognito internals. The force-refresh path covers the common case of "added to the group after my token was minted," and reading both tokens hardens against user-pool configs where `cognito:groups` only appears on one. The avatar-menu additions make the admin and GRN entry points reachable without hand-typing subdomains.

## Test plan
- [ ] Verify admin.oliviasgarden.org now lets the admin-group user in (force refresh should pick up the group).
- [ ] Verify a non-admin user sees the new restricted screen with the themed "Back to Olivia's Garden" button and no Cognito wording.
- [ ] Signed-in user on oliviasgarden.org sees Good Roots Network in the avatar menu; clicking lands them authed in the GRN app.
- [ ] Admin-group user additionally sees an Admin entry; clicking lands them authed in the admin app.
- [ ] Non-signed-in user sees no avatar menu (unchanged behavior).

## Follow-ups (not in this PR)
- Replace the header "Good Roots Network" nav link with a new marketing page that introduces what GRN is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)