### PR TITLE
Add organization grower support to GRN

### DIFF
--- a/apps/grn/src/components/Onboarding/GrowerWizard.test.tsx
+++ b/apps/grn/src/components/Onboarding/GrowerWizard.test.tsx
@@ -78,6 +78,56 @@ describe('GrowerWizard', () => {
           homeZone: '8a',
           address: '123 Main St, Springfield, IL',
           shareRadiusMiles: 5,
+          isOrganization: false,
+        })
+      );
+    });
+  });
+
+  it('requires organization name for organization growers', async () => {
+    render(<GrowerWizard onComplete={mockOnComplete} />);
+
+    fireEvent.change(screen.getByLabelText(/Address/i), {
+      target: { value: '123 Main St, Springfield, IL' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    fireEvent.change(await screen.findByLabelText(/USDA Hardiness Zone/i), {
+      target: { value: '8a' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    fireEvent.click(screen.getByLabelText(/We are growing as an organization/i));
+    fireEvent.click(await screen.findByRole('button', { name: /complete setup/i }));
+
+    expect(await screen.findByText('Organization name is required')).toBeInTheDocument();
+    expect(mockOnComplete).not.toHaveBeenCalled();
+  });
+
+  it('submits organization grower data', async () => {
+    render(<GrowerWizard onComplete={mockOnComplete} />);
+
+    fireEvent.change(screen.getByLabelText(/Address/i), {
+      target: { value: '800 Community Garden Way, Austin, TX 78701' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    fireEvent.change(await screen.findByLabelText(/USDA Hardiness Zone/i), {
+      target: { value: '8a' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    fireEvent.click(screen.getByLabelText(/We are growing as an organization/i));
+    fireEvent.change(screen.getByLabelText(/Organization name/i), {
+      target: { value: 'North Austin Community Garden' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /complete setup/i }));
+
+    await waitFor(() => {
+      expect(mockOnComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isOrganization: true,
+          organizationName: 'North Austin Community Garden',
         })
       );
     });

--- a/apps/grn/src/components/Onboarding/GrowerWizard.tsx
+++ b/apps/grn/src/components/Onboarding/GrowerWizard.tsx
@@ -14,6 +14,8 @@ interface FormData {
   homeZone: string;
   address: string;
   shareRadiusMiles: number;
+  isOrganization: boolean;
+  organizationName: string;
   units: 'metric' | 'imperial';
   locale: string;
 }
@@ -22,6 +24,7 @@ interface ValidationErrors {
   homeZone?: string;
   location?: string;
   shareRadiusMiles?: string;
+  organizationName?: string;
 }
 
 async function reverseGeocode(latitude: number, longitude: number): Promise<string | null> {
@@ -63,6 +66,8 @@ export function GrowerWizard({ onComplete, onBack }: GrowerWizardProps) {
     homeZone: '',
     address: '',
     shareRadiusMiles: 5,
+    isOrganization: false,
+    organizationName: '',
     units: 'imperial',
     locale: navigator.language || 'en-US',
   });
@@ -164,6 +169,10 @@ export function GrowerWizard({ onComplete, onBack }: GrowerWizardProps) {
       newErrors.shareRadiusMiles = 'Share radius must be 100 or less';
     }
 
+    if (formData.isOrganization && !formData.organizationName.trim()) {
+      newErrors.organizationName = 'Organization name is required';
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -208,6 +217,8 @@ export function GrowerWizard({ onComplete, onBack }: GrowerWizardProps) {
         homeZone: formData.homeZone.trim(),
         address: formData.address.trim(),
         shareRadiusMiles: formData.shareRadiusMiles,
+        isOrganization: formData.isOrganization,
+        organizationName: formData.organizationName.trim() || undefined,
         units: formData.units,
         locale: formData.locale,
       };
@@ -342,6 +353,55 @@ export function GrowerWizard({ onComplete, onBack }: GrowerWizardProps) {
             </div>
 
             <div className="space-y-4">
+              <div className="rounded-base border border-neutral-200 bg-white p-4">
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={formData.isOrganization}
+                    onChange={(e) => {
+                      const isOrganization = e.target.checked;
+                      setFormData((prev) => ({
+                        ...prev,
+                        isOrganization,
+                        organizationName: isOrganization ? prev.organizationName : '',
+                      }));
+                      if (errors.organizationName) {
+                        setErrors((prev) => ({ ...prev, organizationName: undefined }));
+                      }
+                    }}
+                    className="mt-1 h-4 w-4 rounded border-neutral-300 text-primary-600"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium text-neutral-900">
+                      We are growing as an organization
+                    </span>
+                    <span className="block text-sm text-neutral-600">
+                      Use this for community gardens, schools, churches, food pantries, and other groups sharing surplus together.
+                    </span>
+                  </span>
+                </label>
+              </div>
+
+              {formData.isOrganization && (
+                <Input
+                  label="Organization name"
+                  type="text"
+                  value={formData.organizationName}
+                  onChange={(e) => {
+                    setFormData((prev) => ({
+                      ...prev,
+                      organizationName: e.target.value,
+                    }));
+                    if (errors.organizationName) {
+                      setErrors((prev) => ({ ...prev, organizationName: undefined }));
+                    }
+                  }}
+                  placeholder="North Austin Community Garden"
+                  error={errors.organizationName}
+                  required
+                />
+              )}
+
               <div>
                 <label className="text-sm font-medium text-neutral-700 mb-2 block">
                   Share Radius

--- a/apps/grn/src/components/Onboarding/UserTypeSelection.test.tsx
+++ b/apps/grn/src/components/Onboarding/UserTypeSelection.test.tsx
@@ -26,6 +26,9 @@ describe('UserTypeSelection', () => {
       screen.getByText(/I grow food and want to share my surplus/)
     ).toBeInTheDocument();
     expect(
+      screen.getByText(/shared organization plot/i)
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(/I'm looking for locally grown food/)
     ).toBeInTheDocument();
   });

--- a/apps/grn/src/components/Onboarding/UserTypeSelection.tsx
+++ b/apps/grn/src/components/Onboarding/UserTypeSelection.tsx
@@ -115,7 +115,7 @@ export function UserTypeSelection({ onSelect }: UserTypeSelectionProps) {
               {/* Description */}
               <p className="text-neutral-600 text-sm leading-relaxed">
                 I grow food and want to share my surplus with the community.
-                I'll post what's available from my garden.
+                This can be my own garden or a shared organization plot.
               </p>
 
               {/* Selected Indicator */}

--- a/apps/grn/src/components/Profile/ProfileView.tsx
+++ b/apps/grn/src/components/Profile/ProfileView.tsx
@@ -137,7 +137,12 @@ export function ProfileView() {
   const phaseLabel = profile.userType === 'gatherer'
     ? 'Phase 2: Search and Request Flow'
     : 'Phase 1: Grower Listing Flow';
-  const roleLabel = profile.userType === 'gatherer' ? 'Gatherer' : 'Grower';
+  const isOrganizationGrower = profile.userType === 'grower' && profile.growerProfile?.isOrganization;
+  const roleLabel = profile.userType === 'gatherer'
+    ? 'Gatherer'
+    : isOrganizationGrower
+      ? 'Organization grower'
+      : 'Grower';
   const sectionItems = profile.userType === 'grower'
     ? [
         { id: 'profile-overview', label: 'Overview' },
@@ -176,6 +181,20 @@ export function ProfileView() {
       ),
     },
   ];
+
+  if (profile.userType === 'grower') {
+    overviewItems.push({
+      key: 'grower-type',
+      label: 'Grower setup',
+      value: (
+        <p className="text-gray-900">
+          {isOrganizationGrower
+            ? profile.growerProfile?.organizationName ?? 'Organization grower'
+            : 'Individual grower'}
+        </p>
+      ),
+    });
+  }
 
   return (
     <AppShell>

--- a/apps/grn/src/hooks/useOnboarding.test.ts
+++ b/apps/grn/src/hooks/useOnboarding.test.ts
@@ -23,6 +23,33 @@ describe('useOnboarding', () => {
         homeZone: '8a',
         address: '123 Main St, Springfield, IL',
         shareRadiusMiles: 5.0,
+        isOrganization: false,
+        organizationName: undefined,
+        units: 'imperial' as const,
+        locale: 'en-US',
+      };
+
+      vi.mocked(api.updateMe).mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useOnboarding());
+
+      await act(async () => {
+        await result.current.submitGrowerProfile(profileInput);
+      });
+
+      expect(api.updateMe).toHaveBeenCalledWith({
+        userType: 'grower',
+        growerProfile: profileInput,
+      });
+    });
+
+    it('submits organization grower profile details', async () => {
+      const profileInput = {
+        homeZone: '8a',
+        address: '800 Community Garden Way, Austin, TX 78701',
+        shareRadiusMiles: 12.0,
+        isOrganization: true,
+        organizationName: 'North Austin Community Garden',
         units: 'imperial' as const,
         locale: 'en-US',
       };

--- a/apps/grn/src/hooks/useOnboarding.ts
+++ b/apps/grn/src/hooks/useOnboarding.ts
@@ -18,6 +18,8 @@ export interface GrowerProfileInput {
   homeZone: string;
   address: string;
   shareRadiusMiles: number;
+  isOrganization: boolean;
+  organizationName?: string;
   units: 'metric' | 'imperial';
   locale: string;
 }
@@ -80,6 +82,7 @@ export function useOnboarding(onSuccess?: () => void) {
           homeZone: profileData.homeZone,
           hasAddress: !!profileData.address,
           shareRadiusMiles: profileData.shareRadiusMiles,
+          isOrganization: profileData.isOrganization,
         });
 
         const payload: UpdateUserProfileRequest = {

--- a/apps/grn/src/hooks/useUser.test.ts
+++ b/apps/grn/src/hooks/useUser.test.ts
@@ -31,6 +31,7 @@ describe('useUser', () => {
       lat: 37.7749,
       lng: -122.4194,
       shareRadiusMiles: 5.0,
+      isOrganization: false,
       units: 'imperial',
       locale: 'en-US',
     },
@@ -87,6 +88,7 @@ describe('useUser', () => {
     expect(result.current.user?.growerProfile).toBeDefined();
     expect(result.current.user?.growerProfile?.homeZone).toBe('8a');
     expect(result.current.user?.growerProfile?.shareRadiusMiles).toBe(5.0);
+    expect(result.current.user?.growerProfile?.isOrganization).toBe(false);
     expect(result.current.user?.gathererProfile).toBeNull();
   });
 

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -147,6 +147,8 @@ export interface UpdateUserProfileRequest {
     homeZone: string;
     address: string;
     shareRadiusMiles: number;
+    isOrganization?: boolean;
+    organizationName?: string;
     units: GrowerProfile['units'];
     locale: string;
   };

--- a/apps/grn/src/types/user.test.ts
+++ b/apps/grn/src/types/user.test.ts
@@ -21,6 +21,7 @@ describe('User Types', () => {
         lat: 37.7749,
         lng: -122.4194,
         shareRadiusMiles: 5.0,
+        isOrganization: false,
         units: 'imperial',
         locale: 'en-US',
       };
@@ -38,6 +39,7 @@ describe('User Types', () => {
         lat: 37.7749,
         lng: -122.4194,
         shareRadiusMiles: 5.0,
+        isOrganization: false,
         units: 'metric',
         locale: 'en-US',
         createdAt: '2024-01-15T10:30:00Z',
@@ -46,6 +48,24 @@ describe('User Types', () => {
 
       expect(profile.createdAt).toBeDefined();
       expect(profile.updatedAt).toBeDefined();
+    });
+
+    it('should accept organization grower metadata', () => {
+      const profile: GrowerProfile = {
+        homeZone: '8a',
+        address: '800 Community Garden Way, Austin, TX 78701',
+        geoKey: '9q8yy9',
+        lat: 30.2672,
+        lng: -97.7431,
+        shareRadiusMiles: 12.0,
+        isOrganization: true,
+        organizationName: 'North Austin Community Garden',
+        units: 'imperial',
+        locale: 'en-US',
+      };
+
+      expect(profile.isOrganization).toBe(true);
+      expect(profile.organizationName).toBe('North Austin Community Garden');
     });
   });
 
@@ -113,6 +133,7 @@ describe('User Types', () => {
           lat: 37.7749,
           lng: -122.4194,
           shareRadiusMiles: 5.0,
+          isOrganization: false,
           units: 'imperial',
           locale: 'en-US',
         },

--- a/apps/grn/src/types/user.ts
+++ b/apps/grn/src/types/user.ts
@@ -18,6 +18,8 @@ export interface GrowerProfile {
   lat?: number;
   lng?: number;
   shareRadiusMiles: number;
+  isOrganization: boolean;
+  organizationName?: string;
   units: 'metric' | 'imperial';
   locale: string;
   createdAt?: string;

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -610,7 +610,7 @@ function OrganizationInquiryForm() {
 
       setFeedback({
         type: 'success',
-        message: "Thanks. We'll be in touch within a few days to get your organization verified and your team set up with free Pro access.",
+        message: "Thanks. We'll be in touch within a few days to help you get your organization set up in Good Roots Network.",
       });
       setOrgName('');
       setContactName('');
@@ -895,26 +895,23 @@ export function GoodRootsPage({
       <Section
         id="organizations"
         title="Feeding a community? Let's make it easier."
-        intro="Community gardens, schools, churches, food pantries, shelters, and mutual-aid groups can now join Good Roots directly as growers or gatherers. If your team is coordinating larger-volume pickups or shared community plots, we'll help verify your organization and get the right setup in place."
+        intro="Community gardens, schools, churches, food pantries, shelters, and mutual-aid groups can now join Good Roots directly as growers or gatherers. If you're coordinating shared community plots or regular local pickups, we'll help you choose the right starting setup."
         className="good-roots-orgs-section"
       >
         <div className="good-roots-orgs">
-          <Card title="What organizations get" className="good-roots-orgs__perks">
+          <Card title="How organizations can use Good Roots" className="good-roots-orgs__perks">
             <ul className="site-list">
               <li>Grower onboarding for shared gardens and community plots</li>
               <li>Organization name visible in the app for grower accounts</li>
-              <li>Verified organization badge for larger recipient operations</li>
-              <li>Bulk claim requests across multiple growers</li>
-              <li>Recurring pickup scheduling</li>
-              <li>Free Pro access for the whole team</li>
-              <li>Light-touch onboarding — we'll walk you through it</li>
+              <li>Gatherer onboarding for food pantries, shelters, schools, and mutual-aid groups</li>
+              <li>Direct coordination with local growers through the existing listing flow</li>
+              <li>Light-touch onboarding guidance from our team when you need it</li>
             </ul>
           </Card>
           <Card title="Apply for organization access" className="good-roots-orgs__form">
             <p className="contact-card__eyebrow">Tell us about your org</p>
             <p>
-              Share a few details and we'll reach out to verify your organization and get your team set up
-              with free Pro access.
+              Share a few details and we'll reach out to help you get set up in the right role for how your organization participates.
             </p>
             <OrganizationInquiryForm />
           </Card>

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -800,13 +800,15 @@ export function GoodRootsPage({
             <p>
               Most home gardens end in a pile of zucchini no one can keep up with. Good Roots helps you plan
               around what your community actually needs — and turns surplus into something your neighbors
-              will thank you for. Track your beds, set watering and harvest reminders, and watch your little
-              patch of ground become part of something bigger.
+              will thank you for. Whether you're growing at home, on church land, at a school, or in a
+              community garden, you can join as a grower, track your beds, set watering and harvest reminders,
+              and watch your patch of ground become part of something bigger.
             </p>
             <ul className="site-list">
               <li>Garden planner with what-to-plant-when</li>
               <li>Watering, fertilizer, and harvest reminders</li>
               <li>Listings for surplus produce</li>
+              <li>Organization growers can show who they grow on behalf of</li>
               <li>A running picture of what's growing nearby</li>
             </ul>
           </div>
@@ -893,13 +895,15 @@ export function GoodRootsPage({
       <Section
         id="organizations"
         title="Feeding a community? Let's make it easier."
-        intro="Food pantries, shelters, school programs, and mutual-aid groups can create a verified organization account to claim larger volumes, coordinate recurring pickups, and show up in growers' feeds as a priority recipient. We'll waive Pro fees for verified nonprofits — your work shouldn't cost extra."
+        intro="Community gardens, schools, churches, food pantries, shelters, and mutual-aid groups can now join Good Roots directly as growers or gatherers. If your team is coordinating larger-volume pickups or shared community plots, we'll help verify your organization and get the right setup in place."
         className="good-roots-orgs-section"
       >
         <div className="good-roots-orgs">
           <Card title="What organizations get" className="good-roots-orgs__perks">
             <ul className="site-list">
-              <li>Verified organization badge on your profile</li>
+              <li>Grower onboarding for shared gardens and community plots</li>
+              <li>Organization name visible in the app for grower accounts</li>
+              <li>Verified organization badge for larger recipient operations</li>
               <li>Bulk claim requests across multiple growers</li>
               <li>Recurring pickup scheduling</li>
               <li>Free Pro access for the whole team</li>

--- a/postman/collections/Good Roots Network API - Utility Tests/Idempotency/PUT Me - First Call.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Idempotency/PUT Me - First Call.request.yaml
@@ -17,7 +17,15 @@ body:
   content: |-
     {
       "displayName": "Idempotency Test User",
-      "userType": "grower"
+      "userType": "grower",
+      "growerProfile": {
+        "homeZone": "8a",
+        "address": "123 Test St, Austin, TX 78701",
+        "shareRadiusMiles": 5,
+        "isOrganization": false,
+        "units": "imperial",
+        "locale": "en-US"
+      }
     }
 scripts:
   - type: afterResponse

--- a/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/PUT Me - Org Grower Missing Organization Name.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/PUT Me - Org Grower Missing Organization Name.request.yaml
@@ -1,11 +1,11 @@
 $kind: http-request
-name: 'PUT /me - Negative shareRadiusMiles'
+name: 'PUT /me - Org Grower Missing Organization Name'
 description: |-
-  Sends a PUT /me request with `shareRadiusMiles` set to -1 in the grower profile.
-  Expects a 400 status code because shareRadiusMiles must be greater than 0.
+  Sends a PUT /me request for an organization grower without `organizationName`.
+  Expects a 400 status code because organization growers must provide a name.
 method: PUT
 url: '{{baseUrl}}/me'
-order: 6000
+order: 6500
 headers:
   - key: Authorization
     value: 'Bearer {{premiumAuthToken}}'
@@ -15,14 +15,13 @@ body:
   type: json
   content: |-
     {
-      "displayName": "Negative Path Test User",
+      "displayName": "Org Grower Validation Test",
       "userType": "grower",
       "growerProfile": {
         "homeZone": "8a",
         "address": "123 Test St, Austin, TX 78701",
-        "shareRadiusMiles": -1,
+        "shareRadiusMiles": 10,
         "isOrganization": true,
-        "organizationName": "Negative Path Garden",
         "units": "imperial",
         "locale": "en-US"
       }
@@ -35,7 +34,8 @@ scripts:
           pm.response.to.have.status(400);
       });
 
-      pm.test("Response contains error property", function () {
+      pm.test("Response error mentions organizationName", function () {
           const body = pm.response.json();
           pm.expect(body).to.have.property("error");
+          pm.expect(body.error).to.include("organizationName");
       });

--- a/postman/collections/Good Roots Network API/Profile Smoke/1 - Update Current User.request.yaml
+++ b/postman/collections/Good Roots Network API/Profile Smoke/1 - Update Current User.request.yaml
@@ -23,6 +23,8 @@ body:
         "homeZone": "US-TX-Austin",
         "address": "1100 Congress Ave, Austin, TX 78701",
         "shareRadiusMiles": 15,
+        "isOrganization": true,
+        "organizationName": "Profile Smoke Garden Team",
         "units": "imperial",
         "locale": "en-US"
       }

--- a/postman/collections/Good Roots Network API/Profile Smoke/3 - Get Current User.request.yaml
+++ b/postman/collections/Good Roots Network API/Profile Smoke/3 - Get Current User.request.yaml
@@ -146,6 +146,15 @@ scripts:
           }
       });
 
+      pm.test("growerProfile organization fields are present and reflect org-grower onboarding", function () {
+          if (jsonData.growerProfile !== null) {
+              pm.expect(jsonData.growerProfile).to.have.property("isOrganization");
+              pm.expect(jsonData.growerProfile.isOrganization).to.eql(true);
+              pm.expect(jsonData.growerProfile).to.have.property("organizationName");
+              pm.expect(jsonData.growerProfile.organizationName).to.eql("Profile Smoke Garden Team");
+          }
+      });
+
       pm.test("seasonalTimeline is an array when present", function () {
           if (jsonData.seasonalTimeline !== undefined) {
               pm.expect(Array.isArray(jsonData.seasonalTimeline)).to.eql(true);

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -231,12 +231,20 @@ create table if not exists grower_profiles (
   lat double precision,
   lng double precision,
   share_radius_km double precision not null default 5.0,
+  is_organization boolean not null default false,
+  organization_name text,
   units units_system not null default 'imperial',
   locale text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint grower_profiles_radius_positive check (share_radius_km > 0),
   constraint grower_profiles_address_nonempty check (address is null or length(btrim(address)) > 0),
+  constraint grower_profiles_organization_name_nonempty check (
+    organization_name is null or length(btrim(organization_name)) > 0
+  ),
+  constraint grower_profiles_organization_requires_name check (
+    is_organization = false or organization_name is not null
+  ),
   constraint grower_profiles_lat_lng_pair check (
     (lat is null and lng is null) or (lat is not null and lng is not null)
   )

--- a/services/grn-api/db/migrations/0027_org_grower_profiles.sql
+++ b/services/grn-api/db/migrations/0027_org_grower_profiles.sql
@@ -1,0 +1,34 @@
+-- Adds optional organization metadata for grower onboarding without
+-- introducing a new user_type. Organizations can participate as growers.
+
+alter table grower_profiles
+  add column if not exists is_organization boolean not null default false;
+
+alter table grower_profiles
+  add column if not exists organization_name text;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'grower_profiles_organization_name_nonempty'
+  ) then
+    alter table grower_profiles
+      add constraint grower_profiles_organization_name_nonempty
+      check (organization_name is null or length(btrim(organization_name)) > 0);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'grower_profiles_organization_requires_name'
+  ) then
+    alter table grower_profiles
+      add constraint grower_profiles_organization_requires_name
+      check (is_organization = false or organization_name is not null);
+  end if;
+end $$;

--- a/services/grn-api/openapi/schemas/profile.yaml
+++ b/services/grn-api/openapi/schemas/profile.yaml
@@ -132,6 +132,11 @@ GrowerProfile:
       nullable: true
     shareRadiusMiles:
       type: string
+    isOrganization:
+      type: boolean
+    organizationName:
+      type: string
+      nullable: true
     units:
       type: string
       enum: [imperial, metric]
@@ -151,6 +156,12 @@ GrowerProfileInput:
       type: number
       format: double
       exclusiveMinimum: 0
+    isOrganization:
+      type: boolean
+      default: false
+    organizationName:
+      type: string
+      nullable: true
     units:
       type: string
       enum: [imperial, metric]

--- a/services/grn-api/src/api/handlers/user.rs
+++ b/services/grn-api/src/api/handlers/user.rs
@@ -159,6 +159,12 @@ async fn upsert_grower_profile(
 ) -> Result<(), lambda_http::Error> {
     let address = location::normalize_address(&profile.address);
     let geocoded = location::geocode_address(&address, correlation_id).await?;
+    let organization_name = profile
+        .organization_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
 
     let share_radius_km = miles_to_km(profile.share_radius_miles);
 
@@ -166,9 +172,9 @@ async fn upsert_grower_profile(
         .execute(
             "
             insert into grower_profiles
-                (user_id, home_zone, address, geo_key, lat, lng, share_radius_km, units, locale)
+                (user_id, home_zone, address, geo_key, lat, lng, share_radius_km, is_organization, organization_name, units, locale)
             values
-                ($1, $2, $3, $4, $5, $6, $7, coalesce($8::text::units_system, 'imperial'::units_system), $9)
+                ($1, $2, $3, $4, $5, $6, $7, $8, $9, coalesce($10::text::units_system, 'imperial'::units_system), $11)
             on conflict (user_id) do update
             set home_zone = excluded.home_zone,
                 address = excluded.address,
@@ -176,6 +182,8 @@ async fn upsert_grower_profile(
                 lat = excluded.lat,
                 lng = excluded.lng,
                 share_radius_km = excluded.share_radius_km,
+                is_organization = excluded.is_organization,
+                organization_name = excluded.organization_name,
                 units = excluded.units,
                 locale = excluded.locale,
                 updated_at = now()
@@ -188,6 +196,8 @@ async fn upsert_grower_profile(
                 &geocoded.lat,
                 &geocoded.lng,
                 &share_radius_km,
+                &profile.is_organization,
+                &organization_name,
                 &profile.units,
                 &profile.locale,
             ],
@@ -362,6 +372,19 @@ fn validate_put_me_payload(payload: &PutMeRequest) -> Result<(), lambda_http::Er
         if grower.address.trim().is_empty() {
             return Err(lambda_http::Error::from("address is required".to_string()));
         }
+
+        if grower.is_organization {
+            let has_organization_name = grower
+                .organization_name
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty());
+
+            if !has_organization_name {
+                return Err(lambda_http::Error::from(
+                    "organizationName is required when isOrganization is true".to_string(),
+                ));
+            }
+        }
     }
 
     if let Some(gatherer) = &payload.gatherer_profile {
@@ -518,7 +541,7 @@ async fn load_grower_profile(
 ) -> Result<Option<GrowerProfile>, lambda_http::Error> {
     let row = client
         .query_opt(
-            "select home_zone, address, geo_key, lat, lng, share_radius_km::text as share_radius_km, units::text as units, locale from grower_profiles where user_id = $1",
+            "select home_zone, address, geo_key, lat, lng, share_radius_km::text as share_radius_km, is_organization, organization_name, units::text as units, locale from grower_profiles where user_id = $1",
             &[&user_id],
         )
         .await
@@ -535,6 +558,8 @@ async fn load_grower_profile(
             .get::<_, Option<f64>>("lng")
             .map(location::round_for_response),
         share_radius_miles: km_text_to_miles_text(&grower.get::<_, String>("share_radius_km")),
+        is_organization: grower.get("is_organization"),
+        organization_name: grower.get("organization_name"),
         units: grower.get("units"),
         locale: grower.get("locale"),
     }))
@@ -705,6 +730,8 @@ mod tests {
                 home_zone: "8a".to_string(),
                 address: "123 Main St".to_string(),
                 share_radius_miles: 5.0,
+                is_organization: false,
+                organization_name: None,
                 units: "imperial".to_string(),
                 locale: "en-US".to_string(),
             }),
@@ -757,6 +784,8 @@ mod tests {
                 home_zone: "8a".to_string(),
                 address: "   ".to_string(),
                 share_radius_miles: 5.0,
+                is_organization: false,
+                organization_name: None,
                 units: "imperial".to_string(),
                 locale: "en-US".to_string(),
             }),
@@ -803,6 +832,8 @@ mod tests {
                 home_zone: "8a".to_string(),
                 address: "123 Main St".to_string(),
                 share_radius_miles: 5.0,
+                is_organization: false,
+                organization_name: None,
                 units: "imperial".to_string(),
                 locale: "en-US".to_string(),
             }),
@@ -841,6 +872,8 @@ mod tests {
                 home_zone: "8a".to_string(),
                 address: "123 Main St".to_string(),
                 share_radius_miles: 5.0,
+                is_organization: false,
+                organization_name: None,
                 units: "imperial".to_string(),
                 locale: "en-US".to_string(),
             }),
@@ -848,6 +881,31 @@ mod tests {
         };
 
         assert!(should_mark_onboarding_complete(&payload));
+    }
+
+    #[test]
+    fn test_validate_org_grower_requires_organization_name() {
+        let payload = PutMeRequest {
+            display_name: Some("Community Garden".to_string()),
+            user_type: Some(UserType::Grower),
+            grower_profile: Some(GrowerProfileInput {
+                home_zone: "8a".to_string(),
+                address: "123 Main St".to_string(),
+                share_radius_miles: 5.0,
+                is_organization: true,
+                organization_name: Some("   ".to_string()),
+                units: "imperial".to_string(),
+                locale: "en-US".to_string(),
+            }),
+            gatherer_profile: None,
+        };
+
+        let result = validate_put_me_payload(&payload);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("organizationName is required"));
     }
 
     #[test]

--- a/services/grn-api/src/api/models/profile.rs
+++ b/services/grn-api/src/api/models/profile.rs
@@ -19,6 +19,8 @@ pub struct GrowerProfile {
     pub lat: Option<f64>,
     pub lng: Option<f64>,
     pub share_radius_miles: String,
+    pub is_organization: bool,
+    pub organization_name: Option<String>,
     pub units: String,
     pub locale: Option<String>,
 }
@@ -95,6 +97,9 @@ pub struct GrowerProfileInput {
     pub home_zone: String,
     pub address: String,
     pub share_radius_miles: f64,
+    #[serde(default)]
+    pub is_organization: bool,
+    pub organization_name: Option<String>,
     pub units: String,
     pub locale: String,
 }

--- a/services/grn-api/tests/get_me_integration_test.rs
+++ b/services/grn-api/tests/get_me_integration_test.rs
@@ -30,6 +30,8 @@ mod get_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusKm": "5.0",
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             },
@@ -62,6 +64,8 @@ mod get_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusKm": "5.0",
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             },
@@ -82,6 +86,8 @@ mod get_me_tests {
         assert!(grower_profile.get("lat").is_some());
         assert!(grower_profile.get("lng").is_some());
         assert!(grower_profile.get("shareRadiusKm").is_some());
+        assert!(grower_profile.get("isOrganization").is_some());
+        assert!(grower_profile.get("organizationName").is_some());
         assert!(grower_profile.get("units").is_some());
         assert!(grower_profile.get("locale").is_some());
     }
@@ -202,6 +208,8 @@ mod get_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusKm": "5.0",
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             },
@@ -253,6 +261,40 @@ mod get_me_tests {
         assert_eq!(
             gatherer_profile["organizationAffiliation"],
             "Community Food Bank"
+        );
+    }
+
+    #[test]
+    fn test_grower_with_organization_profile() {
+        let grower_with_org = json!({
+            "id": "550e8400-e29b-41d4-a716-446655440006",
+            "email": "garden@example.com",
+            "displayName": "Neighborhood Garden",
+            "isVerified": false,
+            "userType": "grower",
+            "onboardingCompleted": true,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "growerProfile": {
+                "homeZone": "8a",
+                "address": "800 Community Garden Way, Austin, TX 78701",
+                "geoKey": "9q8yy9m",
+                "lat": 30.2672,
+                "lng": -97.7431,
+                "shareRadiusKm": "12.0",
+                "isOrganization": true,
+                "organizationName": "North Austin Community Garden",
+                "units": "imperial",
+                "locale": "en-US"
+            },
+            "gathererProfile": null,
+            "ratingSummary": null
+        });
+
+        let grower_profile = &grower_with_org["growerProfile"];
+        assert_eq!(grower_profile["isOrganization"], true);
+        assert_eq!(
+            grower_profile["organizationName"],
+            "North Austin Community Garden"
         );
     }
 

--- a/services/grn-api/tests/put_me_integration_test.rs
+++ b/services/grn-api/tests/put_me_integration_test.rs
@@ -53,6 +53,8 @@ mod put_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusMiles": 5.0,
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             }
@@ -66,6 +68,8 @@ mod put_me_tests {
         assert_eq!(profile["lat"], 37.7749);
         assert_eq!(profile["lng"], -122.4194);
         assert_eq!(profile["shareRadiusMiles"], 5.0);
+        assert_eq!(profile["isOrganization"], false);
+        assert!(profile["organizationName"].is_null());
         assert_eq!(profile["units"], "imperial");
         assert_eq!(profile["locale"], "en-US");
 
@@ -83,6 +87,8 @@ mod put_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusMiles": "5.0",
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             },
@@ -218,6 +224,8 @@ mod put_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusMiles": 5.0,
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             }
@@ -237,6 +245,8 @@ mod put_me_tests {
                 "lat": 37.7749,
                 "lng": -122.4194,
                 "shareRadiusMiles": "5.0",
+                "isOrganization": false,
+                "organizationName": null,
                 "units": "imperial",
                 "locale": "en-US"
             },
@@ -265,6 +275,49 @@ mod put_me_tests {
 
         let profile = &invalid_request["growerProfile"];
         assert!(profile["shareRadiusMiles"].as_f64().unwrap() < 0.0);
+    }
+
+    #[test]
+    fn test_org_grower_profile_upsert() {
+        let grower_profile_request = json!({
+            "userType": "grower",
+            "growerProfile": {
+                "homeZone": "8a",
+                "address": "800 Community Garden Way, Austin, TX 78701",
+                "shareRadiusMiles": 12.0,
+                "isOrganization": true,
+                "organizationName": "North Austin Community Garden",
+                "units": "imperial",
+                "locale": "en-US"
+            }
+        });
+
+        let profile = &grower_profile_request["growerProfile"];
+        assert_eq!(profile["isOrganization"], true);
+        assert_eq!(profile["organizationName"], "North Austin Community Garden");
+
+        let expected_response = json!({
+            "userType": "grower",
+            "onboardingCompleted": true,
+            "growerProfile": {
+                "homeZone": "8a",
+                "address": "800 Community Garden Way, Austin, TX 78701",
+                "geoKey": "9q8yy9m",
+                "lat": 30.2672,
+                "lng": -97.7431,
+                "shareRadiusMiles": "12.0",
+                "isOrganization": true,
+                "organizationName": "North Austin Community Garden",
+                "units": "imperial",
+                "locale": "en-US"
+            }
+        });
+
+        assert_eq!(expected_response["growerProfile"]["isOrganization"], true);
+        assert_eq!(
+            expected_response["growerProfile"]["organizationName"],
+            "North Austin Community Garden"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add organization grower support to Good Roots Network without introducing a new user role
- extend the GRN onboarding flow, shared types, dashboard copy, and marketing copy so community gardens and other orgs can join as growers
- update the Rust API contract, migration, OpenAPI schema, and Postman coverage for org grower profile fields

## What Changed
- added `isOrganization` and `organizationName` to grower profiles in the API model and response handling
- added migration `0027_org_grower_profiles.sql` and updated `grower_profiles` DDL constraints
- updated GRN grower onboarding to capture organization growers and require an organization name when selected
- updated the profile view to show organization grower identity in-app
- tightened GRN marketing copy so it reflects the current shipped scope: organizations can participate as growers or gatherers today, without implying team management or verification workflows that are not yet implemented
- added/updated Rust tests, GRN tests, and Postman profile utility coverage for the new contract

## Validation
- `cargo check` in `services/grn-api`
- `cargo clippy -- -D warnings` in `services/grn-api`
- `cargo test` in `services/grn-api`
- `npm exec tsc -- --noEmit` in `apps/grn`

## Blockers / Notes
- `apps/grn` Vitest could not be run in this environment because `vitest.config.ts` hits a sandbox `spawn EPERM` from `esbuild`
- `npm run lint` in `apps/grn` still fails on pre-existing unrelated `react-hooks/set-state-in-effect` errors in `GrowerListingPanel.tsx`, `SearcherRequestPanel.tsx`, and `useAuth.ts`