### PR TITLE
Fix GRN postman failures: org-name 400 mapping, geocodable addresses, true idempotency check

### DIFF
--- a/postman/collections/Good Roots Network API - Utility Tests/Idempotency/PUT Me - First Call.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Idempotency/PUT Me - First Call.request.yaml
@@ -20,7 +20,7 @@ body:
       "userType": "grower",
       "growerProfile": {
         "homeZone": "8a",
-        "address": "123 Test St, Austin, TX 78701",
+        "address": "1100 Congress Ave, Austin, TX 78701",
         "shareRadiusMiles": 5,
         "isOrganization": false,
         "units": "imperial",

--- a/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/PUT Me - Org Grower Missing Organization Name.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/PUT Me - Org Grower Missing Organization Name.request.yaml
@@ -19,7 +19,7 @@ body:
       "userType": "grower",
       "growerProfile": {
         "homeZone": "8a",
-        "address": "123 Test St, Austin, TX 78701",
+        "address": "1100 Congress Ave, Austin, TX 78701",
         "shareRadiusMiles": 10,
         "isOrganization": true,
         "units": "imperial",

--- a/postman/collections/Good Roots Network API/Profile Smoke/2 - Update Current User - Idempotency Check.request.yaml
+++ b/postman/collections/Good Roots Network API/Profile Smoke/2 - Update Current User - Idempotency Check.request.yaml
@@ -27,6 +27,8 @@ body:
         "homeZone": "US-TX-Austin",
         "address": "1100 Congress Ave, Austin, TX 78701",
         "shareRadiusMiles": 15,
+        "isOrganization": true,
+        "organizationName": "Profile Smoke Garden Team",
         "units": "imperial",
         "locale": "en-US"
       }

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -291,6 +291,7 @@ fn map_api_error_to_response(
         || message.contains("radiusMiles")
         || message.contains("shareRadiusMiles")
         || message.contains("searchRadiusMiles")
+        || message.contains("organizationName")
         || message.contains("Gatherer profile location is required")
         || message.contains("Listing is not claimable")
         || message.contains("requestId must reference an open request")
@@ -406,6 +407,15 @@ mod tests {
     fn map_api_error_maps_request_needed_by_validation_to_400() {
         let error =
             lambda_http::Error::from("neededBy must be within the next 365 days".to_string());
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn map_api_error_maps_organization_name_validation_to_400() {
+        let error = lambda_http::Error::from(
+            "organizationName is required when isOrganization is true".to_string(),
+        );
         let response = map_api_error_to_response(&error).unwrap();
         assert_eq!(response.status().as_u16(), 400);
     }


### PR DESCRIPTION
## Summary

Three independent bugs from the org-grower additions in [#250](https://github.com/allenheltondev/olivias-garden-foundation/pull/250):

- **`PUT /me` returned 500 for missing `organizationName`** — the validator produced the right message, but the router's error→status map didn't include `organizationName` in its 400 substring list, so it fell through to the generic 500 branch. Added the substring in [router.rs:293](services/grn-api/src/api/router.rs:293) and a unit test.
- **`Idempotency / PUT /me - First Call` failed with 400 "Address could not be geocoded"** — the payload used `"123 Test St, Austin, TX 78701"` which Nominatim can't resolve. Swapped to `1100 Congress Ave, Austin, TX 78701` (the Texas State Capitol, already in use by Profile Smoke). Did the same to the `Org Grower Missing Organization Name` negative path so it exercises the validator like its description claims.
- **`Profile Smoke / Get Current User` saw `isOrganization=false`** — Step 2 was billed as "re-run with the exact same payload" but omitted `isOrganization`/`organizationName`. Because `GrowerProfileInput` has `#[serde(default)] pub is_organization: bool`, the missing field deserialized as `false` and the upsert silently reset the columns. Restored the org fields in Step 2 so it is a true idempotency repeat.

## Test plan

- [x] `cargo test --bin api` (169 passed, including new `map_api_error_maps_organization_name_validation_to_400`)
- [x] `cargo clippy --bin api -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Re-run the Postman collections on staging and confirm all four previously failing assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)