### PR TITLE
Restore foundation Cognito custom auth domain

### DIFF
--- a/infra/foundation-web/template.yaml
+++ b/infra/foundation-web/template.yaml
@@ -53,6 +53,7 @@ Globals:
     MemorySize: 512
 
 Conditions:
+  IsProdEnvironment: !Equals [!Ref EnvironmentName, 'prod']
   DeployCustomDomain: !And
     - !Not [!Equals [!Ref DomainName, '']]
     - !Not [!Equals [!Ref DomainHostedZoneId, '']]
@@ -62,6 +63,9 @@ Conditions:
   EnableGoogleOnClient: !And
     - !Condition EnableGoogleIdentityProvider
     - !Equals [!Ref EnableGoogleOnUserPoolClient, 'true']
+  EnableProdCognitoCustomDomain: !And
+    - !Condition IsProdEnvironment
+    - !Condition DeployCustomDomain
 
 Metadata:
   esbuild-properties: &esbuild-properties
@@ -221,11 +225,51 @@ Resources:
       Description: Pro tier users with pro foundation and GRN features
       Precedence: 1
 
+  FoundationUserPoolCustomDomainCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: EnableProdCognitoCustomDomain
+    Properties:
+      DomainName: !Sub 'auth.${DomainName}'
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: !Sub 'auth.${DomainName}'
+          HostedZoneId: !Ref DomainHostedZoneId
+
   FoundationUserPoolDomain:
     Type: AWS::Cognito::UserPoolDomain
     Properties:
       UserPoolId: !Ref FoundationUserPool
-      Domain: !Sub '${AWS::StackName}-auth-${AWS::AccountId}'
+      Domain: !If
+        - EnableProdCognitoCustomDomain
+        - !Sub 'auth.${DomainName}'
+        - !Sub '${AWS::StackName}-auth-${AWS::AccountId}'
+      ManagedLoginVersion: 2
+      CustomDomainConfig: !If
+        - EnableProdCognitoCustomDomain
+        - CertificateArn: !Ref FoundationUserPoolCustomDomainCertificate
+        - !Ref AWS::NoValue
+
+  FoundationUserPoolCustomDomainRecordA:
+    Type: AWS::Route53::RecordSet
+    Condition: EnableProdCognitoCustomDomain
+    Properties:
+      HostedZoneId: !Ref DomainHostedZoneId
+      Name: !Sub 'auth.${DomainName}'
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt FoundationUserPoolDomain.CloudFrontDistribution
+        HostedZoneId: Z2FDTNDATAQYW2
+
+  FoundationUserPoolCustomDomainRecordAAAA:
+    Type: AWS::Route53::RecordSet
+    Condition: EnableProdCognitoCustomDomain
+    Properties:
+      HostedZoneId: !Ref DomainHostedZoneId
+      Name: !Sub 'auth.${DomainName}'
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt FoundationUserPoolDomain.CloudFrontDistribution
+        HostedZoneId: Z2FDTNDATAQYW2
 
   FoundationGoogleIdentityProvider:
     Type: AWS::Cognito::UserPoolIdentityProvider
@@ -335,7 +379,7 @@ Resources:
   # asset (anything with a dot in the final segment) pass through
   # unchanged so /assets/*, /images/*, robots.txt, sitemap.xml etc. still
   # resolve. When the rewritten path has no snapshot in S3 the existing
-  # 403/404 → /index.html fallback still delivers the SPA shell.
+  # 403/404 â†’ /index.html fallback still delivers the SPA shell.
   WebFrontendRewriteFunction:
     Type: AWS::CloudFront::Function
     Properties:
@@ -668,6 +712,14 @@ Outputs:
 
   UserPoolDomain:
     Description: Cognito Hosted UI domain for the foundation web app.
-    Value: !Sub '${FoundationUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com'
+    Value: !If
+      - EnableProdCognitoCustomDomain
+      - !Sub 'auth.${DomainName}'
+      - !Sub '${FoundationUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com'
     Export:
       Name: OGF-UserPoolDomain
+
+  UserPoolDomainCloudFrontTarget:
+    Condition: EnableProdCognitoCustomDomain
+    Description: CloudFront distribution target for the Cognito custom domain alias.
+    Value: !GetAtt FoundationUserPoolDomain.CloudFrontDistribution


### PR DESCRIPTION
## Summary
Restore the prod-only Cognito custom auth domain path in foundation now that the import/export cleanup has already been deployed.

## What changed
- Re-add the prod-only `EnableProdCognitoCustomDomain` condition in `infra/foundation-web/template.yaml`
- Re-add the ACM certificate for `auth.${DomainName}`
- Re-enable the Cognito user pool custom domain configuration in prod
- Re-add the Route53 alias records for the Cognito custom auth domain
- Restore the `OGF-UserPoolDomain` output to publish `auth.${DomainName}` in prod
- Re-add the `UserPoolDomainCloudFrontTarget` output for the Cognito alias target

## Why
The temporary rollback PR removed the custom auth domain so foundation could deploy without hitting the old export dependency. That sequencing blocker has been cleared, so the custom auth domain can now be restored.

## Validation
- `sam validate -t infra/foundation-web/template.yaml --region us-east-1`

## Notes
- No API contracts changed, so no Postman collections were updated.