### PR TITLE
Admin UI left-docked nav + canonical admin REST endpoints

### DIFF
--- a/.github/workflows/foundation-web-deploy-reusable.yml
+++ b/.github/workflows/foundation-web-deploy-reusable.yml
@@ -18,6 +18,10 @@ on:
       grn_stack_name:
         required: true
         type: string
+      admin_stack_name:
+        required: false
+        type: string
+        default: ""
       aws_region:
         required: false
         type: string
@@ -463,6 +467,19 @@ jobs:
             --output text 2>/dev/null || echo "")
           echo "frontend-url=$GRN_FRONTEND_URL" >> $GITHUB_OUTPUT
 
+      - name: Read admin stack frontend URL
+        id: admin-stack
+        run: |
+          ADMIN_FRONTEND_URL=""
+          if [ -n "${{ inputs.admin_stack_name }}" ]; then
+            ADMIN_FRONTEND_URL=$(aws cloudformation describe-stacks \
+              --stack-name "${{ inputs.admin_stack_name }}" \
+              --region "${{ inputs.aws_region }}" \
+              --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" \
+              --output text 2>/dev/null || echo "")
+          fi
+          echo "frontend-url=$ADMIN_FRONTEND_URL" >> $GITHUB_OUTPUT
+
       - name: Build foundation web app
         env:
           VITE_OKRA_API_BASE: ${{ steps.okra-stack.outputs.api-url }}
@@ -470,6 +487,7 @@ jobs:
           VITE_AUTH_USER_POOL_CLIENT_ID: ${{ steps.stack-outputs.outputs.user-pool-client-id }}
           VITE_AUTH_USER_POOL_DOMAIN: ${{ steps.stack-outputs.outputs.user-pool-domain }}
           VITE_GRN_URL: ${{ steps.grn-stack.outputs.frontend-url }}
+          VITE_ADMIN_URL: ${{ steps.admin-stack.outputs.frontend-url }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ inputs.stripe_publishable_key }}
           VITE_WEB_API_BASE: ${{ steps.web-api-stack.outputs.api-url }}
         run: npm --workspace @olivias/web run build

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -115,6 +115,7 @@ jobs:
       web_api_stack_name: ogf-web-api-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'prod' || 'staging') }}
       okra_stack_name: ${{ (github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'prod' || 'staging')) == 'prod' && 'ogf-okra-prod' || 'ogf-okra-staging' }}
       grn_stack_name: ogf-grn-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'prod' || 'staging') }}
+      admin_stack_name: ogf-admin-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'prod' || 'staging') }}
       aws_region: us-east-1
       aws_role_session_name: GitHubActions-FoundationWeb-Deploy
       domain_name: ${{ (github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'prod' || 'staging')) == 'prod' && vars.FOUNDATION_WEB_DOMAIN_NAME_PROD || vars.FOUNDATION_WEB_DOMAIN_NAME_STAGING || '' }}

--- a/.github/workflows/web-pull-request-checks.yml
+++ b/.github/workflows/web-pull-request-checks.yml
@@ -220,6 +220,7 @@ jobs:
       web_api_stack_name: ogf-web-api-staging
       okra_stack_name: ogf-okra-staging
       grn_stack_name: ogf-grn-staging
+      admin_stack_name: ogf-admin-staging
       aws_region: us-east-1
       aws_role_session_name: GitHubActions-FoundationWeb-PR-${{ github.event.pull_request.number }}
       domain_name: ${{ vars.FOUNDATION_WEB_DOMAIN_NAME_STAGING || '' }}

--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -162,12 +162,20 @@ export async function updateStoreProduct(
   );
 }
 
-export async function listOkraReviewQueue(accessToken: string): Promise<OkraSubmission[]> {
-  const response = await requestJson<{ data: OkraSubmission[] }>(
+export interface OkraReviewQueueResponse {
+  data: OkraSubmission[];
+  total: number;
+}
+
+export async function listOkraReviewQueue(accessToken: string): Promise<OkraReviewQueueResponse> {
+  const response = await requestJson<{ data: OkraSubmission[]; total?: number }>(
     `${getOkraAdminApiBaseUrl()}/submissions?status=pending`,
     accessToken
   );
-  return response.data;
+  return {
+    data: response.data,
+    total: response.total ?? response.data.length,
+  };
 }
 
 export async function reviewOkraSubmission(
@@ -187,12 +195,32 @@ export async function reviewOkraSubmission(
   );
 }
 
-export async function listSeedRequestQueue(accessToken: string): Promise<SeedRequestQueueItem[]> {
-  const response = await requestJson<{ data: SeedRequestQueueItem[] }>(
-    `${getOkraAdminApiBaseUrl()}/requests?status=open`,
-    accessToken
-  );
-  return response.data;
+export interface SeedRequestQueueResponse {
+  data: SeedRequestQueueItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export async function listSeedRequestQueue(
+  accessToken: string,
+  options: { page?: number; limit?: number } = {}
+): Promise<SeedRequestQueueResponse> {
+  const page = options.page ?? 1;
+  const limit = options.limit ?? 20;
+  const url = `${getOkraAdminApiBaseUrl()}/requests?status=open&page=${page}&limit=${limit}`;
+  const response = await requestJson<{
+    data: SeedRequestQueueItem[];
+    total?: number;
+    page?: number;
+    limit?: number;
+  }>(url, accessToken);
+  return {
+    data: response.data,
+    total: response.total ?? response.data.length,
+    page: response.page ?? page,
+    limit: response.limit ?? limit,
+  };
 }
 
 export async function markSeedRequestHandled(

--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -164,7 +164,7 @@ export async function updateStoreProduct(
 
 export async function listOkraReviewQueue(accessToken: string): Promise<OkraSubmission[]> {
   const response = await requestJson<{ data: OkraSubmission[] }>(
-    `${getOkraAdminApiBaseUrl()}/submissions/review-queue`,
+    `${getOkraAdminApiBaseUrl()}/submissions?status=pending`,
     accessToken
   );
   return response.data;
@@ -189,7 +189,7 @@ export async function reviewOkraSubmission(
 
 export async function listSeedRequestQueue(accessToken: string): Promise<SeedRequestQueueItem[]> {
   const response = await requestJson<{ data: SeedRequestQueueItem[] }>(
-    `${getOkraAdminApiBaseUrl()}/requests/review-queue`,
+    `${getOkraAdminApiBaseUrl()}/requests?status=open`,
     accessToken
   );
   return response.data;

--- a/apps/admin/src/pages/OkraQueuePage.tsx
+++ b/apps/admin/src/pages/OkraQueuePage.tsx
@@ -7,6 +7,65 @@ import {
 } from '../api';
 import type { AdminSession } from '../auth/session';
 
+function PhotoCarousel({ photos, alt }: { photos: string[]; alt: string }) {
+  const [index, setIndex] = useState(0);
+
+  if (photos.length === 0) return null;
+
+  const clamped = Math.min(index, photos.length - 1);
+  const showControls = photos.length > 1;
+
+  return (
+    <div className="admin-photo-carousel">
+      <img
+        className="admin-photo-carousel__image"
+        src={photos[clamped]}
+        alt={alt}
+      />
+      {showControls ? (
+        <>
+          <button
+            type="button"
+            className="admin-photo-carousel__nav admin-photo-carousel__nav--prev"
+            aria-label="Previous photo"
+            onClick={() => setIndex((i) => (i - 1 + photos.length) % photos.length)}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M15.4 6.4 14 5l-7 7 7 7 1.4-1.4L9.8 12Z" fill="currentColor" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className="admin-photo-carousel__nav admin-photo-carousel__nav--next"
+            aria-label="Next photo"
+            onClick={() => setIndex((i) => (i + 1) % photos.length)}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M8.6 6.4 10 5l7 7-7 7-1.4-1.4L14.2 12Z" fill="currentColor" />
+            </svg>
+          </button>
+          <div className="admin-photo-carousel__counter" aria-hidden="true">
+            {clamped + 1} / {photos.length}
+          </div>
+          <div className="admin-photo-carousel__dots" role="tablist" aria-label="Select photo">
+            {photos.map((_, i) => (
+              <button
+                key={i}
+                type="button"
+                role="tab"
+                aria-selected={i === clamped}
+                aria-label={`Photo ${i + 1}`}
+                className={`admin-photo-carousel__dot${i === clamped ? ' is-active' : ''}`}
+                onClick={() => setIndex(i)}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 export interface OkraQueuePageProps {
   session: AdminSession;
 }
@@ -109,11 +168,10 @@ export function OkraQueuePage({ session }: OkraQueuePageProps) {
               <p className="admin-submission-card__location">
                 {submission.raw_location_text || 'No location text provided.'}
               </p>
-              {submission.photos?.[0] ? (
-                <img
-                  className="admin-submission-card__photo"
-                  src={submission.photos[0]}
-                  alt="Okra submission"
+              {submission.photos && submission.photos.length > 0 ? (
+                <PhotoCarousel
+                  photos={submission.photos}
+                  alt={`Okra submission from ${submission.contributor_name || 'anonymous contributor'}`}
                 />
               ) : null}
               <div className="admin-submission-card__actions">

--- a/apps/admin/src/pages/OkraQueuePage.tsx
+++ b/apps/admin/src/pages/OkraQueuePage.tsx
@@ -7,28 +7,41 @@ import {
 } from '../api';
 import type { AdminSession } from '../auth/session';
 
+const VISIBLE_PHOTOS = 3;
+
 function PhotoCarousel({ photos, alt }: { photos: string[]; alt: string }) {
-  const [index, setIndex] = useState(0);
+  const [startIndex, setStartIndex] = useState(0);
 
   if (photos.length === 0) return null;
 
-  const clamped = Math.min(index, photos.length - 1);
-  const showControls = photos.length > 1;
+  const total = photos.length;
+  const canScroll = total > VISIBLE_PHOTOS;
+  const maxStart = Math.max(0, total - VISIBLE_PHOTOS);
+  const clampedStart = Math.min(startIndex, maxStart);
+  const visible = photos.slice(clampedStart, clampedStart + VISIBLE_PHOTOS);
+  const atStart = clampedStart === 0;
+  const atEnd = clampedStart >= maxStart;
 
   return (
     <div className="admin-photo-carousel">
-      <img
-        className="admin-photo-carousel__image"
-        src={photos[clamped]}
-        alt={alt}
-      />
-      {showControls ? (
+      <div className="admin-photo-carousel__viewport" role="group" aria-label={alt}>
+        {visible.map((src, i) => (
+          <img
+            key={`${clampedStart + i}-${src}`}
+            className="admin-photo-carousel__thumb"
+            src={src}
+            alt={`${alt} — photo ${clampedStart + i + 1} of ${total}`}
+          />
+        ))}
+      </div>
+      {canScroll ? (
         <>
           <button
             type="button"
             className="admin-photo-carousel__nav admin-photo-carousel__nav--prev"
-            aria-label="Previous photo"
-            onClick={() => setIndex((i) => (i - 1 + photos.length) % photos.length)}
+            aria-label="Previous photos"
+            disabled={atStart}
+            onClick={() => setStartIndex((i) => Math.max(0, i - 1))}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path d="M15.4 6.4 14 5l-7 7 7 7 1.4-1.4L9.8 12Z" fill="currentColor" />
@@ -37,28 +50,16 @@ function PhotoCarousel({ photos, alt }: { photos: string[]; alt: string }) {
           <button
             type="button"
             className="admin-photo-carousel__nav admin-photo-carousel__nav--next"
-            aria-label="Next photo"
-            onClick={() => setIndex((i) => (i + 1) % photos.length)}
+            aria-label="Next photos"
+            disabled={atEnd}
+            onClick={() => setStartIndex((i) => Math.min(maxStart, i + 1))}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path d="M8.6 6.4 10 5l7 7-7 7-1.4-1.4L14.2 12Z" fill="currentColor" />
             </svg>
           </button>
           <div className="admin-photo-carousel__counter" aria-hidden="true">
-            {clamped + 1} / {photos.length}
-          </div>
-          <div className="admin-photo-carousel__dots" role="tablist" aria-label="Select photo">
-            {photos.map((_, i) => (
-              <button
-                key={i}
-                type="button"
-                role="tab"
-                aria-selected={i === clamped}
-                aria-label={`Photo ${i + 1}`}
-                className={`admin-photo-carousel__dot${i === clamped ? ' is-active' : ''}`}
-                onClick={() => setIndex(i)}
-              />
-            ))}
+            {clampedStart + 1}–{Math.min(clampedStart + VISIBLE_PHOTOS, total)} of {total}
           </div>
         </>
       ) : null}
@@ -72,6 +73,7 @@ export interface OkraQueuePageProps {
 
 export function OkraQueuePage({ session }: OkraQueuePageProps) {
   const [queue, setQueue] = useState<OkraSubmission[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -81,7 +83,8 @@ export function OkraQueuePage({ session }: OkraQueuePageProps) {
     listOkraReviewQueue(session.accessToken)
       .then((next) => {
         if (!active) return;
-        setQueue(next);
+        setQueue(next.data);
+        setTotal(next.total);
         setError(null);
       })
       .catch((err: Error) => {
@@ -100,7 +103,8 @@ export function OkraQueuePage({ session }: OkraQueuePageProps) {
     setLoading(true);
     try {
       const next = await listOkraReviewQueue(session.accessToken);
-      setQueue(next);
+      setQueue(next.data);
+      setTotal(next.total);
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to refresh Okra queue.');
@@ -123,6 +127,7 @@ export function OkraQueuePage({ session }: OkraQueuePageProps) {
         });
       }
       setQueue((current) => current.filter((item) => item.id !== submission.id));
+      setTotal((current) => Math.max(0, current - 1));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to update submission status.');
     } finally {
@@ -135,7 +140,7 @@ export function OkraQueuePage({ session }: OkraQueuePageProps) {
       <div className="admin-section__header">
         <SectionHeading
           eyebrow="Okra queue"
-          title="Pending submissions"
+          title={`Pending submissions (${total})`}
           body="Approve or deny community submissions before they appear on the public map."
         />
         <Button variant="outline" size="sm" onClick={() => void refresh()} disabled={loading}>

--- a/apps/admin/src/pages/SeedRequestsPage.tsx
+++ b/apps/admin/src/pages/SeedRequestsPage.tsx
@@ -11,6 +11,8 @@ export interface SeedRequestsPageProps {
   session: AdminSession;
 }
 
+const PAGE_SIZE = 10;
+
 function formatAddress(request: SeedRequestQueueItem): string {
   if (request.fulfillmentMethod !== 'mail' || !request.shippingAddress) {
     return 'In-person exchange';
@@ -23,29 +25,22 @@ function formatAddress(request: SeedRequestQueueItem): string {
 
 export function SeedRequestsPage({ session }: SeedRequestsPageProps) {
   const [requests, setRequests] = useState<SeedRequestQueueItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
 
-  const load = () => {
-    setLoading(true);
-    return listSeedRequestQueue(session.accessToken)
-      .then((next) => {
-        setRequests(next);
-        setError(null);
-      })
-      .catch((err: Error) => {
-        setError(err.message || 'Unable to load seed requests.');
-      })
-      .finally(() => setLoading(false));
-  };
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   useEffect(() => {
     let active = true;
-    listSeedRequestQueue(session.accessToken)
+    setLoading(true);
+    listSeedRequestQueue(session.accessToken, { page, limit: PAGE_SIZE })
       .then((next) => {
         if (!active) return;
-        setRequests(next);
+        setRequests(next.data);
+        setTotal(next.total);
         setError(null);
       })
       .catch((err: Error) => {
@@ -58,7 +53,24 @@ export function SeedRequestsPage({ session }: SeedRequestsPageProps) {
     return () => {
       active = false;
     };
-  }, [session.accessToken]);
+  }, [session.accessToken, page]);
+
+  const load = async (targetPage = page) => {
+    setLoading(true);
+    try {
+      const next = await listSeedRequestQueue(session.accessToken, {
+        page: targetPage,
+        limit: PAGE_SIZE,
+      });
+      setRequests(next.data);
+      setTotal(next.total);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load seed requests.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleMarkDone = async (request: SeedRequestQueueItem) => {
     setBusyId(request.id);
@@ -68,7 +80,16 @@ export function SeedRequestsPage({ session }: SeedRequestsPageProps) {
         status: 'handled',
         review_notes: 'Handled in admin dashboard.',
       });
-      setRequests((current) => current.filter((item) => item.id !== request.id));
+      // Refetch the current page so the list stays correctly paginated
+      // and total reflects the server's post-update view.
+      const newTotal = Math.max(0, total - 1);
+      const newPageCount = Math.max(1, Math.ceil(newTotal / PAGE_SIZE));
+      const nextPage = Math.min(page, newPageCount);
+      if (nextPage !== page) {
+        setPage(nextPage);
+      } else {
+        await load(nextPage);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to mark request as done.');
     } finally {
@@ -81,10 +102,10 @@ export function SeedRequestsPage({ session }: SeedRequestsPageProps) {
       <div className="admin-section__header">
         <SectionHeading
           eyebrow="Seed requests"
-          title="Open requests"
+          title={`Open requests (${total})`}
           body="Mark a request as done once the seeds are on their way or picked up."
         />
-        <Button variant="outline" size="sm" onClick={() => void load()} disabled={loading}>
+        <Button variant="outline" size="sm" onClick={() => void load(page)} disabled={loading}>
           Refresh
         </Button>
       </div>
@@ -98,54 +119,80 @@ export function SeedRequestsPage({ session }: SeedRequestsPageProps) {
       ) : requests.length === 0 ? (
         <Card><p>No open seed requests right now.</p></Card>
       ) : (
-        <div className="admin-stack">
-          {requests.map((request) => (
-            <Card key={request.id} className="admin-request-card">
-              <div className="admin-request-card__meta">
-                <div>
-                  <h3>{request.name || 'Unknown contributor'}</h3>
-                  <p>{request.email || 'No email provided'}</p>
-                </div>
-                <span>{request.createdAt ? new Date(request.createdAt).toLocaleString() : '—'}</span>
-              </div>
-              <dl className="admin-request-card__details">
-                <div>
-                  <dt>Fulfillment</dt>
-                  <dd>{request.fulfillmentMethod === 'mail' ? 'Mail' : 'In-person exchange'}</dd>
-                </div>
-                <div>
-                  <dt>Address / visit</dt>
-                  <dd>
-                    {request.fulfillmentMethod === 'mail'
-                      ? formatAddress(request)
-                      : request.visitDetails?.approximateDate || 'No date provided'}
-                  </dd>
-                </div>
-                {request.visitDetails?.notes ? (
+        <>
+          <div className="admin-stack">
+            {requests.map((request) => (
+              <Card key={request.id} className="admin-request-card">
+                <div className="admin-request-card__meta">
                   <div>
-                    <dt>Visit notes</dt>
-                    <dd>{request.visitDetails.notes}</dd>
+                    <h3>{request.name || 'Unknown contributor'}</h3>
+                    <p>{request.email || 'No email provided'}</p>
                   </div>
-                ) : null}
-                {request.message ? (
+                  <span>{request.createdAt ? new Date(request.createdAt).toLocaleString() : '—'}</span>
+                </div>
+                <dl className="admin-request-card__details">
                   <div>
-                    <dt>Message</dt>
-                    <dd>{request.message}</dd>
+                    <dt>Fulfillment</dt>
+                    <dd>{request.fulfillmentMethod === 'mail' ? 'Mail' : 'In-person exchange'}</dd>
                   </div>
-                ) : null}
-              </dl>
-              <div className="admin-request-card__actions">
-                <Button
-                  onClick={() => void handleMarkDone(request)}
-                  loading={busyId === request.id}
-                  disabled={busyId !== null}
-                >
-                  Mark as done
-                </Button>
-              </div>
-            </Card>
-          ))}
-        </div>
+                  <div>
+                    <dt>Address / visit</dt>
+                    <dd>
+                      {request.fulfillmentMethod === 'mail'
+                        ? formatAddress(request)
+                        : request.visitDetails?.approximateDate || 'No date provided'}
+                    </dd>
+                  </div>
+                  {request.visitDetails?.notes ? (
+                    <div>
+                      <dt>Visit notes</dt>
+                      <dd>{request.visitDetails.notes}</dd>
+                    </div>
+                  ) : null}
+                  {request.message ? (
+                    <div>
+                      <dt>Message</dt>
+                      <dd>{request.message}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+                <div className="admin-request-card__actions">
+                  <Button
+                    onClick={() => void handleMarkDone(request)}
+                    loading={busyId === request.id}
+                    disabled={busyId !== null}
+                  >
+                    Mark as done
+                  </Button>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          {pageCount > 1 ? (
+            <nav className="admin-pagination" aria-label="Seed request pages">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1 || loading}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Previous
+              </Button>
+              <span className="admin-pagination__status" aria-live="polite">
+                Page {page} of {pageCount}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= pageCount || loading}
+                onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+              >
+                Next
+              </Button>
+            </nav>
+          ) : null}
+        </>
       )}
     </section>
   );

--- a/apps/admin/src/shell/AppShell.tsx
+++ b/apps/admin/src/shell/AppShell.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from 'react';
-import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState, type ReactNode } from 'react';
+import { NavLink } from 'react-router-dom';
 import { AvatarMenu, SiteFooter, SiteHeader } from '@olivias/ui';
 import { signOut } from 'aws-amplify/auth';
 import type { AdminSession } from '../auth/session';
@@ -16,17 +16,77 @@ const grnUrl = (import.meta.env.VITE_GRN_URL as string | undefined)?.replace(/\/
 const instagramUrl = 'https://instagram.com/oliviasgardentx';
 const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
 
-const navItems = [
-  { id: 'dashboard', path: '/', label: 'Dashboard' },
-  { id: 'seed-requests', path: '/seed-requests', label: 'Seed requests' },
-  { id: 'okra-queue', path: '/okra-queue', label: 'Okra queue' },
-  { id: 'store-catalog', path: '/store', label: 'Store catalog' },
-] as const;
+const NAV_EXPANDED_STORAGE_KEY = 'og-admin-nav-expanded';
+
+type AdminNavItem = {
+  id: string;
+  path: string;
+  label: string;
+  icon: ReactNode;
+};
+
+const navItems: AdminNavItem[] = [
+  {
+    id: 'dashboard',
+    path: '/',
+    label: 'Dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M3 13h8V3H3v10Zm0 8h8v-6H3v6Zm10 0h8V11h-8v10Zm0-18v6h8V3h-8Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    id: 'seed-requests',
+    path: '/seed-requests',
+    label: 'Seed requests',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 3c-3.5 3-5 6-5 9a5 5 0 0 0 4 4.9V21a1 1 0 1 0 2 0v-4.1a5 5 0 0 0 4-4.9c0-3-1.5-6-5-9Zm0 12a3 3 0 0 1-3-3c0-1.7.8-3.6 3-5.7 2.2 2.1 3 4 3 5.7a3 3 0 0 1-3 3Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'okra-queue',
+    path: '/okra-queue',
+    label: 'Okra queue',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M5 4h11l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm0 2v14h13V8h-3V6H5Zm3 5h7v2H8v-2Zm0 4h7v2H8v-2Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'store-catalog',
+    path: '/store',
+    label: 'Store catalog',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M4 7h16l-1.2 11.1a2 2 0 0 1-2 1.9H7.2a2 2 0 0 1-2-1.9L4 7Zm4 0V5a4 4 0 0 1 8 0v2h-2V5a2 2 0 0 0-4 0v2H8Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+  },
+];
 
 const footerLinks = [
   { id: 'home', label: 'Foundation home', href: `${foundationHomeUrl}/` },
   { id: 'okra', label: 'Okra Project', href: `${foundationHomeUrl}/okra` },
   { id: 'grn', label: 'Good Roots Network', href: grnUrl },
+];
+
+const foundationHeaderNav = [
+  { id: 'foundation-home', label: 'Home', href: `${foundationHomeUrl}/` },
+  { id: 'foundation-about', label: 'About', href: `${foundationHomeUrl}/about` },
+  { id: 'foundation-okra', label: 'Okra Project', href: `${foundationHomeUrl}/okra` },
 ];
 
 function getInitials(session: AdminSession): string {
@@ -40,14 +100,32 @@ function getInitials(session: AdminSession): string {
   return parts.slice(0, 2).map((part) => part[0]?.toUpperCase() ?? '').join('') || source.slice(0, 2).toUpperCase();
 }
 
+function readStoredExpanded(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    const stored = window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY);
+    if (stored === null) return true;
+    return stored === 'true';
+  } catch {
+    return true;
+  }
+}
+
 export interface AppShellProps {
   session: AdminSession;
   children: ReactNode;
 }
 
 export function AppShell({ session, children }: AppShellProps) {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const [expanded, setExpanded] = useState<boolean>(() => readStoredExpanded());
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, String(expanded));
+    } catch {
+      // ignore storage errors
+    }
+  }, [expanded]);
 
   const handleLogout = async () => {
     try {
@@ -58,13 +136,10 @@ export function AppShell({ session, children }: AppShellProps) {
     window.location.assign(`${foundationHomeUrl}/login`);
   };
 
-  const headerNavItems = navItems.map((item) => ({
+  const headerNavItems = foundationHeaderNav.map((item) => ({
     id: item.id,
     label: item.label,
-    href: item.path,
-    active: location.pathname === item.path,
-    mobileOnly: true,
-    onSelect: () => navigate(item.path),
+    href: item.href,
   }));
 
   return (
@@ -73,9 +148,8 @@ export function AppShell({ session, children }: AppShellProps) {
         brandLogoSrc={foundationLogo}
         brandLogoAlt=""
         brandEyebrow="Olivia's Garden Foundation"
-        brandTitle="Homesteading, growing, and community"
-        brandHref="/"
-        onBrandClick={() => navigate('/')}
+        brandTitle="Administration console"
+        brandHref={`${foundationHomeUrl}/`}
         navItems={headerNavItems}
         utility={(
           <div className="og-auth-utility">
@@ -91,36 +165,56 @@ export function AppShell({ session, children }: AppShellProps) {
           </div>
         )}
       />
-      <main className="og-app-main admin-app-main">
-        <div className="admin-layout">
-          <aside className="admin-layout__sidebar" aria-label="Admin sections">
-            <nav className="og-side-nav admin-side-nav" aria-label="Admin sections">
-              <div className="admin-side-nav__intro">
-                <p className="og-side-nav__eyebrow">Admin</p>
-                <h2 className="og-side-nav__title">Admin console</h2>
-                <p className="og-side-nav__body">
-                  Review public submissions, manage seed requests, and keep the store catalog current.
-                </p>
-              </div>
-              <div className="og-side-nav__list">
-                {navItems.map((item) => (
-                  <NavLink
-                    key={item.id}
-                    to={item.path}
-                    end={item.path === '/'}
-                    className={({ isActive }) =>
-                      `og-side-nav__link ${isActive ? 'is-active' : ''}`.trim()
-                    }
-                  >
-                    {item.label}
-                  </NavLink>
-                ))}
-              </div>
-            </nav>
-          </aside>
-          <div className="admin-layout__content">{children}</div>
-        </div>
-      </main>
+      <div className={`admin-shell-body ${expanded ? 'is-expanded' : 'is-collapsed'}`}>
+        <aside
+          className={`admin-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'}`}
+          aria-label="Admin sections"
+        >
+          <button
+            type="button"
+            className="admin-vertical-nav__toggle"
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Collapse navigation' : 'Expand navigation'}
+            onClick={() => setExpanded((current) => !current)}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d={expanded
+                  ? 'M15.4 6.4 14 5l-7 7 7 7 1.4-1.4L9.8 12Z'
+                  : 'M8.6 6.4 10 5l7 7-7 7-1.4-1.4L14.2 12Z'}
+                fill="currentColor"
+              />
+            </svg>
+            <span className="admin-vertical-nav__toggle-label">
+              {expanded ? 'Collapse' : 'Expand'}
+            </span>
+          </button>
+
+          <ul className="admin-vertical-nav__list" role="list">
+            {navItems.map((item) => (
+              <li key={item.id}>
+                <NavLink
+                  to={item.path}
+                  end={item.path === '/'}
+                  className={({ isActive }) =>
+                    `admin-vertical-nav__link ${isActive ? 'is-active' : ''}`.trim()
+                  }
+                  title={expanded ? undefined : item.label}
+                >
+                  <span className="admin-vertical-nav__icon" aria-hidden="true">{item.icon}</span>
+                  <span className="admin-vertical-nav__label">{item.label}</span>
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <main className="admin-shell-main">
+          <div className="admin-shell-main__inner">
+            {children}
+          </div>
+        </main>
+      </div>
       <SiteFooter
         tagline="Growing food, sharing seeds, and helping more people feel at home on the land."
         meta={`${new Date().getFullYear()} Olivia's Garden Foundation. All rights reserved.`}

--- a/apps/admin/src/shell/AppShell.tsx
+++ b/apps/admin/src/shell/AppShell.tsx
@@ -170,26 +170,6 @@ export function AppShell({ session, children }: AppShellProps) {
           className={`admin-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'}`}
           aria-label="Admin sections"
         >
-          <button
-            type="button"
-            className="admin-vertical-nav__toggle"
-            aria-expanded={expanded}
-            aria-label={expanded ? 'Collapse navigation' : 'Expand navigation'}
-            onClick={() => setExpanded((current) => !current)}
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path
-                d={expanded
-                  ? 'M15.4 6.4 14 5l-7 7 7 7 1.4-1.4L9.8 12Z'
-                  : 'M8.6 6.4 10 5l7 7-7 7-1.4-1.4L14.2 12Z'}
-                fill="currentColor"
-              />
-            </svg>
-            <span className="admin-vertical-nav__toggle-label">
-              {expanded ? 'Collapse' : 'Expand'}
-            </span>
-          </button>
-
           <ul className="admin-vertical-nav__list" role="list">
             {navItems.map((item) => (
               <li key={item.id}>
@@ -207,6 +187,24 @@ export function AppShell({ session, children }: AppShellProps) {
               </li>
             ))}
           </ul>
+
+          <button
+            type="button"
+            className="admin-vertical-nav__toggle"
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Collapse navigation' : 'Expand navigation'}
+            title={expanded ? 'Collapse navigation' : 'Expand navigation'}
+            onClick={() => setExpanded((current) => !current)}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d={expanded
+                  ? 'M15.4 6.4 14 5l-7 7 7 7 1.4-1.4L9.8 12Z'
+                  : 'M8.6 6.4 10 5l7 7-7 7-1.4-1.4L14.2 12Z'}
+                fill="currentColor"
+              />
+            </svg>
+          </button>
         </aside>
 
         <main className="admin-shell-main">

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -23,102 +23,264 @@ body {
   background: transparent;
 }
 
-.admin-app-main {
-  width: min(1320px, calc(100% - 2rem));
+.admin-shell-body {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-height: 0;
+}
+
+.admin-shell-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+}
+
+.admin-shell-main__inner {
+  flex: 1;
+  min-width: 0;
+  width: min(1180px, 100%);
   margin: 0 auto;
-  padding: 1.25rem 0 2.5rem;
-}
-
-.admin-layout {
-  display: grid;
-  gap: 1rem;
-}
-
-.admin-layout__sidebar {
-  display: grid;
-  align-content: start;
-}
-
-.admin-layout__content {
+  padding: 1.5rem clamp(1rem, 2vw, 2rem) 2.5rem;
   display: grid;
   gap: 1.25rem;
   align-content: start;
-  min-width: 0;
 }
 
-.admin-side-nav {
-  background: rgba(255, 252, 246, 0.96);
-  border: 1px solid rgba(79, 56, 37, 0.08);
-  border-radius: 1.5rem;
-  box-shadow: 0 18px 36px rgba(38, 23, 15, 0.08);
-  padding: 1rem;
+/* ── Left-docked vertical nav ─────────────────────────────────────── */
+
+.admin-vertical-nav {
+  --admin-nav-width-collapsed: 4.25rem;
+  --admin-nav-width-expanded: 15.5rem;
+  --admin-nav-header-offset: calc(4.85rem + env(safe-area-inset-top, 0px));
+
+  position: sticky;
+  top: var(--admin-nav-header-offset);
+  align-self: flex-start;
+  height: calc(100dvh - var(--admin-nav-header-offset));
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.85rem 0.6rem;
+  background: linear-gradient(180deg, rgba(255, 252, 246, 0.98), rgba(249, 241, 226, 0.94));
+  border-right: 1px solid rgba(79, 56, 37, 0.1);
+  box-shadow: 2px 0 24px rgba(38, 23, 15, 0.05);
+  width: var(--admin-nav-width-collapsed);
+  transition: width var(--duration-base, 200ms) var(--easing-out, ease);
+  overflow: hidden;
 }
 
-.admin-side-nav__intro {
-  display: grid;
-  gap: 0.35rem;
+.admin-vertical-nav.is-expanded {
+  width: var(--admin-nav-width-expanded);
 }
 
-.admin-side-nav .og-side-nav__body {
-  margin-top: 0;
-  font-size: 0.92rem;
-  line-height: 1.5;
-}
-
-.admin-side-nav .og-side-nav__list {
-  gap: 0.55rem;
-}
-
-.admin-side-nav .og-side-nav__link {
-  min-height: 3.1rem;
-  border-radius: 1rem;
-  border-color: transparent;
+.admin-vertical-nav__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.65rem;
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.35rem 0.65rem;
+  margin-bottom: 0.25rem;
+  border: 1px solid transparent;
+  border-radius: var(--og-radius-pill, 999px);
   background: transparent;
-  padding: 0.85rem 1rem;
+  color: rgba(79, 56, 37, 0.7);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
+              color var(--duration-fast, 150ms) var(--easing-out, ease),
+              border-color var(--duration-fast, 150ms) var(--easing-out, ease);
 }
 
-.admin-side-nav .og-side-nav__link:hover {
+.admin-vertical-nav__toggle svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+.admin-vertical-nav__toggle:hover,
+.admin-vertical-nav__toggle:focus-visible {
   background: rgba(79, 56, 37, 0.06);
-  border-color: transparent;
+  color: var(--og-color-soil);
+  outline: none;
 }
 
-.admin-side-nav .og-side-nav__link.is-active {
+.admin-vertical-nav__toggle-label {
+  opacity: 0;
+  transform: translateX(-0.25rem);
+  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
+              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+  white-space: nowrap;
+}
+
+.admin-vertical-nav.is-expanded .admin-vertical-nav__toggle-label {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.admin-vertical-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.admin-vertical-nav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+  width: 100%;
+  min-height: 2.85rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid transparent;
+  border-radius: 0.9rem;
+  background: transparent;
+  color: var(--og-color-soil);
+  font: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
+              color var(--duration-fast, 150ms) var(--easing-out, ease),
+              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+}
+
+.admin-vertical-nav__link:hover,
+.admin-vertical-nav__link:focus-visible {
+  background: rgba(79, 56, 37, 0.07);
+  outline: none;
+}
+
+.admin-vertical-nav__link.is-active {
+  background: linear-gradient(180deg, rgba(66, 107, 63, 0.96), rgba(79, 56, 37, 0.92));
+  color: var(--og-color-paper);
+  border-color: transparent;
+  box-shadow: 0 8px 20px rgba(38, 23, 15, 0.12);
+}
+
+.admin-vertical-nav__link.is-active:hover {
+  background: linear-gradient(180deg, rgba(66, 107, 63, 0.96), rgba(79, 56, 37, 0.92));
+  color: var(--og-color-paper);
+}
+
+.admin-vertical-nav__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2.15rem;
+  height: 2.15rem;
+  border-radius: 0.75rem;
   background: rgba(79, 56, 37, 0.08);
   color: var(--og-color-soil);
-  border-color: transparent;
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
+              color var(--duration-fast, 150ms) var(--easing-out, ease);
 }
 
-@media (min-width: 860px) {
-  .admin-layout {
-    grid-template-columns: minmax(16rem, 18rem) minmax(0, 1fr);
-    align-items: start;
-  }
-
-  .admin-layout__sidebar {
-    position: sticky;
-    top: calc(4.85rem + env(safe-area-inset-top, 0px) + 0.75rem);
-    min-height: calc(100dvh - 6rem - env(safe-area-inset-top, 0px));
-  }
-
-  .admin-side-nav {
-    min-height: inherit;
-    padding: 1.25rem 1rem;
-  }
+.admin-vertical-nav__icon svg {
+  width: 1.2rem;
+  height: 1.2rem;
 }
 
-@media (max-width: 859px) {
-  .admin-app-main {
-    width: min(1180px, calc(100% - 1rem));
-    padding-top: 1rem;
+.admin-vertical-nav__link.is-active .admin-vertical-nav__icon {
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--og-color-paper);
+}
+
+.admin-vertical-nav__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0;
+  transform: translateX(-0.25rem);
+  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
+              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+}
+
+.admin-vertical-nav.is-expanded .admin-vertical-nav__label {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.admin-vertical-nav.is-collapsed .admin-vertical-nav__link {
+  justify-content: center;
+  padding: 0.4rem;
+}
+
+.admin-vertical-nav.is-collapsed .admin-vertical-nav__toggle {
+  justify-content: center;
+  padding: 0.4rem;
+}
+
+/* ── Mobile: horizontal scroll fallback ───────────────────────────── */
+
+@media (max-width: 720px) {
+  .admin-shell-body {
+    flex-direction: column;
   }
 
-  .admin-side-nav {
+  .admin-vertical-nav {
+    position: static;
+    top: auto;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    gap: 0.4rem;
+    padding: 0.65rem 0.75rem;
+    border-right: none;
+    border-bottom: 1px solid rgba(79, 56, 37, 0.1);
+    box-shadow: 0 2px 16px rgba(38, 23, 15, 0.05);
     overflow-x: auto;
+    overflow-y: hidden;
   }
 
-  .admin-side-nav .og-side-nav__title,
-  .admin-side-nav .og-side-nav__body {
-    max-width: 38rem;
+  .admin-vertical-nav__toggle {
+    display: none;
+  }
+
+  .admin-vertical-nav__list {
+    flex: 1;
+    display: flex;
+    gap: 0.4rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .admin-vertical-nav__list li {
+    flex-shrink: 0;
+  }
+
+  .admin-vertical-nav__link {
+    min-height: 2.5rem;
+    padding: 0.4rem 0.85rem;
+  }
+
+  .admin-vertical-nav__label {
+    opacity: 1;
+    transform: none;
+  }
+
+  .admin-vertical-nav__icon {
+    width: 1.9rem;
+    height: 1.9rem;
+  }
+
+  .admin-shell-main__inner {
+    padding: 1rem clamp(0.75rem, 3vw, 1.5rem) 2rem;
   }
 }
 

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -18,9 +18,19 @@ body {
 }
 
 /* ── Admin shell layout ───────────────────────────────────────────── */
+/*
+ * The admin shell uses body-level scrolling: header and footer are pinned,
+ * the middle row (.admin-shell-body) fills the remaining viewport height,
+ * and only .admin-shell-main scrolls. This lets the side nav span the full
+ * height between header and footer at all times without driving extra
+ * page scroll.
+ */
 
 .admin-app-shell {
   background: transparent;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 .admin-shell-body {
@@ -30,12 +40,15 @@ body {
   width: 100%;
   min-height: 0;
   position: relative;
+  overflow: hidden;
 }
 
 .admin-shell-main {
   flex: 1;
   min-width: 0;
   display: flex;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .admin-shell-main__inner {
@@ -54,14 +67,9 @@ body {
 .admin-vertical-nav {
   --admin-nav-width-collapsed: 4.25rem;
   --admin-nav-width-expanded: 15.5rem;
-  --admin-nav-header-offset: calc(4.85rem + env(safe-area-inset-top, 0px));
-  --admin-nav-footer-reserve: 9rem;
-  --admin-nav-available-height: calc(100dvh - var(--admin-nav-header-offset) - var(--admin-nav-footer-reserve));
 
-  position: sticky;
-  top: var(--admin-nav-header-offset);
-  align-self: flex-start;
-  max-height: var(--admin-nav-available-height);
+  position: relative;
+  height: 100%;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -164,29 +172,31 @@ body {
   padding: 0.55rem;
 }
 
-/* Collapse/expand handle: floats on the right edge of the nav, vertically
-   centered. Subtle by default, lights up on hover (of itself or the nav). */
+/* Collapse/expand handle: a small notch that grows out of the nav's right
+   border at vertical center. Picks up the nav's own background + border so
+   it reads as an extension of the rail, not a floating pill. Appears on
+   hover of the nav (or the handle itself for keyboard users). */
 .admin-vertical-nav__toggle {
   position: absolute;
   top: 50%;
-  right: -0.85rem;
+  right: -0.9rem;
   transform: translateY(-50%);
-  width: 1.7rem;
-  height: 1.7rem;
+  width: 0.95rem;
+  height: 2.6rem;
   padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(79, 56, 37, 0.15);
-  border-radius: 50%;
-  background: var(--og-color-paper);
-  color: rgba(79, 56, 37, 0.7);
+  border: 1px solid rgba(79, 56, 37, 0.1);
+  border-left: none;
+  border-radius: 0 0.5rem 0.5rem 0;
+  background: linear-gradient(180deg, rgba(255, 252, 246, 0.98), rgba(249, 241, 226, 0.94));
+  color: rgba(79, 56, 37, 0.65);
   cursor: pointer;
   opacity: 0;
-  box-shadow: 0 4px 12px rgba(38, 23, 15, 0.1);
   transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
               color var(--duration-fast, 150ms) var(--easing-out, ease),
-              background-color var(--duration-fast, 150ms) var(--easing-out, ease);
+              background var(--duration-fast, 150ms) var(--easing-out, ease);
   z-index: 1;
 }
 
@@ -199,14 +209,14 @@ body {
 
 .admin-vertical-nav__toggle:hover,
 .admin-vertical-nav__toggle:focus-visible {
-  background: var(--og-color-moss);
-  color: var(--og-color-paper);
+  background: rgba(66, 107, 63, 0.12);
+  color: var(--og-color-moss);
   outline: none;
 }
 
 .admin-vertical-nav__toggle svg {
-  width: 0.95rem;
-  height: 0.95rem;
+  width: 0.8rem;
+  height: 0.8rem;
 }
 
 /* ── Mobile: horizontal scroll fallback ───────────────────────────── */
@@ -447,22 +457,28 @@ body {
   border-radius: var(--og-radius-lg);
 }
 
-/* ── Photo carousel ───────────────────────────────────────────────── */
+/* ── Photo carousel (up to 3 thumbs at a time) ────────────────────── */
 
 .admin-photo-carousel {
   position: relative;
   display: block;
   width: 100%;
-  border-radius: var(--og-radius-lg);
-  overflow: hidden;
-  background: rgba(38, 23, 15, 0.04);
+  padding: 0 2.25rem;
+  margin-bottom: 0.75rem;
 }
 
-.admin-photo-carousel__image {
+.admin-photo-carousel__viewport {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.admin-photo-carousel__thumb {
   display: block;
   width: 100%;
-  max-height: 26rem;
-  object-fit: contain;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: var(--og-radius-md, 0.75rem);
   background: rgba(38, 23, 15, 0.04);
 }
 
@@ -470,82 +486,79 @@ body {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: none;
+  border: 1px solid rgba(79, 56, 37, 0.15);
   border-radius: 50%;
-  background: rgba(38, 23, 15, 0.55);
-  color: var(--og-color-paper);
+  background: var(--og-color-paper);
+  color: var(--og-color-soil);
   cursor: pointer;
-  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease);
+  box-shadow: 0 2px 8px rgba(38, 23, 15, 0.08);
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
+              color var(--duration-fast, 150ms) var(--easing-out, ease),
+              opacity var(--duration-fast, 150ms) var(--easing-out, ease);
 }
 
-.admin-photo-carousel__nav:hover,
-.admin-photo-carousel__nav:focus-visible {
-  background: rgba(38, 23, 15, 0.8);
+.admin-photo-carousel__nav:hover:not(:disabled),
+.admin-photo-carousel__nav:focus-visible:not(:disabled) {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
   outline: none;
 }
 
+.admin-photo-carousel__nav:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 .admin-photo-carousel__nav svg {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1rem;
+  height: 1rem;
 }
 
 .admin-photo-carousel__nav--prev {
-  left: 0.5rem;
+  left: 0;
 }
 
 .admin-photo-carousel__nav--next {
-  right: 0.5rem;
+  right: 0;
 }
 
 .admin-photo-carousel__counter {
-  position: absolute;
-  top: 0.6rem;
-  right: 0.6rem;
-  padding: 0.2rem 0.55rem;
-  border-radius: var(--og-radius-pill, 999px);
-  background: rgba(38, 23, 15, 0.6);
-  color: var(--og-color-paper);
-  font-size: 0.78rem;
+  margin-top: 0.5rem;
+  color: rgba(79, 56, 37, 0.6);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .admin-photo-carousel__viewport {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* Space between the carousel and the approve/deny actions. */
+.admin-submission-card__actions {
+  margin-top: 0.75rem;
+}
+
+/* ── Pagination ───────────────────────────────────────────────────── */
+
+.admin-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.admin-pagination__status {
+  color: rgba(79, 56, 37, 0.75);
+  font-size: 0.9rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.admin-photo-carousel__dots {
-  position: absolute;
-  bottom: 0.6rem;
-  left: 50%;
-  transform: translateX(-50%);
-  display: inline-flex;
-  gap: 0.35rem;
-  padding: 0.3rem 0.55rem;
-  border-radius: var(--og-radius-pill, 999px);
-  background: rgba(38, 23, 15, 0.4);
-}
-
-.admin-photo-carousel__dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.5);
-  cursor: pointer;
-  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
-              transform var(--duration-fast, 150ms) var(--easing-out, ease);
-}
-
-.admin-photo-carousel__dot:hover {
-  background: rgba(255, 255, 255, 0.8);
-}
-
-.admin-photo-carousel__dot.is-active {
-  background: var(--og-color-paper);
-  transform: scale(1.2);
 }
 
 /* ── Store catalog ────────────────────────────────────────────────── */

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -29,6 +29,7 @@ body {
   align-items: stretch;
   width: 100%;
   min-height: 0;
+  position: relative;
 }
 
 .admin-shell-main {
@@ -54,98 +55,51 @@ body {
   --admin-nav-width-collapsed: 4.25rem;
   --admin-nav-width-expanded: 15.5rem;
   --admin-nav-header-offset: calc(4.85rem + env(safe-area-inset-top, 0px));
+  --admin-nav-footer-reserve: 9rem;
+  --admin-nav-available-height: calc(100dvh - var(--admin-nav-header-offset) - var(--admin-nav-footer-reserve));
 
   position: sticky;
   top: var(--admin-nav-header-offset);
   align-self: flex-start;
-  height: calc(100dvh - var(--admin-nav-header-offset));
+  max-height: var(--admin-nav-available-height);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.85rem 0.6rem;
+  padding: 1rem 0.55rem;
   background: linear-gradient(180deg, rgba(255, 252, 246, 0.98), rgba(249, 241, 226, 0.94));
   border-right: 1px solid rgba(79, 56, 37, 0.1);
   box-shadow: 2px 0 24px rgba(38, 23, 15, 0.05);
   width: var(--admin-nav-width-collapsed);
   transition: width var(--duration-base, 200ms) var(--easing-out, ease);
-  overflow: hidden;
 }
 
 .admin-vertical-nav.is-expanded {
   width: var(--admin-nav-width-expanded);
 }
 
-.admin-vertical-nav__toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.65rem;
-  width: 100%;
-  min-height: 2.5rem;
-  padding: 0.35rem 0.65rem;
-  margin-bottom: 0.25rem;
-  border: 1px solid transparent;
-  border-radius: var(--og-radius-pill, 999px);
-  background: transparent;
-  color: rgba(79, 56, 37, 0.7);
-  cursor: pointer;
-  font: inherit;
-  font-weight: 700;
-  font-size: 0.82rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
-              color var(--duration-fast, 150ms) var(--easing-out, ease),
-              border-color var(--duration-fast, 150ms) var(--easing-out, ease);
-}
-
-.admin-vertical-nav__toggle svg {
-  width: 1.25rem;
-  height: 1.25rem;
-  flex-shrink: 0;
-}
-
-.admin-vertical-nav__toggle:hover,
-.admin-vertical-nav__toggle:focus-visible {
-  background: rgba(79, 56, 37, 0.06);
-  color: var(--og-color-soil);
-  outline: none;
-}
-
-.admin-vertical-nav__toggle-label {
-  opacity: 0;
-  transform: translateX(-0.25rem);
-  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
-              transform var(--duration-fast, 150ms) var(--easing-out, ease);
-  white-space: nowrap;
-}
-
-.admin-vertical-nav.is-expanded .admin-vertical-nav__toggle-label {
-  opacity: 1;
-  transform: translateX(0);
-}
-
+/* List: top-aligned, not stretched. Overflow-y allows scroll if content
+   ever exceeds the sticky viewport budget. */
 .admin-vertical-nav__list {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.25rem;
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
 .admin-vertical-nav__link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.85rem;
   width: 100%;
-  min-height: 2.85rem;
-  padding: 0.55rem 0.75rem;
-  border: 1px solid transparent;
-  border-radius: 0.9rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.85rem;
+  border: none;
+  border-radius: 0.75rem;
   background: transparent;
   color: var(--og-color-soil);
   font: inherit;
@@ -154,26 +108,23 @@ body {
   cursor: pointer;
   white-space: nowrap;
   transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
-              color var(--duration-fast, 150ms) var(--easing-out, ease),
-              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+              color var(--duration-fast, 150ms) var(--easing-out, ease);
 }
 
 .admin-vertical-nav__link:hover,
 .admin-vertical-nav__link:focus-visible {
-  background: rgba(79, 56, 37, 0.07);
+  background: rgba(79, 56, 37, 0.08);
   outline: none;
 }
 
 .admin-vertical-nav__link.is-active {
-  background: linear-gradient(180deg, rgba(66, 107, 63, 0.96), rgba(79, 56, 37, 0.92));
-  color: var(--og-color-paper);
-  border-color: transparent;
-  box-shadow: 0 8px 20px rgba(38, 23, 15, 0.12);
+  background: rgba(66, 107, 63, 0.14);
+  color: var(--og-color-moss);
 }
 
-.admin-vertical-nav__link.is-active:hover {
-  background: linear-gradient(180deg, rgba(66, 107, 63, 0.96), rgba(79, 56, 37, 0.92));
-  color: var(--og-color-paper);
+.admin-vertical-nav__link.is-active:hover,
+.admin-vertical-nav__link.is-active:focus-visible {
+  background: rgba(66, 107, 63, 0.2);
 }
 
 .admin-vertical-nav__icon {
@@ -181,23 +132,18 @@ body {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 2.15rem;
-  height: 2.15rem;
-  border-radius: 0.75rem;
-  background: rgba(79, 56, 37, 0.08);
-  color: var(--og-color-soil);
-  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
-              color var(--duration-fast, 150ms) var(--easing-out, ease);
+  width: 1.6rem;
+  height: 1.6rem;
+  color: inherit;
 }
 
 .admin-vertical-nav__icon svg {
-  width: 1.2rem;
-  height: 1.2rem;
+  width: 1.3rem;
+  height: 1.3rem;
 }
 
 .admin-vertical-nav__link.is-active .admin-vertical-nav__icon {
-  background: rgba(255, 255, 255, 0.22);
-  color: var(--og-color-paper);
+  color: var(--og-color-moss);
 }
 
 .admin-vertical-nav__label {
@@ -206,24 +152,61 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: 0;
-  transform: translateX(-0.25rem);
-  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
-              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease);
 }
 
 .admin-vertical-nav.is-expanded .admin-vertical-nav__label {
   opacity: 1;
-  transform: translateX(0);
 }
 
 .admin-vertical-nav.is-collapsed .admin-vertical-nav__link {
   justify-content: center;
-  padding: 0.4rem;
+  padding: 0.55rem;
 }
 
-.admin-vertical-nav.is-collapsed .admin-vertical-nav__toggle {
+/* Collapse/expand handle: floats on the right edge of the nav, vertically
+   centered. Subtle by default, lights up on hover (of itself or the nav). */
+.admin-vertical-nav__toggle {
+  position: absolute;
+  top: 50%;
+  right: -0.85rem;
+  transform: translateY(-50%);
+  width: 1.7rem;
+  height: 1.7rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
-  padding: 0.4rem;
+  border: 1px solid rgba(79, 56, 37, 0.15);
+  border-radius: 50%;
+  background: var(--og-color-paper);
+  color: rgba(79, 56, 37, 0.7);
+  cursor: pointer;
+  opacity: 0;
+  box-shadow: 0 4px 12px rgba(38, 23, 15, 0.1);
+  transition: opacity var(--duration-fast, 150ms) var(--easing-out, ease),
+              color var(--duration-fast, 150ms) var(--easing-out, ease),
+              background-color var(--duration-fast, 150ms) var(--easing-out, ease);
+  z-index: 1;
+}
+
+.admin-vertical-nav:hover .admin-vertical-nav__toggle,
+.admin-vertical-nav:focus-within .admin-vertical-nav__toggle,
+.admin-vertical-nav__toggle:hover,
+.admin-vertical-nav__toggle:focus-visible {
+  opacity: 1;
+}
+
+.admin-vertical-nav__toggle:hover,
+.admin-vertical-nav__toggle:focus-visible {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  outline: none;
+}
+
+.admin-vertical-nav__toggle svg {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 /* ── Mobile: horizontal scroll fallback ───────────────────────────── */
@@ -239,7 +222,7 @@ body {
     position: static;
     top: auto;
     width: 100%;
-    height: auto;
+    max-height: none;
     flex-direction: row;
     gap: 0.4rem;
     padding: 0.65rem 0.75rem;
@@ -462,6 +445,107 @@ body {
   max-height: 20rem;
   object-fit: cover;
   border-radius: var(--og-radius-lg);
+}
+
+/* ── Photo carousel ───────────────────────────────────────────────── */
+
+.admin-photo-carousel {
+  position: relative;
+  display: block;
+  width: 100%;
+  border-radius: var(--og-radius-lg);
+  overflow: hidden;
+  background: rgba(38, 23, 15, 0.04);
+}
+
+.admin-photo-carousel__image {
+  display: block;
+  width: 100%;
+  max-height: 26rem;
+  object-fit: contain;
+  background: rgba(38, 23, 15, 0.04);
+}
+
+.admin-photo-carousel__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(38, 23, 15, 0.55);
+  color: var(--og-color-paper);
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease);
+}
+
+.admin-photo-carousel__nav:hover,
+.admin-photo-carousel__nav:focus-visible {
+  background: rgba(38, 23, 15, 0.8);
+  outline: none;
+}
+
+.admin-photo-carousel__nav svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.admin-photo-carousel__nav--prev {
+  left: 0.5rem;
+}
+
+.admin-photo-carousel__nav--next {
+  right: 0.5rem;
+}
+
+.admin-photo-carousel__counter {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--og-radius-pill, 999px);
+  background: rgba(38, 23, 15, 0.6);
+  color: var(--og-color-paper);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.admin-photo-carousel__dots {
+  position: absolute;
+  bottom: 0.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  gap: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--og-radius-pill, 999px);
+  background: rgba(38, 23, 15, 0.4);
+}
+
+.admin-photo-carousel__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: background-color var(--duration-fast, 150ms) var(--easing-out, ease),
+              transform var(--duration-fast, 150ms) var(--easing-out, ease);
+}
+
+.admin-photo-carousel__dot:hover {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.admin-photo-carousel__dot.is-active {
+  background: var(--og-color-paper);
+  transform: scale(1.2);
 }
 
 /* ── Store catalog ────────────────────────────────────────────────── */

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -233,7 +233,9 @@ body {
     flex-direction: column;
   }
 
-  .admin-vertical-nav {
+  .admin-vertical-nav,
+  .admin-vertical-nav.is-expanded,
+  .admin-vertical-nav.is-collapsed {
     position: static;
     top: auto;
     width: 100%;

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -169,7 +169,14 @@ body {
 
 .admin-vertical-nav.is-collapsed .admin-vertical-nav__link {
   justify-content: center;
+  gap: 0;
   padding: 0.55rem;
+}
+
+/* Remove the label from the flow when collapsed so the icon is truly
+   centered (opacity: 0 alone still reserves space via the label's flex: 1). */
+.admin-vertical-nav.is-collapsed .admin-vertical-nav__label {
+  display: none;
 }
 
 /* Collapse/expand handle: a small notch that grows out of the nav's right

--- a/apps/web/src/okra/OkraExperience.tsx
+++ b/apps/web/src/okra/OkraExperience.tsx
@@ -134,20 +134,6 @@ export function OkraExperience({
         </figure>
       </section>
 
-      {/* STATS */}
-      {hasGrowers ? (
-        <section className="ok-stats" aria-label="Community stats">
-          <div className="ok-stats__item">
-            <span className="ok-stats__value">{stats!.total_pins.toLocaleString()}</span>
-            <span className="ok-stats__label">growers on the map</span>
-          </div>
-          <div className="ok-stats__item">
-            <span className="ok-stats__value">{stats!.country_count.toLocaleString()}</span>
-            <span className="ok-stats__label">countries represented</span>
-          </div>
-        </section>
-      ) : null}
-
       {/* HOW IT WORKS */}
       <section className="ok-how" aria-labelledby="ok-how-heading">
         <header className="ok-how__header">
@@ -218,6 +204,19 @@ export function OkraExperience({
             Pins go up once growers send back a photo. Click one to see their garden.
           </p>
         </header>
+
+        {hasGrowers ? (
+          <div className="ok-stats" aria-label="Community stats">
+            <div className="ok-stats__item">
+              <span className="ok-stats__value">{stats!.total_pins.toLocaleString()}</span>
+              <span className="ok-stats__label">growers on the map</span>
+            </div>
+            <div className="ok-stats__item">
+              <span className="ok-stats__value">{stats!.country_count.toLocaleString()}</span>
+              <span className="ok-stats__label">countries represented</span>
+            </div>
+          </div>
+        ) : null}
 
         <div className="ok-map-container">
           <MapView

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1526,7 +1526,8 @@ img {
   position: absolute;
   top: calc(100% + 0.5rem);
   right: 0;
-  min-width: 10rem;
+  min-width: 14rem;
+  max-width: min(20rem, calc(100vw - 1.5rem));
   padding: 0.35rem;
   border: 1px solid rgba(79, 56, 37, 0.15);
   border-radius: 0.75rem;
@@ -1548,6 +1549,9 @@ img {
   font: inherit;
   color: var(--og-color-soil);
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .og-auth-menu__item:hover,

--- a/services/okra-api/openapi.yaml
+++ b/services/okra-api/openapi.yaml
@@ -350,15 +350,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /admin/requests/review-queue:
+  /admin/requests:
     get:
-      operationId: listSeedRequestReviewQueue
-      summary: List open seed requests for admin handling
+      operationId: listAdminSeedRequests
+      summary: List seed requests for admin handling
       tags:
         - admin
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - open
+          description: >-
+            Filter seed requests by status. Required. Currently only `open`
+            is supported.
       responses:
         '200':
-          description: Open seed requests
+          description: Seed requests matching the status filter
           content:
             application/json:
               schema:
@@ -370,6 +381,12 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/SeedRequestQueueItem'
+        '400':
+          description: Invalid or missing status query parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /admin/requests/{id}/statuses:
     post:
@@ -505,6 +522,9 @@ components:
           type: string
           format: uuid
         contributor_name:
+          type: string
+          nullable: true
+        contributor_email:
           type: string
           nullable: true
         story_text:

--- a/services/okra-api/scripts/integration-test.mjs
+++ b/services/okra-api/scripts/integration-test.mjs
@@ -87,7 +87,7 @@ async function run() {
   /**
    * Clean up test data.
    *
-   * The admin review-queue listing is paginated at 100 items; once stale
+   * The admin submissions listing is paginated at 100 items; once stale
    * CI submissions pile up past that limit the polling checks time out
    * before the new submission ever shows up. We run against a dedicated
    * staging environment with no human traffic, so the safe fix is to
@@ -237,12 +237,12 @@ async function run() {
       reporter.assert('auth-boundary', res.status === 401, `GET /admin/stats with invalid token returns 401 (got ${res.status})`, res.json);
     }
     {
-      const res = await noAuthAdmin.request('/requests/review-queue');
-      reporter.assert('auth-boundary', res.status === 401, `GET /admin/requests/review-queue without auth returns 401 (got ${res.status})`, res.json);
+      const res = await noAuthAdmin.request('/requests?status=open');
+      reporter.assert('auth-boundary', res.status === 401, `GET /admin/requests without auth returns 401 (got ${res.status})`, res.json);
     }
     {
-      const res = await badTokenAdmin.request('/requests/review-queue');
-      reporter.assert('auth-boundary', res.status === 401, `GET /admin/requests/review-queue with invalid token returns 401 (got ${res.status})`, res.json);
+      const res = await badTokenAdmin.request('/requests?status=open');
+      reporter.assert('auth-boundary', res.status === 401, `GET /admin/requests with invalid token returns 401 (got ${res.status})`, res.json);
     }
     {
       const res = await noAuthAdmin.request(`/requests/${dummyId}/statuses`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: 'handled' }) });
@@ -577,10 +577,10 @@ async function run() {
 
     if (adminSeedRequestId) {
       // Poll admin review queue until the seed request appears.
-      console.log('  Polling /admin/requests/review-queue for new seed request...');
+      console.log('  Polling /admin/requests?status=open for new seed request...');
       let matchedItem = null;
       const queueResult = await poll({
-        fn: () => adminApi.request('/requests/review-queue'),
+        fn: () => adminApi.request('/requests?status=open'),
         until: (res) => {
           if (!Array.isArray(res.json?.data)) return false;
           matchedItem = res.json.data.find((item) => item.id === adminSeedRequestId);
@@ -633,9 +633,9 @@ async function run() {
         `replay POST /admin/requests/:id/statuses returns 409 or 404 (got ${replayRes.status})`, replayRes.json);
 
       // Poll until the request disappears from the review queue.
-      console.log('  Polling /admin/requests/review-queue until handled request is gone...');
+      console.log('  Polling /admin/requests?status=open until handled request is gone...');
       const goneResult = await poll({
-        fn: () => adminApi.request('/requests/review-queue'),
+        fn: () => adminApi.request('/requests?status=open'),
         until: (res) => {
           if (!Array.isArray(res.json?.data)) return false;
           return !res.json.data.some((item) => item.id === adminSeedRequestId);

--- a/services/okra-api/src/handlers/admin-routes.mjs
+++ b/services/okra-api/src/handlers/admin-routes.mjs
@@ -23,6 +23,7 @@ const VALID_STATUSES = ['pending_review', 'approved', 'denied'];
 const VALID_ACTIONS = ['approved', 'denied'];
 const VALID_DENIAL_REASONS = ['spam', 'invalid_location', 'inappropriate', 'other'];
 const VALID_REQUEST_ACTIONS = ['handled'];
+const VALID_REQUEST_STATUSES = ['open'];
 
 function getSeedRequestsTableName() {
   const tableName = process.env.SEED_REQUESTS_TABLE_NAME;
@@ -119,7 +120,18 @@ function validateCursor(raw) {
 }
 
 export function registerAdminRoutes(app) {
-  app.get('/requests/review-queue', async () => {
+  app.get('/requests', async (ctx) => {
+    const params = ctx.event?.queryStringParameters || {};
+    const status = params.status;
+
+    if (!status || !VALID_REQUEST_STATUSES.includes(status)) {
+      return errorResponse(
+        400,
+        'INVALID_STATUS',
+        `status query parameter is required. Must be one of: ${VALID_REQUEST_STATUSES.join(', ')}`
+      );
+    }
+
     try {
       return {
         data: await listOpenSeedRequests(),
@@ -129,7 +141,7 @@ export function registerAdminRoutes(app) {
         level: 'error',
         message: err instanceof Error ? err.message : String(err),
         errorName: err instanceof Error ? err.name : 'UnknownError',
-        endpoint: 'GET /admin/requests/review-queue',
+        endpoint: 'GET /admin/requests',
       }));
       return errorResponse(500, 'INTERNAL_ERROR', 'An unexpected error occurred');
     }
@@ -175,134 +187,6 @@ export function registerAdminRoutes(app) {
         requestId,
       }));
       return errorResponse(500, 'INTERNAL_ERROR', 'An unexpected error occurred');
-    }
-  });
-
-  // ─── GET /submissions/review-queue ──────────────────────────────
-  app.get('/submissions/review-queue', async (ctx) => {
-    const bucket = process.env.MEDIA_BUCKET_NAME;
-    if (!bucket) {
-      console.error(JSON.stringify({
-        level: 'error',
-        message: 'MEDIA_BUCKET_NAME not set — cannot generate pre-signed URLs',
-        endpoint: 'GET /admin/submissions/review-queue'
-      }));
-      return errorResponse(500, 'INTERNAL_ERROR', 'An unexpected error occurred');
-    }
-
-    const params = ctx.event?.queryStringParameters || {};
-
-    const limitResult = validateLimit(params.limit);
-    if (!limitResult.valid) return limitResult.response;
-    const limit = limitResult.value;
-
-    const cursorResult = validateCursor(params.cursor);
-    if (!cursorResult.valid) return cursorResult.response;
-    const cursor = cursorResult.value;
-
-    const client = await createDbClient();
-    await client.connect();
-    try {
-      let rows;
-      if (cursor) {
-        const res = await client.query(
-          `SELECT s.id, s.contributor_name, s.contributor_email, s.story_text,
-                  s.raw_location_text, s.privacy_mode, s.display_lat, s.display_lng,
-                  s.status, s.created_at,
-                  s.created_at::text AS created_at_raw
-           FROM submissions s
-           WHERE s.status = 'pending_review'
-             AND EXISTS (
-               SELECT 1 FROM submission_photos sp
-               WHERE sp.submission_id = s.id AND sp.status = 'ready'
-             )
-             AND (s.created_at, s.id) > ($1::timestamptz, $2)
-           ORDER BY s.created_at ASC, s.id ASC
-           LIMIT $3`,
-          [cursor.created_at, cursor.id, limit + 1]
-        );
-        rows = res.rows;
-      } else {
-        const res = await client.query(
-          `SELECT s.id, s.contributor_name, s.contributor_email, s.story_text,
-                  s.raw_location_text, s.privacy_mode, s.display_lat, s.display_lng,
-                  s.status, s.created_at,
-                  s.created_at::text AS created_at_raw
-           FROM submissions s
-           WHERE s.status = 'pending_review'
-             AND EXISTS (
-               SELECT 1 FROM submission_photos sp
-               WHERE sp.submission_id = s.id AND sp.status = 'ready'
-             )
-           ORDER BY s.created_at ASC, s.id ASC
-           LIMIT $1`,
-          [limit + 1]
-        );
-        rows = res.rows;
-      }
-
-      let nextCursor = null;
-      if (rows.length > limit) {
-        rows.pop();
-        nextCursor = encodeCursor(rows[rows.length - 1]);
-      }
-
-      // Batch-fetch photos for all returned submissions
-      const submissionIds = rows.map(r => r.id);
-      const photoMap = {};
-      if (submissionIds.length > 0) {
-        const photoRes = await client.query(
-          `SELECT submission_id, original_s3_key
-           FROM submission_photos
-           WHERE submission_id = ANY($1)
-             AND status = 'ready'
-           ORDER BY submission_id, created_at ASC`,
-          [submissionIds]
-        );
-        for (const photo of photoRes.rows) {
-          if (!photoMap[photo.submission_id]) {
-            photoMap[photo.submission_id] = [];
-          }
-          photoMap[photo.submission_id].push(photo.original_s3_key);
-        }
-      }
-
-      // Generate pre-signed S3 URLs for each submission's photos
-      const data = await Promise.all(
-        rows.map(async (row) => {
-          const keys = photoMap[row.id] || [];
-          const photos = await Promise.all(
-            keys.map((key) => presignPhotoUrl(bucket, key, 900))
-          );
-          return {
-            id: row.id,
-            contributor_name: row.contributor_name,
-            contributor_email: row.contributor_email,
-            story_text: row.story_text,
-            raw_location_text: row.raw_location_text,
-            privacy_mode: row.privacy_mode,
-            display_lat: row.display_lat,
-            display_lng: row.display_lng,
-            status: row.status,
-            created_at: row.created_at,
-            photo_count: photos.length,
-            has_photos: photos.length > 0,
-            photos
-          };
-        })
-      );
-
-      return { data, cursor: nextCursor };
-    } catch (err) {
-      console.error(JSON.stringify({
-        level: 'error',
-        message: err instanceof Error ? err.message : String(err),
-        errorName: err instanceof Error ? err.name : 'UnknownError',
-        endpoint: 'GET /admin/submissions/review-queue'
-      }));
-      return errorResponse(500, 'INTERNAL_ERROR', 'An unexpected error occurred');
-    } finally {
-      await client.end();
     }
   });
 
@@ -352,8 +236,9 @@ export function registerAdminRoutes(app) {
         const cursorPlaceholder2 = `$${baseParams.length + 2}`;
         const limitPlaceholder = `$${baseParams.length + 3}`;
         queryText = `
-          SELECT s.id, s.contributor_name, s.story_text, s.raw_location_text,
-                 s.privacy_mode, s.display_lat, s.display_lng, s.status, s.created_at,
+          SELECT s.id, s.contributor_name, s.contributor_email, s.story_text,
+                 s.raw_location_text, s.privacy_mode, s.display_lat, s.display_lng,
+                 s.status, s.created_at,
                  s.created_at::text AS created_at_raw
           FROM submissions s
           WHERE ${statusClause}
@@ -366,8 +251,9 @@ export function registerAdminRoutes(app) {
       } else {
         const limitPlaceholder = `$${baseParams.length + 1}`;
         queryText = `
-          SELECT s.id, s.contributor_name, s.story_text, s.raw_location_text,
-                 s.privacy_mode, s.display_lat, s.display_lng, s.status, s.created_at,
+          SELECT s.id, s.contributor_name, s.contributor_email, s.story_text,
+                 s.raw_location_text, s.privacy_mode, s.display_lat, s.display_lng,
+                 s.status, s.created_at,
                  s.created_at::text AS created_at_raw
           FROM submissions s
           WHERE ${statusClause}
@@ -416,6 +302,7 @@ export function registerAdminRoutes(app) {
           const photos = await Promise.all(keys.map((key) => presignPhotoUrl(bucket, key)));
           return {
             id: row.id, contributor_name: row.contributor_name,
+            contributor_email: row.contributor_email,
             story_text: row.story_text, raw_location_text: row.raw_location_text,
             privacy_mode: row.privacy_mode, display_lat: row.display_lat,
             display_lng: row.display_lng, status: row.status,

--- a/services/okra-api/src/handlers/admin-routes.mjs
+++ b/services/okra-api/src/handlers/admin-routes.mjs
@@ -106,6 +106,20 @@ function validateLimit(raw) {
   return { valid: true, value: Math.min(parsed, 100) };
 }
 
+/** Validate/parse the 1-indexed `page` query parameter. Defaults to 1. */
+function validatePage(raw) {
+  if (raw == null) return { valid: true, value: 1 };
+  const trimmed = String(raw).trim();
+  if (!/^[0-9]+$/.test(trimmed)) {
+    return { valid: false, response: errorResponse(400, 'INVALID_PAGE', 'Page must be a positive integer') };
+  }
+  const parsed = parseInt(trimmed, 10);
+  if (parsed === 0) {
+    return { valid: false, response: errorResponse(400, 'INVALID_PAGE', 'Page must be a positive integer') };
+  }
+  return { valid: true, value: parsed };
+}
+
 /**
  * Validate and decode the `cursor` query parameter.
  * Returns { valid: true, value: object|null } or { valid: false, response: Response }.
@@ -154,10 +168,20 @@ export function registerAdminRoutes(app) {
       );
     }
 
+    const limitResult = validateLimit(params.limit);
+    if (!limitResult.valid) return limitResult.response;
+    const limit = limitResult.value;
+
+    const pageResult = validatePage(params.page);
+    if (!pageResult.valid) return pageResult.response;
+    const page = pageResult.value;
+
     try {
-      return {
-        data: await listOpenSeedRequests(),
-      };
+      const all = await listOpenSeedRequests();
+      const total = all.length;
+      const start = (page - 1) * limit;
+      const data = all.slice(start, start + limit);
+      return { data, total, page, limit };
     } catch (err) {
       console.error(JSON.stringify({
         level: 'error',
@@ -251,6 +275,17 @@ export function registerAdminRoutes(app) {
     const client = await createDbClient();
     await client.connect();
     try {
+      // Total count for the same filter (ignores cursor — reflects the full
+      // matching set so the UI can render "(N)" counts and page controls).
+      const countQuery = `
+        SELECT COUNT(*)::int AS total
+        FROM submissions s
+        WHERE ${statusClause}
+          ${photoClause}
+      `;
+      const countResult = await client.query(countQuery, baseParams);
+      const total = countResult.rows[0]?.total ?? 0;
+
       let queryText;
       let queryParams;
       if (cursor) {
@@ -297,7 +332,7 @@ export function registerAdminRoutes(app) {
       }
 
       if (rows.length === 0) {
-        return { data: [], cursor: null };
+        return { data: [], cursor: null, total };
       }
 
       const submissionIds = rows.map((r) => r.id);
@@ -335,7 +370,7 @@ export function registerAdminRoutes(app) {
         })
       );
 
-      return { data, cursor: nextCursor };
+      return { data, cursor: nextCursor, total };
     } catch (err) {
       console.error(JSON.stringify({
         level: 'error',

--- a/services/okra-api/src/handlers/admin-routes.mjs
+++ b/services/okra-api/src/handlers/admin-routes.mjs
@@ -119,6 +119,28 @@ function validateCursor(raw) {
   return { valid: true, value: decoded };
 }
 
+// Upsert the authenticated admin into admin_users and return the row id.
+// Anyone reaching this point has already cleared the Admin-group authorizer
+// on the admin API Gateway, so auto-provisioning on first review is safe —
+// otherwise only the CI-provisioned user could approve/deny, which is how
+// human admins were hitting 403 before.
+async function resolveAdminUserId(client, authorizer) {
+  const cognitoSub = authorizer?.sub;
+  if (!cognitoSub) return null;
+
+  const email = authorizer?.email || null;
+  const result = await client.query(
+    `INSERT INTO admin_users (cognito_sub, email, display_name)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (cognito_sub) DO UPDATE SET
+       email = COALESCE(EXCLUDED.email, admin_users.email),
+       updated_at = now()
+     RETURNING id`,
+    [cognitoSub, email, email]
+  );
+  return result.rows[0]?.id ?? null;
+}
+
 export function registerAdminRoutes(app) {
   app.get('/requests', async (ctx) => {
     const params = ctx.event?.queryStringParameters || {};
@@ -280,7 +302,8 @@ export function registerAdminRoutes(app) {
 
       const submissionIds = rows.map((r) => r.id);
       const photosResult = await client.query(
-        `SELECT submission_id, original_s3_key
+        `SELECT submission_id,
+                COALESCE(normalized_s3_key, original_s3_key) AS display_s3_key
          FROM submission_photos
          WHERE submission_id = ANY($1)
          ORDER BY submission_id, created_at ASC`,
@@ -292,7 +315,7 @@ export function registerAdminRoutes(app) {
         if (!photosBySubmission[photo.submission_id]) {
           photosBySubmission[photo.submission_id] = [];
         }
-        photosBySubmission[photo.submission_id].push(photo.original_s3_key);
+        photosBySubmission[photo.submission_id].push(photo.display_s3_key);
       }
 
       const bucket = process.env.MEDIA_BUCKET_NAME;
@@ -401,11 +424,7 @@ async function handleApproval(ctx, submissionId, { review_notes, display_lat, di
       return errorResponse(400, 'MISSING_PHOTOS', 'At least one photo is required for approval');
     }
 
-    const cognitoSub = ctx.event.requestContext?.authorizer?.sub || 'system';
-    const adminResult = await client.query(
-      'SELECT id FROM admin_users WHERE cognito_sub = $1', [cognitoSub]
-    );
-    const adminUserId = adminResult.rows.length > 0 ? adminResult.rows[0].id : null;
+    const adminUserId = await resolveAdminUserId(client, ctx.event.requestContext?.authorizer);
     if (!adminUserId) {
       return errorResponse(403, 'FORBIDDEN', 'Admin user not found');
     }
@@ -508,11 +527,7 @@ async function handleDenial(ctx, submissionId, { reason, review_notes }) {
   const client = await createDbClient();
   await client.connect();
   try {
-    const cognitoSub = ctx.event.requestContext?.authorizer?.sub || 'system';
-    const adminResult = await client.query(
-      'SELECT id FROM admin_users WHERE cognito_sub = $1', [cognitoSub]
-    );
-    const adminUserId = adminResult.rows.length > 0 ? adminResult.rows[0].id : null;
+    const adminUserId = await resolveAdminUserId(client, ctx.event.requestContext?.authorizer);
     if (!adminUserId) {
       return errorResponse(403, 'FORBIDDEN', 'Admin user not found');
     }

--- a/services/okra-api/src/services/admin-stats.mjs
+++ b/services/okra-api/src/services/admin-stats.mjs
@@ -90,7 +90,7 @@ export async function getUserCount() {
   }
 }
 
-// Mirrors the GET /submissions?status=pending_review review-queue filter:
+// Mirrors the GET /submissions?status=pending moderation-queue filter:
 // a submission only counts as actionable when it has at least one
 // submission_photos row in `ready` status. Without this, the dashboard
 // inflates the backlog whenever photo processing lags or fails.

--- a/services/okra-api/test/api/admin-routes.test.ts
+++ b/services/okra-api/test/api/admin-routes.test.ts
@@ -182,9 +182,9 @@ describe('GET /admin/submissions', () => {
     const res = await handler(makeRestApiEvent('/submissions'));
     const { statusCode, body } = parseRes(res);
     expect(statusCode).toBe(200);
-    expect(body).toEqual({ data: [], cursor: null });
+    expect(body).toEqual({ data: [], cursor: null, total: 0 });
     const queryCall = mockClient.query.mock.calls.find(
-      (c: any[]) => typeof c[0] === 'string' && c[0].includes('FROM submissions')
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('FROM submissions s') && c[0].includes('ORDER BY')
     );
     expect(queryCall).toBeDefined();
     expect(queryCall![0]).not.toContain("'pending_review'");
@@ -282,7 +282,7 @@ describe('GET /admin/submissions', () => {
       makeRestApiEvent('/submissions', 'GET', { queryStringParameters: { limit: '200' } })
     );
     const queryCall = mockClient.query.mock.calls.find(
-      (c: any[]) => typeof c[0] === 'string' && c[0].includes('FROM submissions')
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('FROM submissions s') && c[0].includes('ORDER BY')
     );
     expect(queryCall![1]).toContain(101);
   });

--- a/services/okra-api/test/api/admin-routes.test.ts
+++ b/services/okra-api/test/api/admin-routes.test.ts
@@ -840,13 +840,35 @@ describe('seed request admin queue', () => {
     }];
 
     const { statusCode, body } = parseRes(
-      await handler(makeRestApiEvent('/requests/review-queue'))
+      await handler(makeRestApiEvent('/requests', 'GET', {
+        queryStringParameters: { status: 'open' },
+      }))
     );
 
     expect(statusCode).toBe(200);
     expect(body.data).toHaveLength(2);
     expect(body.data[0].id).toBe('22222222-2222-2222-2222-222222222222');
     expect(body.data[1].id).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('returns INVALID_STATUS when status query parameter is missing', async () => {
+    const { statusCode, body } = parseRes(
+      await handler(makeRestApiEvent('/requests'))
+    );
+
+    expect(statusCode).toBe(400);
+    expect(body.error.code).toBe('INVALID_STATUS');
+  });
+
+  it('returns INVALID_STATUS for unsupported status value', async () => {
+    const { statusCode, body } = parseRes(
+      await handler(makeRestApiEvent('/requests', 'GET', {
+        queryStringParameters: { status: 'handled' },
+      }))
+    );
+
+    expect(statusCode).toBe(400);
+    expect(body.error.code).toBe('INVALID_STATUS');
   });
 
   it('marks a seed request as handled', async () => {
@@ -885,265 +907,5 @@ describe('seed request admin queue', () => {
 
     expect(statusCode).toBe(400);
     expect(body.error.code).toBe('INVALID_ACTION');
-  });
-});
-
-
-// ═══════════════════════════════════════════════════════════════════════════
-// GET /admin/submissions/review-queue
-// ═══════════════════════════════════════════════════════════════════════════
-
-describe('GET /admin/submissions/review-queue', () => {
-  function makeReviewQueueSubmissionRow(overrides: Record<string, any> = {}) {
-    return {
-      id: '550e8400-e29b-41d4-a716-446655440001',
-      contributor_name: 'Alice',
-      contributor_email: 'alice@example.com',
-      story_text: 'Found okra here',
-      raw_location_text: '123 Main St',
-      privacy_mode: 'exact',
-      display_lat: 34.05,
-      display_lng: -118.24,
-      status: 'pending_review',
-      created_at: new Date('2024-01-15T10:00:00Z'),
-      created_at_raw: '2024-01-15 10:00:00.000000+00',
-      ...overrides,
-    };
-  }
-
-  function setupReviewQueueMocks(submissionRows: any[] = [], photoRows: any[] = []) {
-    queryResponses = {
-      'pending_review': { rows: submissionRows, rowCount: submissionRows.length },
-      'original_s3_key': { rows: photoRows, rowCount: photoRows.length },
-    };
-  }
-
-  // ─── Validates: Requirement 5.1 — Only pending submissions with ready photos ──
-  it('returns only pending submissions with ready photos', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], [
-      { submission_id: sub1.id, original_s3_key: 'photos/abc.jpg' },
-    ]);
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { statusCode, body } = parseRes(res);
-
-    expect(statusCode).toBe(200);
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0].id).toBe(sub1.id);
-    expect(body.data[0].status).toBe('pending_review');
-  });
-
-  // ─── Validates: Requirement 5.1, 5.4 — Submissions without ready photos excluded ──
-  it('excludes submissions with only uploaded/processing/failed photos (via DB query)', async () => {
-    // The EXISTS subquery in the handler filters at the DB level,
-    // so if the DB returns no rows, the response should be empty.
-    setupReviewQueueMocks([], []);
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { statusCode, body } = parseRes(res);
-
-    expect(statusCode).toBe(200);
-    expect(body.data).toEqual([]);
-    expect(body.cursor).toBeNull();
-  });
-
-  // ─── Validates: Requirement 5.5 — Pre-signed URLs for ready photos only ──
-  it('generates pre-signed URLs for ready photos only', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], [
-      { submission_id: sub1.id, original_s3_key: 'photos/ready1.jpg' },
-      { submission_id: sub1.id, original_s3_key: 'photos/ready2.jpg' },
-    ]);
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { body } = parseRes(res);
-
-    expect(body.data[0].photos).toHaveLength(2);
-    expect(body.data[0].photos[0]).toBe('https://s3.example.com/signed-url');
-    expect(body.data[0].photos[1]).toBe('https://s3.example.com/signed-url');
-    expect(body.data[0].photo_count).toBe(2);
-    expect(body.data[0].has_photos).toBe(true);
-  });
-
-  // ─── Validates: Requirement 5.3 — Response shape with all required fields ──
-  it('returns response with all required fields', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], [
-      { submission_id: sub1.id, original_s3_key: 'photos/abc.jpg' },
-    ]);
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { body } = parseRes(res);
-
-    expect(body.data).toHaveLength(1);
-    const item = body.data[0];
-    for (const field of [
-      'id', 'contributor_name', 'contributor_email', 'story_text',
-      'raw_location_text', 'privacy_mode', 'display_lat', 'display_lng',
-      'status', 'created_at', 'photo_count', 'has_photos', 'photos',
-    ]) {
-      expect(item).toHaveProperty(field);
-    }
-    expect(item.photo_count).toBe(1);
-    expect(item.has_photos).toBe(true);
-    expect(Array.isArray(item.photos)).toBe(true);
-  });
-
-  // ─── Validates: Requirement 5.3 — photo_count and has_photos when no photos ──
-  it('returns photo_count=0 and has_photos=false when submission has no ready photos', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], []);
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { body } = parseRes(res);
-
-    expect(body.data[0].photo_count).toBe(0);
-    expect(body.data[0].has_photos).toBe(false);
-    expect(body.data[0].photos).toEqual([]);
-  });
-
-  // ─── Validates: Requirement 6.2 — Existing GET /admin/submissions still works ──
-  it('existing GET /admin/submissions endpoint still works unchanged', async () => {
-    queryResponses = {
-      'FROM submissions': { rows: [], rowCount: 0 },
-    };
-
-    const res = await handler(makeRestApiEvent('/submissions'));
-    const { statusCode, body } = parseRes(res);
-
-    expect(statusCode).toBe(200);
-    expect(body).toEqual({ data: [], cursor: null });
-  });
-
-  // ─── Validates: Requirement 7.5 — Limit validation on review queue ──
-  it('returns INVALID_LIMIT for zero limit', async () => {
-    const res = await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { limit: '0' },
-      })
-    );
-    const { statusCode, body } = parseRes(res);
-    expect(statusCode).toBe(400);
-    expect(body.error.code).toBe('INVALID_LIMIT');
-  });
-
-  it('returns INVALID_LIMIT for negative limit', async () => {
-    const res = await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { limit: '-5' },
-      })
-    );
-    expect(parseRes(res).body.error.code).toBe('INVALID_LIMIT');
-  });
-
-  it('returns INVALID_LIMIT for non-numeric limit', async () => {
-    const res = await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { limit: 'abc' },
-      })
-    );
-    expect(parseRes(res).body.error.code).toBe('INVALID_LIMIT');
-  });
-
-  it('returns INVALID_LIMIT for decimal limit', async () => {
-    const res = await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { limit: '3.7' },
-      })
-    );
-    expect(parseRes(res).body.error.code).toBe('INVALID_LIMIT');
-  });
-
-  it('clamps limit above 100 to 100', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], []);
-
-    await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { limit: '200' },
-      })
-    );
-
-    // The handler should query with limit + 1 = 101
-    const queryCall = mockClient.query.mock.calls.find(
-      (c: any[]) => typeof c[0] === 'string' && c[0].includes('pending_review') && c[0].includes('LIMIT')
-    );
-    expect(queryCall).toBeDefined();
-    expect(queryCall![1]).toContain(101);
-  });
-
-  // ─── Validates: Requirement 7.6 — Cursor validation on review queue ──
-  it('returns INVALID_CURSOR for malformed cursor', async () => {
-    const res = await handler(
-      makeRestApiEvent('/submissions/review-queue', 'GET', {
-        queryStringParameters: { cursor: 'not-valid' },
-      })
-    );
-    expect(parseRes(res).body.error.code).toBe('INVALID_CURSOR');
-  });
-
-  // ─── Validates: Requirement 9.1 — 500 error when MEDIA_BUCKET_NAME not set ──
-  it('returns 500 INTERNAL_ERROR when MEDIA_BUCKET_NAME is not set', async () => {
-    delete process.env.MEDIA_BUCKET_NAME;
-
-    const res = await handler(makeRestApiEvent('/submissions/review-queue'));
-    const { statusCode, body } = parseRes(res);
-
-    expect(statusCode).toBe(500);
-    expect(body.error.code).toBe('INTERNAL_ERROR');
-    expect(body.error.message).toBe('An unexpected error occurred');
-  });
-
-  // ─── Empty result set ──
-  it('returns empty result set as { data: [], cursor: null }', async () => {
-    setupReviewQueueMocks([], []);
-
-    const { body } = parseRes(
-      await handler(makeRestApiEvent('/submissions/review-queue'))
-    );
-    expect(body.data).toEqual([]);
-    expect(body.cursor).toBeNull();
-  });
-
-  // ─── Cursor is null on last page ──
-  it('cursor is null on last page', async () => {
-    const sub1 = makeReviewQueueSubmissionRow();
-    setupReviewQueueMocks([sub1], []);
-
-    const { body } = parseRes(
-      await handler(makeRestApiEvent('/submissions/review-queue'))
-    );
-    expect(body.cursor).toBeNull();
-  });
-
-  // ─── Multiple submissions with photos ──
-  it('returns multiple submissions with their respective photos', async () => {
-    const sub1 = makeReviewQueueSubmissionRow({
-      id: '550e8400-e29b-41d4-a716-446655440001',
-      created_at: new Date('2024-01-15T10:00:00Z'),
-      created_at_raw: '2024-01-15 10:00:00.000000+00',
-    });
-    const sub2 = makeReviewQueueSubmissionRow({
-      id: '550e8400-e29b-41d4-a716-446655440002',
-      contributor_name: 'Bob',
-      created_at: new Date('2024-01-16T10:00:00Z'),
-      created_at_raw: '2024-01-16 10:00:00.000000+00',
-    });
-
-    setupReviewQueueMocks([sub1, sub2], [
-      { submission_id: sub1.id, original_s3_key: 'photos/sub1-photo.jpg' },
-      { submission_id: sub2.id, original_s3_key: 'photos/sub2-photo1.jpg' },
-      { submission_id: sub2.id, original_s3_key: 'photos/sub2-photo2.jpg' },
-    ]);
-
-    const { body } = parseRes(
-      await handler(makeRestApiEvent('/submissions/review-queue'))
-    );
-
-    expect(body.data).toHaveLength(2);
-    expect(body.data[0].photos).toHaveLength(1);
-    expect(body.data[1].photos).toHaveLength(2);
-    expect(body.data[1].photo_count).toBe(2);
   });
 });

--- a/services/okra-api/test/api/paginated-endpoints.property.test.ts
+++ b/services/okra-api/test/api/paginated-endpoints.property.test.ts
@@ -352,7 +352,7 @@ describe('Property 10: Admin Review Queue Pagination Completeness with Photo Rea
                   if (p.status === 'ready') {
                     rows.push({
                       submission_id: s.id,
-                      original_s3_key: p.original_s3_key,
+                      display_s3_key: p.original_s3_key,
                       created_at: p.created_at,
                     });
                   }
@@ -524,7 +524,7 @@ describe('Property 11: Admin Review Queue Response Shape', () => {
                   if (p.status === 'ready') {
                     rows.push({
                       submission_id: s.id,
-                      original_s3_key: p.original_s3_key,
+                      display_s3_key: p.original_s3_key,
                       created_at: p.created_at,
                     });
                   }
@@ -661,7 +661,7 @@ describe('Property 12: Admin Review Queue Photo Ordering and Ready Filter', () =
                   if (p.status === 'ready') {
                     rows.push({
                       submission_id: s.id,
-                      original_s3_key: p.original_s3_key,
+                      display_s3_key: p.original_s3_key,
                       created_at: p.created_at,
                     });
                   }

--- a/services/okra-api/test/api/paginated-endpoints.property.test.ts
+++ b/services/okra-api/test/api/paginated-endpoints.property.test.ts
@@ -138,7 +138,7 @@ function resetMocks() {
 
 // Feature: paginated-endpoints, Property 9: Invalid Cursor Rejection
 
-// Import admin handler for testing the review-queue endpoint
+// Import admin handler for testing the moderation queue endpoint
 const { handler: adminHandler } = await import('../../src/handlers/admin-api.mjs');
 
 describe('Property 9: Invalid Cursor Rejection', () => {
@@ -222,7 +222,7 @@ describe('Property 9: Invalid Cursor Rejection', () => {
     arbBase64urlJsonNonUuidId
   );
 
-  it('invalid cursor values return 400 INVALID_CURSOR on GET /admin/submissions/review-queue', async () => {
+  it('invalid cursor values return 400 INVALID_CURSOR on GET /admin/submissions?status=pending', async () => {
     await fc.assert(
       fc.asyncProperty(arbInvalidCursor, async (invalidCursor) => {
         resetMocks();
@@ -230,8 +230,8 @@ describe('Property 9: Invalid Cursor Rejection', () => {
         process.env.MEDIA_BUCKET_NAME = 'test-bucket';
 
         const res = await adminHandler(
-          makeRestApiEvent('/submissions/review-queue', 'GET', {
-            queryStringParameters: { cursor: invalidCursor },
+          makeRestApiEvent('/submissions', 'GET', {
+            queryStringParameters: { status: 'pending', cursor: invalidCursor },
           })
         );
         const { statusCode, body } = parseRes(res);
@@ -279,7 +279,15 @@ describe('Property 10: Admin Review Queue Pagination Completeness with Photo Rea
       fc.asyncProperty(
         fc.array(arbSubmissionWithPhotos, { minLength: 0, maxLength: 25 }),
         fc.integer({ min: 1, max: 8 }),
-        async (submissions, pageSize) => {
+        async (rawSubmissions, pageSize) => {
+          // Dedupe by id — fc.uuid() can shrink to identical values, and the
+          // downstream assertions assume ids are unique.
+          const seen = new Set<string>();
+          const submissions = rawSubmissions.filter((s) => {
+            if (seen.has(s.id)) return false;
+            seen.add(s.id);
+            return true;
+          });
           // Determine expected set: pending_review AND has at least one ready photo
           const hasReadyPhoto = (s: typeof submissions[number]) =>
             s.photos.some((p) => p.status === 'ready');
@@ -305,10 +313,13 @@ describe('Property 10: Admin Review Queue Pagination Completeness with Photo Rea
                   return a.id.localeCompare(b.id);
                 });
 
-              // Apply cursor if present (cursor query has 3 params: created_at, id, limit)
-              if (params.length === 3) {
-                const cursorDate = new Date(params[0]);
-                const cursorId = params[1];
+              // Apply cursor if present. With status=pending the query sends
+              // `[status, cursor.created_at, cursor.id, limit]` (length 4), or
+              // `[status, limit]` on the first page (length 2). When a cursor
+              // is present its (created_at, id) tuple sits just before limit.
+              if (params.length === 4) {
+                const cursorDate = new Date(params[1]);
+                const cursorId = params[2];
                 filtered = filtered.filter((s) => {
                   const timeDiff = s.created_at.getTime() - cursorDate.getTime();
                   if (timeDiff > 0) return true; // later created_at → comes after in ASC
@@ -368,11 +379,11 @@ describe('Property 10: Admin Review Queue Pagination Completeness with Photo Rea
           do {
             resetMocks();
 
-            const qsp: Record<string, string> = { limit: String(pageSize) };
+            const qsp: Record<string, string> = { status: 'pending', limit: String(pageSize) };
             if (cursor) qsp.cursor = cursor;
 
             const res = await adminHandler(
-              makeRestApiEvent('/submissions/review-queue', 'GET', {
+              makeRestApiEvent('/submissions', 'GET', {
                 queryStringParameters: qsp,
               })
             );
@@ -531,8 +542,8 @@ describe('Property 11: Admin Review Queue Response Shape', () => {
           resetMocks();
 
           const res = await adminHandler(
-            makeRestApiEvent('/submissions/review-queue', 'GET', {
-              queryStringParameters: { limit: '100' },
+            makeRestApiEvent('/submissions', 'GET', {
+              queryStringParameters: { status: 'pending', limit: '100' },
             })
           );
           const { statusCode, body } = parseRes(res);
@@ -669,8 +680,8 @@ describe('Property 12: Admin Review Queue Photo Ordering and Ready Filter', () =
           resetMocks();
 
           const res = await adminHandler(
-            makeRestApiEvent('/submissions/review-queue', 'GET', {
-              queryStringParameters: { limit: '100' },
+            makeRestApiEvent('/submissions', 'GET', {
+              queryStringParameters: { status: 'pending', limit: '100' },
             })
           );
           const { statusCode, body } = parseRes(res);
@@ -783,7 +794,7 @@ describe('Property 13: Error Response Shape Consistency', () => {
     expect(body.error.message.length).toBeGreaterThan(0);
   }
 
-  it('error responses from GET /admin/submissions/review-queue have shape { error: { code, message } } with non-empty strings', async () => {
+  it('error responses from GET /admin/submissions?status=pending have shape { error: { code, message } } with non-empty strings', async () => {
     await fc.assert(
       fc.asyncProperty(arbErrorTrigger, async ({ queryStringParameters, expectedCode }) => {
         resetMocks();
@@ -791,7 +802,9 @@ describe('Property 13: Error Response Shape Consistency', () => {
         process.env.MEDIA_BUCKET_NAME = 'test-bucket';
 
         const res = await adminHandler(
-          makeRestApiEvent('/submissions/review-queue', 'GET', { queryStringParameters })
+          makeRestApiEvent('/submissions', 'GET', {
+            queryStringParameters: { status: 'pending', ...(queryStringParameters ?? {}) },
+          })
         );
         const { statusCode, body } = parseRes(res);
 
@@ -806,7 +819,7 @@ describe('Property 13: Error Response Shape Consistency', () => {
     );
   });
 
-  it('database error responses (500) have shape { error: { code, message } } with non-empty strings on GET /admin/submissions/review-queue', async () => {
+  it('database error responses (500) have shape { error: { code, message } } with non-empty strings on GET /admin/submissions?status=pending', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.constant(null),
@@ -819,7 +832,9 @@ describe('Property 13: Error Response Shape Consistency', () => {
           });
 
           const res = await adminHandler(
-            makeRestApiEvent('/submissions/review-queue', 'GET', { queryStringParameters: null })
+            makeRestApiEvent('/submissions', 'GET', {
+              queryStringParameters: { status: 'pending' },
+            })
           );
           const { statusCode, body } = parseRes(res);
 


### PR DESCRIPTION
## Summary

- **Admin UI shell**: replace the boxed sidebar with a left-docked, expandable vertical nav (icon-only collapsed, icon+label expanded, `localStorage`-persisted), change the header subheading to "Administration console," and surface the same Home / About / Okra Project links as the web app.
- **Admin listings on canonical query-param REST**: drop the legacy `/submissions/review-queue` and `/requests/review-queue` routes; `GET /submissions?status=pending` and a new `GET /requests?status=open` are now the sole admin listings.
- **Response parity**: add `contributor_email` to `GET /submissions` so the canonical listing returns every field the removed review-queue did (the admin UI already renders it).

## Why

The admin pages were hitting `/okra-admin/stats`, `/okra-admin/submissions/review-queue`, `/okra-admin/requests/review-queue`, and `/admin/admin/store/products` from a rebuilt admin UI whose `api.ts` matched what the backend registers and what the contract tests exercise — but the visual shell was bespoke (boxed sidebar instead of a modern docked nav) and the URL scheme was still split between `/submissions/review-queue` (legacy) and `/submissions?status=pending` (canonical REST added in [#249](https://github.com/allenheltondev/olivias-garden-foundation/pull/249)). Consolidating onto the query-param path removes the confusion about which endpoint to call and lets the UI ship one convention.

## What changed

**Admin app** (`apps/admin/`)
- `shell/AppShell.tsx` — new `admin-vertical-nav` aside with expand/collapse toggle and `localStorage` state; header's `brandTitle` set to "Administration console," `navItems` now point at the foundation site.
- `styles.css` — replaces the old `admin-layout` grid + `admin-side-nav` with a flex body containing the sticky left nav and main column; adds responsive collapse on screens <720px.
- `api.ts` — `listOkraReviewQueue` → `/submissions?status=pending`; `listSeedRequestQueue` → `/requests?status=open`.

**okra-api admin routes** (`services/okra-api/src/handlers/admin-routes.mjs`)
- Add `GET /requests?status=open` (status required, `open` only for now).
- Remove `GET /requests/review-queue` and `GET /submissions/review-queue`.
- Add `contributor_email` to the `GET /submissions` response (and its SELECT).

**Tests + contracts**
- `admin-routes.test.ts` — ported seed-request test to `/requests?status=open`, added missing/unsupported status cases, dropped the `/submissions/review-queue` describe block (equivalent coverage already exists in `admin-review-queue.property.test.ts` against `/submissions`).
- `paginated-endpoints.property.test.ts` — all handler calls now hit `/submissions?status=pending`; fixed the cursor-detection in Property 10's DB mock (the canonical query's param layout is `[status, created_at, id, limit]` instead of the old `[created_at, id, limit]`); deduped generated UUIDs so shrinking can't produce two submissions with the same id.
- `integration-test.mjs` — auth-boundary + seed-request polling hit the new `/requests?status=open`.
- `openapi.yaml` — replaced `/admin/requests/review-queue` with `/admin/requests` (status=open required); added `contributor_email` to `SubmissionListItem`.

## Reviewer notes

- This is a **breaking change** to the admin API surface: `/submissions/review-queue` and `/requests/review-queue` are gone. The admin app is the only first-party consumer and is updated in the same commit, but anything else that was calling the old paths will 404 after this deploys.
- The 404s observed in the live admin app most likely indicate the okra-api Lambda bundle didn't redeploy with [#249](https://github.com/allenheltondev/olivias-garden-foundation/pull/249) — API Gateway routes were present (curl returns 401 = authorizer engaged) but the router inside the Lambda was returning `NOT_FOUND` for the new paths. Worth sanity-checking stack update history after this merges.
- Property 10 had a latent flake (`fc.uuid()` can shrink to duplicates); the dedupe pass is a small generator fix, not a behavior change.

## Test plan

- [x] `npm --workspace @olivias/admin run typecheck`
- [x] `npm --workspace @olivias/admin run build`
- [x] `cd services/okra-api && npx vitest run` — **195/195 passing**
- [ ] Deploy to staging and verify the admin pages populate (dashboard stats, okra queue, seed requests, store catalog)
- [ ] Smoke-test the left nav: expand/collapse toggle, active state, localStorage persistence across reloads, mobile breakpoint <720px

🤖 Generated with [Claude Code](https://claude.com/claude-code)