### PR TITLE
Add account-deletion flow with self-serve DELETE /profile

### DIFF
--- a/apps/web/scripts/prerender-head.mjs
+++ b/apps/web/scripts/prerender-head.mjs
@@ -78,6 +78,24 @@ const prerenderRoutes = [
     description: 'A community platform that connects home growers with neighbors and organizations who need fresh food. Plan your garden, see local food gaps, and share what you have extra.',
     seoImage: defaultImage,
   },
+  {
+    path: '/privacy',
+    title: 'Privacy Policy',
+    description: "Read how Olivia's Garden Foundation collects, uses, stores, and protects information across the foundation website, donations, and account features.",
+    seoImage: defaultImage,
+  },
+  {
+    path: '/terms',
+    title: 'Terms of Service',
+    description: "Review the terms that govern use of Olivia's Garden Foundation websites, accounts, donations, community tools, and submitted content.",
+    seoImage: defaultImage,
+  },
+  {
+    path: '/data-deletion',
+    title: 'Data and account deletion',
+    description: "How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data from Facebook or Google sign-in.",
+    seoImage: defaultImage,
+  },
 ];
 
 function buildPageTitle(route) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,7 @@ import { readRedirectTargetFromSearch } from './auth/redirect';
 import {
   AboutPage,
   ContactPage,
+  DataDeletionPage,
   GetInvolvedPage,
   GoodRootsPage,
   HomePage,
@@ -238,6 +239,13 @@ function App() {
     signOut(authConfig);
   };
 
+  const handleAccountDeleted = () => {
+    setAuthSession(null);
+    setProfileAvatarUrl(null);
+    signOut(authConfig);
+    navigate('/');
+  };
+
   const handleAuthSuccess = (session: AuthSession) => {
     setAuthSession(session);
     setAuthError(null);
@@ -337,6 +345,7 @@ function App() {
                   authReady={authReady}
                   onNavigate={navigate}
                   onAvatarUrlChange={setProfileAvatarUrl}
+                  onAccountDeleted={handleAccountDeleted}
                 />
               </Suspense>
             }
@@ -344,6 +353,7 @@ function App() {
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
           <Route path="/terms" element={<TermsOfServicePage />} />
+          <Route path="/data-deletion" element={<DataDeletionPage onNavigate={navigate} />} />
           <Route
             path="/good-roots"
             element={<GoodRootsPage authSession={authSession} onNavigate={navigate} />}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2146,3 +2146,165 @@ html {
     grid-column: 1 / -1;
   }
 }
+
+/* ── Profile danger zone ─────────────────────────────────────────────── */
+
+.profile-danger-zone__panel {
+  border: 1px solid rgba(176, 54, 48, 0.35);
+  background: rgba(176, 54, 48, 0.05);
+  border-radius: 1.2rem;
+}
+
+.profile-danger-zone__body {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.profile-danger-zone__heading {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 1.15rem;
+  color: #8a1f1f;
+}
+
+.profile-danger-zone__text {
+  margin: 0;
+  color: var(--site-ink);
+  line-height: 1.55;
+  font-size: 0.96rem;
+}
+
+.profile-danger-zone__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.3rem;
+}
+
+.profile-danger-zone__button {
+  min-height: 2.75rem;
+}
+
+@media (max-width: 600px) {
+  .profile-danger-zone__panel {
+    border-radius: 1rem;
+  }
+
+  .profile-danger-zone__actions {
+    justify-content: stretch;
+  }
+
+  .profile-danger-zone__button {
+    width: 100%;
+  }
+}
+
+/* ── Profile delete confirmation dialog ──────────────────────────────── */
+
+.profile-delete-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.profile-delete-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 20, 20, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.profile-delete-dialog__panel {
+  position: relative;
+  background: var(--site-paper, #fbf7ef);
+  border-radius: 1rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  padding: 1.5rem;
+  max-width: 32rem;
+  width: 100%;
+  display: grid;
+  gap: 0.8rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.profile-delete-dialog__title {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 1.35rem;
+  color: #8a1f1f;
+}
+
+.profile-delete-dialog__body {
+  margin: 0;
+  color: var(--site-ink);
+  line-height: 1.55;
+  font-size: 0.96rem;
+}
+
+.profile-delete-dialog__label {
+  font-size: 0.9rem;
+  color: var(--site-ink);
+  margin-top: 0.3rem;
+}
+
+.profile-delete-dialog__input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  font: inherit;
+  font-size: 1rem;
+  border: 1px solid var(--site-border, rgba(76, 52, 38, 0.25));
+  border-radius: 0.6rem;
+  background: white;
+  color: var(--site-ink);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.profile-delete-dialog__input:focus {
+  outline: 2px solid rgba(138, 31, 31, 0.45);
+  outline-offset: 2px;
+}
+
+.profile-delete-dialog__actions {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+.profile-delete-dialog__cancel,
+.profile-delete-dialog__confirm {
+  width: 100%;
+  min-height: 2.75rem;
+}
+
+@media (min-width: 520px) {
+  .profile-delete-dialog__actions {
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .profile-delete-dialog__cancel,
+  .profile-delete-dialog__confirm {
+    width: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .profile-delete-dialog {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .profile-delete-dialog__panel {
+    max-width: 100%;
+    border-radius: 1rem 1rem 0 0;
+    padding: 1.25rem 1.1rem calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    max-height: 90vh;
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2147,6 +2147,297 @@ html {
   }
 }
 
+/* ── Legal document ───────────────────────────────────────────────────── */
+
+.legal-document {
+  --legal-rule: rgba(76, 52, 38, 0.18);
+  --legal-ink: #2e2318;
+  --legal-muted: color-mix(in srgb, var(--legal-ink) 70%, transparent);
+  --legal-eyebrow: color-mix(in srgb, var(--site-branch) 82%, black 10%);
+
+  width: min(46rem, calc(100% - 2.2rem));
+  margin: 0 auto;
+  padding: 2.5rem 0 4rem;
+  color: var(--legal-ink);
+  font-family: 'Iowan Old Style', 'Palatino Linotype', 'Palatino', 'Georgia', 'Times New Roman', serif;
+  font-size: 1.02rem;
+  line-height: 1.75;
+  font-feature-settings: 'onum' 1, 'kern' 1, 'liga' 1;
+}
+
+.legal-document__header {
+  border-top: 2px solid var(--legal-ink);
+  border-bottom: 1px solid var(--legal-rule);
+  padding: 1.5rem 0 1.25rem;
+  margin-bottom: 2rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.legal-document__eyebrow {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--legal-eyebrow);
+}
+
+.legal-document__title {
+  margin: 0;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', 'Palatino', 'Georgia', 'Times New Roman', serif;
+  font-size: clamp(1.9rem, 3.6vw, 2.6rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--legal-ink);
+  font-weight: 600;
+}
+
+.legal-document__effective {
+  margin: 0.1rem 0 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: var(--legal-muted);
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.legal-document__effective-label {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-family: var(--site-display);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.legal-document__effective-value {
+  font-variant-numeric: oldstyle-nums;
+}
+
+.legal-document__intro {
+  margin-top: 0.4rem;
+  font-size: 1.04rem;
+  line-height: 1.7;
+  color: color-mix(in srgb, var(--legal-ink) 80%, transparent);
+  font-style: italic;
+}
+
+.legal-document__intro p {
+  margin: 0;
+}
+
+.legal-document__body {
+  display: grid;
+  gap: 2rem;
+}
+
+.legal-section {
+  display: grid;
+  gap: 0.85rem;
+  padding-top: 0.25rem;
+  scroll-margin-top: 4rem;
+}
+
+.legal-section + .legal-section {
+  border-top: 1px solid var(--legal-rule);
+  padding-top: 1.75rem;
+}
+
+.legal-section__heading {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 1.2rem;
+  line-height: 1.3;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  color: var(--legal-ink);
+}
+
+.legal-section__anchor {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.legal-section__anchor:hover .legal-section__title {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+
+.legal-section__number {
+  display: inline-block;
+  min-width: 2rem;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', 'Palatino', 'Georgia', 'Times New Roman', serif;
+  font-feature-settings: 'onum' 1;
+  font-size: 0.98rem;
+  font-weight: 500;
+  color: var(--legal-eyebrow);
+  letter-spacing: 0.08em;
+}
+
+.legal-section__title {
+  font-family: var(--site-display);
+}
+
+.legal-section__body {
+  display: grid;
+  gap: 0.85rem;
+  padding-left: 2.75rem;
+}
+
+.legal-section__body p,
+.legal-section__body li {
+  margin: 0;
+  line-height: 1.8;
+  color: var(--legal-ink);
+  font-size: 1rem;
+}
+
+.legal-section__body p + p {
+  text-indent: 1.5em;
+}
+
+.legal-section__body a {
+  color: var(--legal-ink);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+  text-decoration-color: color-mix(in srgb, var(--legal-ink) 45%, transparent);
+}
+
+.legal-section__body a:hover {
+  text-decoration-color: var(--legal-ink);
+}
+
+.legal-section__body ol,
+.legal-section__body ul {
+  margin: 0;
+  padding-left: 1.4rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.legal-section__body ol {
+  list-style: decimal;
+}
+
+.legal-section__body ul {
+  list-style: disc;
+}
+
+.legal-section__body code {
+  font-family: 'SFMono-Regular', 'Menlo', 'Consolas', monospace;
+  font-size: 0.92em;
+  padding: 0.05em 0.35em;
+  background: rgba(76, 52, 38, 0.08);
+  border-radius: 0.2rem;
+}
+
+.legal-section__body strong {
+  color: var(--legal-ink);
+  font-weight: 700;
+}
+
+.legal-section__body em {
+  font-style: italic;
+}
+
+.legal-toc {
+  border: 1px solid var(--legal-rule);
+  background: rgba(255, 252, 246, 0.6);
+  padding: 1.1rem 1.25rem 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.legal-toc__label {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 0.66rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--legal-eyebrow);
+  font-weight: 700;
+}
+
+.legal-toc__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.2rem;
+  counter-reset: toc;
+}
+
+.legal-toc__item {
+  margin: 0;
+}
+
+.legal-toc__link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  color: var(--legal-ink);
+  text-decoration: none;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.legal-toc__link:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.legal-toc__number {
+  min-width: 1.8rem;
+  font-feature-settings: 'onum' 1;
+  color: var(--legal-eyebrow);
+  font-size: 0.88rem;
+}
+
+@media (max-width: 640px) {
+  .legal-document {
+    padding: 1.75rem 0 3rem;
+    font-size: 1rem;
+  }
+
+  .legal-document__header {
+    padding: 1.25rem 0 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .legal-section + .legal-section {
+    padding-top: 1.25rem;
+  }
+
+  .legal-section__body {
+    padding-left: 0;
+  }
+
+  .legal-section__heading {
+    font-size: 1.1rem;
+  }
+
+  .legal-section__anchor {
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+
+  .legal-section__number {
+    min-width: auto;
+  }
+
+  .legal-section__body p + p {
+    text-indent: 0;
+  }
+}
+
 /* ── Profile danger zone ─────────────────────────────────────────────── */
 
 .profile-danger-zone__panel {

--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -7,7 +7,15 @@ import {
 } from '@olivias/ui';
 import type { AuthSession } from '../auth/session';
 import type { AppRoute } from './routes';
-import { adminUrl, facebookUrl, footerRoutes, goodRootsNetworkUrl, instagramUrl, navRoutes } from './routes';
+import {
+  adminUrl,
+  facebookUrl,
+  footerRoutes,
+  goodRootsNetworkUrl,
+  instagramUrl,
+  legalFooterRoutes,
+  navRoutes,
+} from './routes';
 
 export function buildCrossAppUrl(targetUrl: string, session: AuthSession) {
   try {
@@ -158,6 +166,13 @@ export function SiteFooter({
     active: currentPage.path === route.path,
     onSelect: () => onNavigate(route.path),
   }));
+  const legalFooterLinks = legalFooterRoutes.map((route) => ({
+    id: route.path,
+    label: route.label,
+    href: route.path,
+    active: currentPage.path === route.path,
+    onSelect: () => onNavigate(route.path),
+  }));
 
   return (
     <SharedSiteFooter
@@ -166,6 +181,7 @@ export function SiteFooter({
         : 'Growing food, sharing seeds, and helping more people feel at home on the land.'}
       meta={`${new Date().getFullYear()} Olivia's Garden Foundation. All rights reserved.`}
       links={footerLinks}
+      legalLinks={legalFooterLinks}
       socialLinks={[
         {
           id: 'instagram',
@@ -273,6 +289,82 @@ export function CtaButton({
     <Button className="site-cta" variant={variant} onClick={onClick}>
       {children}
     </Button>
+  );
+}
+
+export function LegalDocument({
+  title,
+  eyebrow = 'Legal',
+  effectiveDate,
+  intro,
+  children,
+}: {
+  title: string;
+  eyebrow?: string;
+  effectiveDate: string;
+  intro?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <article className="legal-document">
+      <header className="legal-document__header">
+        <p className="legal-document__eyebrow">{eyebrow}</p>
+        <h1 className="legal-document__title">{title}</h1>
+        <p className="legal-document__effective">
+          <span className="legal-document__effective-label">Effective date</span>
+          <span className="legal-document__effective-value">{effectiveDate}</span>
+        </p>
+        {intro ? <div className="legal-document__intro">{intro}</div> : null}
+      </header>
+      <div className="legal-document__body">{children}</div>
+    </article>
+  );
+}
+
+export function LegalSection({
+  id,
+  number,
+  title,
+  children,
+}: {
+  id?: string;
+  number: number;
+  title: string;
+  children: ReactNode;
+}) {
+  const anchor = id ?? `section-${number}`;
+  return (
+    <section id={anchor} className="legal-section">
+      <h2 className="legal-section__heading">
+        <a href={`#${anchor}`} className="legal-section__anchor" aria-label={`Link to ${title}`}>
+          <span className="legal-section__number">{String(number).padStart(2, '0')}</span>
+          <span className="legal-section__title">{title}</span>
+        </a>
+      </h2>
+      <div className="legal-section__body">{children}</div>
+    </section>
+  );
+}
+
+export function LegalTableOfContents({
+  items,
+}: {
+  items: { id: string; title: string }[];
+}) {
+  return (
+    <nav className="legal-toc" aria-label="Table of contents">
+      <p className="legal-toc__label">Contents</p>
+      <ol className="legal-toc__list">
+        {items.map((item, index) => (
+          <li key={item.id} className="legal-toc__item">
+            <a href={`#${item.id}`} className="legal-toc__link">
+              <span className="legal-toc__number">{String(index + 1).padStart(2, '0')}</span>
+              <span>{item.title}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
   );
 }
 

--- a/apps/web/src/site/pages/ProfilePage.tsx
+++ b/apps/web/src/site/pages/ProfilePage.tsx
@@ -235,6 +235,19 @@ async function completeAvatarUpload(authSession: AuthSession): Promise<void> {
   }
 }
 
+async function deleteAccount(authSession: AuthSession): Promise<void> {
+  const response = await fetch(webApiUrl('/profile'), {
+    method: 'DELETE',
+    headers: authHeaders(authSession, false),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.error ?? 'Unable to delete your account. Please try again.');
+  }
+}
+
+const DELETE_CONFIRMATION_PHRASE = 'DELETE';
+
 type EditableProfile = {
   firstName: string;
   lastName: string;
@@ -285,11 +298,13 @@ export function ProfilePage({
   authReady,
   onNavigate,
   onAvatarUrlChange,
+  onAccountDeleted,
 }: {
   authSession: AuthSession | null;
   authReady: boolean;
   onNavigate: (path: string) => void;
   onAvatarUrlChange?: (url: string | null) => void;
+  onAccountDeleted?: () => void;
 }) {
   useEffect(() => {
     if (authReady && !authSession) {
@@ -314,6 +329,11 @@ export function ProfilePage({
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
+
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!authSession) {
@@ -465,6 +485,61 @@ export function ProfilePage({
       setAvatarUploading(false);
     }
   };
+
+  const openDeleteDialog = useCallback(() => {
+    setDeleteConfirmation('');
+    setDeleteError(null);
+    setDeleteDialogOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleteSubmitting) return;
+    setDeleteDialogOpen(false);
+    setDeleteError(null);
+    setDeleteConfirmation('');
+  }, [deleteSubmitting]);
+
+  const submitAccountDeletion = useCallback(async () => {
+    if (!authSession) return;
+    if (deleteConfirmation.trim().toUpperCase() !== DELETE_CONFIRMATION_PHRASE) {
+      setDeleteError(`Type ${DELETE_CONFIRMATION_PHRASE} to confirm.`);
+      return;
+    }
+
+    setDeleteError(null);
+    setDeleteSubmitting(true);
+    try {
+      await deleteAccount(authSession);
+      onAvatarUrlChange?.(null);
+      setDeleteDialogOpen(false);
+      if (onAccountDeleted) {
+        onAccountDeleted();
+      } else {
+        onNavigate('/');
+      }
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : 'Unable to delete your account.');
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  }, [authSession, deleteConfirmation, onAccountDeleted, onAvatarUrlChange, onNavigate]);
+
+  useEffect(() => {
+    if (!deleteDialogOpen) return;
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeDeleteDialog();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [deleteDialogOpen, closeDeleteDialog]);
 
   const refreshAvatarManually = async () => {
     if (!authSession) return;
@@ -716,6 +791,107 @@ export function ProfilePage({
           </ul>
         )}
       </Section>
+
+      <Section
+        title="Danger zone"
+        intro="Permanently delete your account and all the personal information tied to it. This cannot be undone."
+        className="profile-danger-zone"
+      >
+        <Panel tone="paper" className="profile-danger-zone__panel">
+          <div className="profile-danger-zone__body">
+            <h3 className="profile-danger-zone__heading">Delete your account</h3>
+            <p className="profile-danger-zone__text">
+              Deleting your account removes your profile details, avatar, saved preferences, and
+              sign-in. Donation records are retained for tax and accounting purposes but we scrub
+              your name and email from them. Seed requests and okra submissions you&apos;ve made will
+              be unlinked from your account.
+            </p>
+            <p className="profile-danger-zone__text">
+              This action takes effect immediately and cannot be reversed. If you change your mind
+              later, you&apos;d need to create a new account.
+            </p>
+            <div className="profile-danger-zone__actions">
+              <Button
+                type="button"
+                variant="danger"
+                onClick={openDeleteDialog}
+                className="profile-danger-zone__button"
+              >
+                Delete my account
+              </Button>
+            </div>
+          </div>
+        </Panel>
+      </Section>
+
+      {deleteDialogOpen ? (
+        <div
+          className="profile-delete-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="profile-delete-dialog-title"
+          aria-describedby="profile-delete-dialog-description"
+        >
+          <div
+            className="profile-delete-dialog__backdrop"
+            onClick={closeDeleteDialog}
+            aria-hidden="true"
+          />
+          <div className="profile-delete-dialog__panel" role="document">
+            <h2 id="profile-delete-dialog-title" className="profile-delete-dialog__title">
+              Delete your account?
+            </h2>
+            <p id="profile-delete-dialog-description" className="profile-delete-dialog__body">
+              Are you sure? This will permanently delete your Olivia&apos;s Garden account, remove
+              your profile, and sign you out. This cannot be undone.
+            </p>
+            <label className="profile-delete-dialog__label" htmlFor="profile-delete-confirm">
+              Type <strong>{DELETE_CONFIRMATION_PHRASE}</strong> to confirm.
+            </label>
+            <input
+              id="profile-delete-confirm"
+              className="profile-delete-dialog__input"
+              type="text"
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              value={deleteConfirmation}
+              onChange={(event) => {
+                setDeleteError(null);
+                setDeleteConfirmation(event.target.value);
+              }}
+              disabled={deleteSubmitting}
+            />
+            {deleteError ? (
+              <FormFeedback tone="error">{deleteError}</FormFeedback>
+            ) : null}
+            <div className="profile-delete-dialog__actions">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={closeDeleteDialog}
+                disabled={deleteSubmitting}
+                className="profile-delete-dialog__cancel"
+              >
+                Keep my account
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={() => void submitAccountDeletion()}
+                disabled={
+                  deleteSubmitting
+                  || deleteConfirmation.trim().toUpperCase() !== DELETE_CONFIRMATION_PHRASE
+                }
+                loading={deleteSubmitting}
+                className="profile-delete-dialog__confirm"
+              >
+                {deleteSubmitting ? 'Deleting…' : 'Yes, delete my account'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -593,6 +593,11 @@ export function PrivacyPolicyPage() {
           information, subject to legal and operational limits. You may also opt out of promotional
           emails through the unsubscribe link included in those messages.
         </p>
+        <p className="page-text">
+          You can delete your account and the personal data associated with it at any time. See our{' '}
+          <a href="/data-deletion">data and account deletion page</a> for step-by-step instructions,
+          including how to remove data received from Facebook Login or Google Sign-In.
+        </p>
       </Section>
 
       <Section title="Security" className="about-prose-block">
@@ -618,6 +623,193 @@ export function PrivacyPolicyPage() {
         </p>
         <p className="page-text">
           Effective date: April 23, 2026.
+        </p>
+      </Section>
+    </>
+  );
+}
+
+export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) => void }) {
+  return (
+    <>
+      <PageHero
+        eyebrow="Legal"
+        title="Data and account deletion"
+        body="How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data received from third-party sign-in providers such as Facebook and Google."
+      />
+
+      <Section title="Who this page is for" className="about-prose-block">
+        <p className="page-text">
+          This page explains how anyone with an Olivia&apos;s Garden Foundation account — including
+          accounts created with Facebook Login, Google Sign-In, or an email and password — can
+          permanently delete their account and the personal data tied to it. It is provided as a
+          standing public reference so people and platforms always have clear instructions.
+        </p>
+      </Section>
+
+      <Section title="Delete from inside your account" className="about-prose-block">
+        <p className="page-text">
+          The fastest way to delete your account is from your profile page. You must be signed in.
+        </p>
+        <ol className="site-list">
+          <li>
+            Sign in at{' '}
+            <a
+              href="/login"
+              onClick={(event) => {
+                event.preventDefault();
+                onNavigate('/login');
+              }}
+            >
+              oliviasgarden.org/login
+            </a>
+            .
+          </li>
+          <li>
+            Open your{' '}
+            <a
+              href="/profile"
+              onClick={(event) => {
+                event.preventDefault();
+                onNavigate('/profile');
+              }}
+            >
+              profile page
+            </a>
+            .
+          </li>
+          <li>Scroll to the <strong>Danger zone</strong> section at the bottom of the page.</li>
+          <li>Click <strong>Delete my account</strong>.</li>
+          <li>Confirm by typing <code>DELETE</code> in the pop-up and choosing <strong>Yes, delete my account</strong>.</li>
+        </ol>
+        <p className="page-text">
+          The deletion happens immediately. You&apos;ll be signed out automatically and your
+          Olivia&apos;s Garden profile, avatar, and saved preferences will be removed.
+        </p>
+      </Section>
+
+      <Section title="Request deletion by email" className="about-prose-block">
+        <p className="page-text">
+          If you can&apos;t sign in — for example, you lost access to the email address or social
+          account you signed up with — you can request deletion by emailing us instead.
+        </p>
+        <ul className="site-list">
+          <li>
+            Send a message to{' '}
+            <a href="mailto:allen@oliviasgarden.org?subject=Account%20deletion%20request">
+              allen@oliviasgarden.org
+            </a>{' '}
+            with the subject <em>Account deletion request</em>.
+          </li>
+          <li>
+            Include the email address or social sign-in (Facebook, Google) you used to create the
+            account so we can match the request to the right record.
+          </li>
+          <li>
+            We&apos;ll confirm the request and complete deletion within 30 days. We may ask a
+            verification question before deleting if we can&apos;t confirm your identity from the
+            request alone.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="What gets deleted" className="about-prose-block">
+        <p className="page-text">
+          When your account is deleted, the following information is permanently removed or
+          irreversibly scrubbed from our systems:
+        </p>
+        <ul className="site-list">
+          <li>Your profile: name, display name, bio, location, timezone, and website.</li>
+          <li>Your avatar image and any related processed versions.</li>
+          <li>Your sign-in record, including any linked social provider identity (for example, Facebook or Google).</li>
+          <li>Your email address and contact details stored on your account.</li>
+          <li>Donor name and contact information attached to your donation history.</li>
+        </ul>
+      </Section>
+
+      <Section title="What we keep and why" className="about-prose-block">
+        <p className="page-text">
+          A small set of records may be retained after account deletion for legal, tax, or
+          accounting reasons. In every case, records kept are scrubbed of personal identifiers so
+          they can no longer be tied back to you.
+        </p>
+        <ul className="site-list">
+          <li>
+            <strong>Donation records.</strong> Nonprofit and tax reporting requires us to keep a
+            record of donations received. We remove your name, email, and dedication notes from
+            those records at deletion time, but the anonymized transaction remains in our
+            accounting.
+          </li>
+          <li>
+            <strong>Moderation and abuse records.</strong> If there is an active investigation into
+            content or abuse on the platform, we may retain the minimum information required to
+            resolve it.
+          </li>
+          <li>
+            <strong>System logs and backups.</strong> Routine operational logs and backups that
+            include account IDs roll off on normal retention schedules. Personal identifiers are
+            not restored if backups are used for recovery.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Third-party sign-in data (Facebook, Google)" className="about-prose-block">
+        <p className="page-text">
+          If you created an Olivia&apos;s Garden Foundation account using Facebook Login or Google
+          Sign-In, we received a limited set of profile information from that provider (such as
+          your name and email) to create and authenticate your account. When you delete your
+          account, that information is deleted from our systems along with the rest of your
+          account.
+        </p>
+        <p className="page-text">
+          Deleting your Olivia&apos;s Garden account does <strong>not</strong> delete your account
+          with Facebook, Google, or any other third-party provider. To remove Olivia&apos;s Garden
+          from the apps connected to your Facebook account, visit{' '}
+          <a href="https://www.facebook.com/settings?tab=business_tools" target="_blank" rel="noreferrer">
+            Facebook&apos;s Business Integrations settings
+          </a>{' '}
+          and remove Olivia&apos;s Garden from the list of connected apps. Removing the app from
+          Facebook revokes Facebook&apos;s ongoing sharing of your profile information with us, but
+          it does not itself delete any data we already stored — use one of the methods above to
+          delete that data.
+        </p>
+      </Section>
+
+      <Section title="How long deletion takes" className="about-prose-block">
+        <p className="page-text">
+          Account deletions initiated from the profile page take effect immediately. Email-based
+          deletion requests are processed within 30 days of our receiving a verified request, and
+          usually much sooner.
+        </p>
+      </Section>
+
+      <Section title="Questions" className="about-prose-block">
+        <p className="page-text">
+          If you have questions about data deletion or your privacy, you can reach us at{' '}
+          <a href="mailto:allen@oliviasgarden.org">allen@oliviasgarden.org</a> or through our{' '}
+          <a
+            href="/contact"
+            onClick={(event) => {
+              event.preventDefault();
+              onNavigate('/contact');
+            }}
+          >
+            contact page
+          </a>
+          . Our full{' '}
+          <a
+            href="/privacy"
+            onClick={(event) => {
+              event.preventDefault();
+              onNavigate('/privacy');
+            }}
+          >
+            privacy policy
+          </a>{' '}
+          has more on what we collect and how we use it.
+        </p>
+        <p className="page-text">
+          Effective date: April 24, 2026.
         </p>
       </Section>
     </>

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -1,7 +1,16 @@
 import { Button, Card, FormFeedback, Input, Select, Textarea } from '@olivias/ui';
 import { lazy, Suspense, useState, type FormEvent, type MouseEvent } from 'react';
 import type { AuthSession } from '../../auth/session';
-import { buildCrossAppUrl, CtaButton, PageHero, Section, WorkIcon } from '../chrome';
+import {
+  buildCrossAppUrl,
+  CtaButton,
+  LegalDocument,
+  LegalSection,
+  LegalTableOfContents,
+  PageHero,
+  Section,
+  WorkIcon,
+} from '../chrome';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
 import { facebookUrl, goodRootsNetworkUrl, instagramUrl, webApiBase } from '../routes';
 
@@ -493,165 +502,202 @@ export function ImpactPage({ onNavigate }: { onNavigate: (path: string) => void;
   );
 }
 
+const PRIVACY_SECTIONS = [
+  { id: 'who-we-are', title: 'Who we are' },
+  { id: 'information-we-collect', title: 'Information we collect' },
+  { id: 'how-we-use-information', title: 'How we use information' },
+  { id: 'how-we-share-information', title: 'How we share information' },
+  { id: 'account-and-sign-in-data', title: 'Account and sign-in data' },
+  { id: 'cookies-and-analytics', title: 'Cookies and analytics' },
+  { id: 'data-retention', title: 'Data retention' },
+  { id: 'childrens-privacy', title: "Children's privacy" },
+  { id: 'your-choices', title: 'Your choices' },
+  { id: 'security', title: 'Security' },
+  { id: 'changes-to-this-policy', title: 'Changes to this policy' },
+  { id: 'contact', title: 'Contact' },
+];
+
 export function PrivacyPolicyPage() {
   return (
-    <>
-      <PageHero
-        eyebrow="Legal"
-        title="Privacy Policy"
-        body="This policy explains what information Olivia's Garden Foundation collects, how we use it, and the choices available to people who visit, donate, sign up, or participate in our programs and online tools."
-      />
+    <LegalDocument
+      title="Privacy Policy"
+      effectiveDate="April 23, 2026"
+      intro={(
+        <p>
+          This policy explains what information Olivia&apos;s Garden Foundation collects, how we
+          use it, and the choices available to people who visit, donate, sign up, or participate in
+          our programs and online tools.
+        </p>
+      )}
+    >
+      <LegalTableOfContents items={PRIVACY_SECTIONS} />
 
-      <Section title="Who we are" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="who-we-are" number={1} title="Who we are">
+        <p>
           Olivia&apos;s Garden Foundation is a nonprofit organization based in Texas. We operate
           oliviasgarden.org and related experiences, including account features, donation flows,
           seed request tools, and community applications tied to the foundation&apos;s work.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Information we collect" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="information-we-collect" number={2} title="Information we collect">
+        <p>
           We may collect information you provide directly, including your name, email address,
           mailing address, donation details, account profile details, messages you send us, seed
           request submissions, photo submissions, and any other information you choose to provide.
         </p>
-        <p className="page-text">
+        <p>
           We may also collect technical and usage information such as device type, browser
           information, approximate location data, pages viewed, referring pages, and interactions
           with our website or forms. Payment card information is generally processed by our payment
           providers and is not stored directly by us except for limited transaction metadata.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="How we use information" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="how-we-use-information" number={3} title="How we use information">
+        <p>
           We use information to operate the website, provide requested services, process donations,
           manage accounts, respond to inquiries, administer programs, improve the user experience,
           protect the platform from misuse, and communicate updates related to the foundation and
           its work.
         </p>
-        <p className="page-text">
+        <p>
           If you opt in to receive updates, we may send occasional emails about foundation news,
           programs, donations, events, or related community opportunities. You can unsubscribe from
           promotional emails at any time.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="How we share information" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="how-we-share-information" number={4} title="How we share information">
+        <p>
           We do not sell personal information. We may share information with service providers who
           help us operate the website and foundation operations, including hosting providers,
           authentication providers, analytics providers, payment processors, email platforms, and
           software vendors that support communication, fulfillment, moderation, and administration.
         </p>
-        <p className="page-text">
-          We may also disclose information when reasonably necessary to comply with law, protect the
-          rights and safety of the foundation or others, investigate abuse or fraud, or in
+        <p>
+          We may also disclose information when reasonably necessary to comply with law, protect
+          the rights and safety of the foundation or others, investigate abuse or fraud, or in
           connection with a reorganization, merger, or transfer of assets.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Account and sign-in data" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="account-and-sign-in-data" number={5} title="Account and sign-in data">
+        <p>
           When you create an account or sign in using services such as Google or, later, Facebook,
-          we receive profile and authentication information made available by that provider based on
-          your permissions and our configuration. We use that information to authenticate you,
+          we receive profile and authentication information made available by that provider based
+          on your permissions and our configuration. We use that information to authenticate you,
           create or maintain your account, and support access across foundation experiences.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Cookies and analytics" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="cookies-and-analytics" number={6} title="Cookies and analytics">
+        <p>
           We and our service providers may use cookies, local storage, pixels, and similar
           technologies to keep you signed in, remember preferences, understand site usage, measure
           campaign effectiveness, and improve performance. You can control cookies through your
           browser settings, though some site features may not function properly if disabled.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Data retention" className="about-prose-block">
-        <p className="page-text">
-          We retain information for as long as reasonably necessary to operate the website, fulfill
-          donations or program obligations, maintain records, resolve disputes, enforce our
-          agreements, and comply with legal, tax, accounting, or reporting requirements.
+      <LegalSection id="data-retention" number={7} title="Data retention">
+        <p>
+          We retain information for as long as reasonably necessary to operate the website,
+          fulfill donations or program obligations, maintain records, resolve disputes, enforce
+          our agreements, and comply with legal, tax, accounting, or reporting requirements.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Children's privacy" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="childrens-privacy" number={8} title="Children's privacy">
+        <p>
           Our website and tools are intended for general audiences and family participation, but
-          account creation and donations should be completed by an adult or authorized guardian. If
-          you believe a child has provided personal information to us inappropriately, contact us so
-          we can review and address the situation.
+          account creation and donations should be completed by an adult or authorized guardian.
+          If you believe a child has provided personal information to us inappropriately, contact
+          us so we can review and address the situation.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Your choices" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="your-choices" number={9} title="Your choices">
+        <p>
           You may contact us to request access to, correction of, or deletion of certain personal
-          information, subject to legal and operational limits. You may also opt out of promotional
-          emails through the unsubscribe link included in those messages.
+          information, subject to legal and operational limits. You may also opt out of
+          promotional emails through the unsubscribe link included in those messages.
         </p>
-        <p className="page-text">
-          You can delete your account and the personal data associated with it at any time. See our{' '}
-          <a href="/data-deletion">data and account deletion page</a> for step-by-step instructions,
-          including how to remove data received from Facebook Login or Google Sign-In.
+        <p>
+          You can delete your account and the personal data associated with it at any time. See
+          our <a href="/data-deletion">data and account deletion page</a> for step-by-step
+          instructions, including how to remove data received from Facebook Login or Google
+          Sign-In.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Security" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="security" number={10} title="Security">
+        <p>
           We use reasonable administrative, technical, and organizational measures to protect
-          information, but no method of transmission or storage is completely secure. You use the
-          website and provide information at your own risk.
+          information, but no method of transmission or storage is completely secure. You use
+          the website and provide information at your own risk.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Changes to this policy" className="about-prose-block">
-        <p className="page-text">
-          We may update this Privacy Policy from time to time. When we do, we will post the updated
-          version on this page and update the effective date below. Continued use of the website
-          after an update means you accept the revised policy.
+      <LegalSection id="changes-to-this-policy" number={11} title="Changes to this policy">
+        <p>
+          We may update this Privacy Policy from time to time. When we do, we will post the
+          updated version on this page and update the effective date above. Continued use of the
+          website after an update means you accept the revised policy.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Contact" className="about-prose-block">
-        <p className="page-text">
-          Questions about this Privacy Policy can be sent through the contact information provided
-          on this website.
+      <LegalSection id="contact" number={12} title="Contact">
+        <p>
+          Questions about this Privacy Policy can be sent through the contact information
+          provided on this website, or by writing to{' '}
+          <a href="mailto:allen@oliviasgarden.org">allen@oliviasgarden.org</a>.
         </p>
-        <p className="page-text">
-          Effective date: April 23, 2026.
-        </p>
-      </Section>
-    </>
+      </LegalSection>
+    </LegalDocument>
   );
 }
 
+const DATA_DELETION_SECTIONS = [
+  { id: 'who-this-is-for', title: 'Who this page is for' },
+  { id: 'delete-from-account', title: 'Delete from inside your account' },
+  { id: 'delete-by-email', title: 'Request deletion by email' },
+  { id: 'what-gets-deleted', title: 'What gets deleted' },
+  { id: 'what-we-keep', title: 'What we keep and why' },
+  { id: 'third-party-sign-in', title: 'Third-party sign-in data (Facebook, Google)' },
+  { id: 'timing', title: 'How long deletion takes' },
+  { id: 'questions', title: 'Questions' },
+];
+
 export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) => void }) {
   return (
-    <>
-      <PageHero
-        eyebrow="Legal"
-        title="Data and account deletion"
-        body="How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data received from third-party sign-in providers such as Facebook and Google."
-      />
-
-      <Section title="Who this page is for" className="about-prose-block">
-        <p className="page-text">
-          This page explains how anyone with an Olivia&apos;s Garden Foundation account — including
-          accounts created with Facebook Login, Google Sign-In, or an email and password — can
-          permanently delete their account and the personal data tied to it. It is provided as a
-          standing public reference so people and platforms always have clear instructions.
+    <LegalDocument
+      title="Data and account deletion"
+      effectiveDate="April 24, 2026"
+      intro={(
+        <p>
+          How to delete your Olivia&apos;s Garden Foundation account and the personal data
+          associated with it, including data received from third-party sign-in providers such as
+          Facebook and Google.
         </p>
-      </Section>
+      )}
+    >
+      <LegalTableOfContents items={DATA_DELETION_SECTIONS} />
 
-      <Section title="Delete from inside your account" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="who-this-is-for" number={1} title="Who this page is for">
+        <p>
+          This page explains how anyone with an Olivia&apos;s Garden Foundation account —
+          including accounts created with Facebook Login, Google Sign-In, or an email and password
+          — can permanently delete their account and the personal data tied to it. It is provided
+          as a standing public reference so people and platforms always have clear instructions.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="delete-from-account" number={2} title="Delete from inside your account">
+        <p>
           The fastest way to delete your account is from your profile page. You must be signed in.
         </p>
-        <ol className="site-list">
+        <ol>
           <li>
             Sign in at{' '}
             <a
@@ -680,20 +726,23 @@ export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) =>
           </li>
           <li>Scroll to the <strong>Danger zone</strong> section at the bottom of the page.</li>
           <li>Click <strong>Delete my account</strong>.</li>
-          <li>Confirm by typing <code>DELETE</code> in the pop-up and choosing <strong>Yes, delete my account</strong>.</li>
+          <li>
+            Confirm by typing <code>DELETE</code> in the pop-up and choosing{' '}
+            <strong>Yes, delete my account</strong>.
+          </li>
         </ol>
-        <p className="page-text">
+        <p>
           The deletion happens immediately. You&apos;ll be signed out automatically and your
           Olivia&apos;s Garden profile, avatar, and saved preferences will be removed.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Request deletion by email" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="delete-by-email" number={3} title="Request deletion by email">
+        <p>
           If you can&apos;t sign in — for example, you lost access to the email address or social
           account you signed up with — you can request deletion by emailing us instead.
         </p>
-        <ul className="site-list">
+        <ul>
           <li>
             Send a message to{' '}
             <a href="mailto:allen@oliviasgarden.org?subject=Account%20deletion%20request">
@@ -711,29 +760,32 @@ export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) =>
             request alone.
           </li>
         </ul>
-      </Section>
+      </LegalSection>
 
-      <Section title="What gets deleted" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="what-gets-deleted" number={4} title="What gets deleted">
+        <p>
           When your account is deleted, the following information is permanently removed or
           irreversibly scrubbed from our systems:
         </p>
-        <ul className="site-list">
+        <ul>
           <li>Your profile: name, display name, bio, location, timezone, and website.</li>
           <li>Your avatar image and any related processed versions.</li>
-          <li>Your sign-in record, including any linked social provider identity (for example, Facebook or Google).</li>
+          <li>
+            Your sign-in record, including any linked social provider identity (for example,
+            Facebook or Google).
+          </li>
           <li>Your email address and contact details stored on your account.</li>
           <li>Donor name and contact information attached to your donation history.</li>
         </ul>
-      </Section>
+      </LegalSection>
 
-      <Section title="What we keep and why" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="what-we-keep" number={5} title="What we keep and why">
+        <p>
           A small set of records may be retained after account deletion for legal, tax, or
           accounting reasons. In every case, records kept are scrubbed of personal identifiers so
           they can no longer be tied back to you.
         </p>
-        <ul className="site-list">
+        <ul>
           <li>
             <strong>Donation records.</strong> Nonprofit and tax reporting requires us to keep a
             record of donations received. We remove your name, email, and dedication notes from
@@ -741,9 +793,9 @@ export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) =>
             accounting.
           </li>
           <li>
-            <strong>Moderation and abuse records.</strong> If there is an active investigation into
-            content or abuse on the platform, we may retain the minimum information required to
-            resolve it.
+            <strong>Moderation and abuse records.</strong> If there is an active investigation
+            into content or abuse on the platform, we may retain the minimum information required
+            to resolve it.
           </li>
           <li>
             <strong>System logs and backups.</strong> Routine operational logs and backups that
@@ -751,40 +803,48 @@ export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) =>
             not restored if backups are used for recovery.
           </li>
         </ul>
-      </Section>
+      </LegalSection>
 
-      <Section title="Third-party sign-in data (Facebook, Google)" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection
+        id="third-party-sign-in"
+        number={6}
+        title="Third-party sign-in data (Facebook, Google)"
+      >
+        <p>
           If you created an Olivia&apos;s Garden Foundation account using Facebook Login or Google
           Sign-In, we received a limited set of profile information from that provider (such as
           your name and email) to create and authenticate your account. When you delete your
           account, that information is deleted from our systems along with the rest of your
           account.
         </p>
-        <p className="page-text">
+        <p>
           Deleting your Olivia&apos;s Garden account does <strong>not</strong> delete your account
           with Facebook, Google, or any other third-party provider. To remove Olivia&apos;s Garden
           from the apps connected to your Facebook account, visit{' '}
-          <a href="https://www.facebook.com/settings?tab=business_tools" target="_blank" rel="noreferrer">
+          <a
+            href="https://www.facebook.com/settings?tab=business_tools"
+            target="_blank"
+            rel="noreferrer"
+          >
             Facebook&apos;s Business Integrations settings
           </a>{' '}
           and remove Olivia&apos;s Garden from the list of connected apps. Removing the app from
-          Facebook revokes Facebook&apos;s ongoing sharing of your profile information with us, but
-          it does not itself delete any data we already stored — use one of the methods above to
-          delete that data.
+          Facebook revokes Facebook&apos;s ongoing sharing of your profile information with us,
+          but it does not itself delete any data we already stored — use one of the methods above
+          to delete that data.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="How long deletion takes" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="timing" number={7} title="How long deletion takes">
+        <p>
           Account deletions initiated from the profile page take effect immediately. Email-based
           deletion requests are processed within 30 days of our receiving a verified request, and
           usually much sooner.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Questions" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="questions" number={8} title="Questions">
+        <p>
           If you have questions about data deletion or your privacy, you can reach us at{' '}
           <a href="mailto:allen@oliviasgarden.org">allen@oliviasgarden.org</a> or through our{' '}
           <a
@@ -808,151 +868,170 @@ export function DataDeletionPage({ onNavigate }: { onNavigate: (path: string) =>
           </a>{' '}
           has more on what we collect and how we use it.
         </p>
-        <p className="page-text">
-          Effective date: April 24, 2026.
-        </p>
-      </Section>
-    </>
+      </LegalSection>
+    </LegalDocument>
   );
 }
 
+const TERMS_SECTIONS = [
+  { id: 'acceptance', title: 'Acceptance of terms' },
+  { id: 'use-of-site', title: 'Use of the site' },
+  { id: 'accounts', title: 'Accounts' },
+  { id: 'donations', title: 'Donations and payments' },
+  { id: 'user-submissions', title: 'User submissions' },
+  { id: 'intellectual-property', title: 'Intellectual property' },
+  { id: 'third-party-services', title: 'Third-party services and links' },
+  { id: 'disclaimers', title: 'Disclaimers' },
+  { id: 'limitation-of-liability', title: 'Limitation of liability' },
+  { id: 'indemnification', title: 'Indemnification' },
+  { id: 'termination', title: 'Termination' },
+  { id: 'governing-law', title: 'Governing law' },
+  { id: 'changes', title: 'Changes to these terms' },
+  { id: 'contact', title: 'Contact' },
+];
+
 export function TermsOfServicePage() {
   return (
-    <>
-      <PageHero
-        eyebrow="Legal"
-        title="Terms of Service"
-        body="These terms govern access to and use of Olivia's Garden Foundation websites, accounts, donation experiences, and related community tools."
-      />
+    <LegalDocument
+      title="Terms of Service"
+      effectiveDate="April 23, 2026"
+      intro={(
+        <p>
+          These terms govern access to and use of Olivia&apos;s Garden Foundation websites,
+          accounts, donation experiences, and related community tools. Please read them carefully.
+        </p>
+      )}
+    >
+      <LegalTableOfContents items={TERMS_SECTIONS} />
 
-      <Section title="Acceptance of terms" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="acceptance" number={1} title="Acceptance of terms">
+        <p>
           By accessing or using this website or any related foundation service, you agree to these
           Terms of Service. If you do not agree, do not use the site or related services.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Use of the site" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="use-of-site" number={2} title="Use of the site">
+        <p>
           You may use the site only for lawful purposes and in a way that does not interfere with
           the operation, security, or availability of the website or the rights of others. You
-          agree not to misuse accounts, attempt unauthorized access, submit fraudulent information,
-          scrape restricted areas, upload malicious content, or use the services in violation of
-          applicable law.
+          agree not to misuse accounts, attempt unauthorized access, submit fraudulent
+          information, scrape restricted areas, upload malicious content, or use the services in
+          violation of applicable law.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Accounts" className="about-prose-block">
-        <p className="page-text">
-          If you create an account, you are responsible for maintaining the confidentiality of your
-          login credentials and for activity that occurs under your account. You agree to provide
-          accurate information and to notify us if you believe your account has been compromised.
+      <LegalSection id="accounts" number={3} title="Accounts">
+        <p>
+          If you create an account, you are responsible for maintaining the confidentiality of
+          your login credentials and for activity that occurs under your account. You agree to
+          provide accurate information and to notify us if you believe your account has been
+          compromised.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Donations and payments" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="donations" number={4} title="Donations and payments">
+        <p>
           Donations, purchases, and other payments made through the site may be processed by
           third-party payment providers. Additional terms from those providers may apply. Except
           where required by law or expressly stated otherwise, donations are generally final and
           non-refundable.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="User submissions" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="user-submissions" number={5} title="User submissions">
+        <p>
           If you submit photos, messages, profile content, seed requests, or other material, you
-          represent that you have the right to provide that content and that it does not violate the
-          rights of any other person. You grant Olivia&apos;s Garden Foundation a non-exclusive,
-          worldwide, royalty-free license to host, store, reproduce, adapt, display, and use that
-          content as needed to operate the site, administer programs, highlight community
-          participation, and support the foundation&apos;s mission.
+          represent that you have the right to provide that content and that it does not violate
+          the rights of any other person. You grant Olivia&apos;s Garden Foundation a
+          non-exclusive, worldwide, royalty-free license to host, store, reproduce, adapt,
+          display, and use that content as needed to operate the site, administer programs,
+          highlight community participation, and support the foundation&apos;s mission.
         </p>
-        <p className="page-text">
-          We may remove or moderate content at our discretion, including content that is unlawful,
-          misleading, abusive, inappropriate, infringing, unsafe, or inconsistent with the
-          foundation&apos;s mission.
+        <p>
+          We may remove or moderate content at our discretion, including content that is
+          unlawful, misleading, abusive, inappropriate, infringing, unsafe, or inconsistent with
+          the foundation&apos;s mission.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Intellectual property" className="about-prose-block">
-        <p className="page-text">
-          Unless otherwise stated, the website, design, text, graphics, logos, photos, videos, and
-          other content provided by Olivia&apos;s Garden Foundation are owned by or licensed to the
-          foundation and are protected by applicable intellectual property laws. You may not copy,
-          reproduce, distribute, or create derivative works from site content except as permitted by
-          law or with prior written permission.
+      <LegalSection id="intellectual-property" number={6} title="Intellectual property">
+        <p>
+          Unless otherwise stated, the website, design, text, graphics, logos, photos, videos,
+          and other content provided by Olivia&apos;s Garden Foundation are owned by or licensed
+          to the foundation and are protected by applicable intellectual property laws. You may
+          not copy, reproduce, distribute, or create derivative works from site content except as
+          permitted by law or with prior written permission.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Third-party services and links" className="about-prose-block">
-        <p className="page-text">
-          The site may link to third-party services or rely on third-party platforms for payments,
-          sign-in, analytics, maps, hosting, or communications. We are not responsible for the
-          content, policies, or practices of third-party services.
+      <LegalSection id="third-party-services" number={7} title="Third-party services and links">
+        <p>
+          The site may link to third-party services or rely on third-party platforms for
+          payments, sign-in, analytics, maps, hosting, or communications. We are not responsible
+          for the content, policies, or practices of third-party services.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Disclaimers" className="about-prose-block">
-        <p className="page-text">
-          The website and services are provided on an &quot;as is&quot; and &quot;as available&quot;
-          basis without warranties of any kind, whether express or implied, to the fullest extent
-          permitted by law. We do not guarantee uninterrupted access, error-free operation, or that
-          the site will always be secure or free from harmful components.
+      <LegalSection id="disclaimers" number={8} title="Disclaimers">
+        <p>
+          The website and services are provided on an &quot;as is&quot; and &quot;as
+          available&quot; basis without warranties of any kind, whether express or implied, to
+          the fullest extent permitted by law. We do not guarantee uninterrupted access,
+          error-free operation, or that the site will always be secure or free from harmful
+          components.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Limitation of liability" className="about-prose-block">
-        <p className="page-text">
-          To the fullest extent permitted by law, Olivia&apos;s Garden Foundation and its officers,
-          directors, volunteers, employees, and affiliates will not be liable for any indirect,
-          incidental, special, consequential, or punitive damages, or for any loss of data,
-          profits, goodwill, or business opportunities arising from or related to use of the site or
-          services.
+      <LegalSection id="limitation-of-liability" number={9} title="Limitation of liability">
+        <p>
+          To the fullest extent permitted by law, Olivia&apos;s Garden Foundation and its
+          officers, directors, volunteers, employees, and affiliates will not be liable for any
+          indirect, incidental, special, consequential, or punitive damages, or for any loss of
+          data, profits, goodwill, or business opportunities arising from or related to use of
+          the site or services.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Indemnification" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="indemnification" number={10} title="Indemnification">
+        <p>
           You agree to indemnify and hold harmless Olivia&apos;s Garden Foundation from claims,
           liabilities, damages, losses, and expenses arising out of your use of the site, your
           submissions, or your violation of these terms or applicable law.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Termination" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="termination" number={11} title="Termination">
+        <p>
           We may suspend or terminate access to the site or specific features at any time if we
           believe it is necessary to protect the foundation, users, or the public, or to address
           violations of these terms.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Governing law" className="about-prose-block">
-        <p className="page-text">
-          These terms are governed by the laws of the State of Texas, without regard to conflict of
-          law principles, except where superseded by applicable federal law.
+      <LegalSection id="governing-law" number={12} title="Governing law">
+        <p>
+          These terms are governed by the laws of the State of Texas, without regard to conflict
+          of law principles, except where superseded by applicable federal law.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Changes to these terms" className="about-prose-block">
-        <p className="page-text">
-          We may update these terms from time to time. The updated version will be posted on this
-          page with a revised effective date. Continued use of the site after changes become
-          effective means you accept the updated terms.
+      <LegalSection id="changes" number={13} title="Changes to these terms">
+        <p>
+          We may update these terms from time to time. The updated version will be posted on
+          this page with a revised effective date. Continued use of the site after changes
+          become effective means you accept the updated terms.
         </p>
-      </Section>
+      </LegalSection>
 
-      <Section title="Contact" className="about-prose-block">
-        <p className="page-text">
+      <LegalSection id="contact" number={14} title="Contact">
+        <p>
           Questions about these Terms of Service can be sent through the contact information
-          provided on this website.
+          provided on this website, or by writing to{' '}
+          <a href="mailto:allen@oliviasgarden.org">allen@oliviasgarden.org</a>.
         </p>
-        <p className="page-text">
-          Effective date: April 23, 2026.
-        </p>
-      </Section>
-    </>
+      </LegalSection>
+    </LegalDocument>
   );
 }
 

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -123,6 +123,15 @@ export const routes: AppRoute[] = [
     allowIndex: true,
     prerender: true,
   },
+  {
+    path: '/data-deletion',
+    label: 'Data Deletion',
+    showInFooter: true,
+    title: 'Data and account deletion',
+    description: "How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data from Facebook or Google sign-in.",
+    allowIndex: true,
+    prerender: true,
+  },
 ];
 
 export const navRoutes = routes.filter((route) => route.showInNav);

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -126,7 +126,7 @@ export const routes: AppRoute[] = [
   },
   {
     path: '/data-deletion',
-    label: 'Data Deletion',
+    label: 'Your data',
     showInLegalFooter: true,
     title: 'Data and account deletion',
     description: "How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data from Facebook or Google sign-in.",

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -7,6 +7,7 @@ export type AppRoute = {
   allowIndex?: boolean;
   showInNav?: boolean;
   showInFooter?: boolean;
+  showInLegalFooter?: boolean;
   prerender?: boolean;
 };
 
@@ -108,7 +109,7 @@ export const routes: AppRoute[] = [
   {
     path: '/privacy',
     label: 'Privacy Policy',
-    showInFooter: true,
+    showInLegalFooter: true,
     title: 'Privacy Policy',
     description: "Read how Olivia's Garden Foundation collects, uses, stores, and protects information across the foundation website, donations, and account features.",
     allowIndex: true,
@@ -117,7 +118,7 @@ export const routes: AppRoute[] = [
   {
     path: '/terms',
     label: 'Terms of Service',
-    showInFooter: true,
+    showInLegalFooter: true,
     title: 'Terms of Service',
     description: "Review the terms that govern use of Olivia's Garden Foundation websites, accounts, donations, community tools, and submitted content.",
     allowIndex: true,
@@ -126,7 +127,7 @@ export const routes: AppRoute[] = [
   {
     path: '/data-deletion',
     label: 'Data Deletion',
-    showInFooter: true,
+    showInLegalFooter: true,
     title: 'Data and account deletion',
     description: "How to delete your Olivia's Garden Foundation account and the personal data associated with it, including data from Facebook or Google sign-in.",
     allowIndex: true,
@@ -136,6 +137,7 @@ export const routes: AppRoute[] = [
 
 export const navRoutes = routes.filter((route) => route.showInNav);
 export const footerRoutes = routes.filter((route) => route.showInFooter);
+export const legalFooterRoutes = routes.filter((route) => route.showInLegalFooter);
 export const prerenderRoutes = routes.filter((route) => route.prerender);
 export const internalPaths = new Set(routes.map((route) => route.path));
 

--- a/apps/web/tests/legal.spec.ts
+++ b/apps/web/tests/legal.spec.ts
@@ -5,8 +5,8 @@ test.describe('legal pages', () => {
   test('privacy policy loads and is linked in the footer', async ({ page }) => {
     await gotoAndWait(page, '/privacy');
 
-    await expect(page.getByRole('heading', { name: 'Privacy Policy' })).toBeVisible();
-    await expect(page.getByText('Effective date: April 23, 2026.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Privacy Policy', level: 1 })).toBeVisible();
+    await expect(page.locator('.legal-document__effective')).toContainText('April 23, 2026');
 
     const footerLink = page.locator('footer').getByRole('link', { name: 'Terms of Service' });
     await expect(footerLink).toBeVisible();
@@ -15,10 +15,23 @@ test.describe('legal pages', () => {
   test('terms of service loads and is linked in the footer', async ({ page }) => {
     await gotoAndWait(page, '/terms');
 
-    await expect(page.getByRole('heading', { name: 'Terms of Service' })).toBeVisible();
-    await expect(page.getByText('Effective date: April 23, 2026.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Terms of Service', level: 1 })).toBeVisible();
+    await expect(page.locator('.legal-document__effective')).toContainText('April 23, 2026');
 
     const footerLink = page.locator('footer').getByRole('link', { name: 'Privacy Policy' });
+    await expect(footerLink).toBeVisible();
+  });
+
+  test('data deletion page loads with deletion instructions and footer link', async ({ page }) => {
+    await gotoAndWait(page, '/data-deletion');
+
+    await expect(
+      page.getByRole('heading', { name: 'Data and account deletion', level: 1 }),
+    ).toBeVisible();
+    await expect(page.locator('.legal-document__effective')).toContainText('April 24, 2026');
+    await expect(page.getByRole('heading', { name: /Delete from inside your account/ })).toBeVisible();
+
+    const footerLink = page.locator('footer').getByRole('link', { name: 'Data Deletion' });
     await expect(footerLink).toBeVisible();
   });
 });

--- a/apps/web/tests/legal.spec.ts
+++ b/apps/web/tests/legal.spec.ts
@@ -31,7 +31,7 @@ test.describe('legal pages', () => {
     await expect(page.locator('.legal-document__effective')).toContainText('April 24, 2026');
     await expect(page.getByRole('heading', { name: /Delete from inside your account/ })).toBeVisible();
 
-    const footerLink = page.locator('footer').getByRole('link', { name: 'Data Deletion' });
+    const footerLink = page.locator('footer').getByRole('link', { name: 'Your data' });
     await expect(footerLink).toBeVisible();
   });
 });

--- a/packages/ui/src/components/SiteFooter.tsx
+++ b/packages/ui/src/components/SiteFooter.tsx
@@ -17,51 +17,68 @@ export interface SiteFooterProps {
   tagline: string;
   meta: string;
   links?: SiteFooterLink[];
+  legalLinks?: SiteFooterLink[];
   socialLinks?: SiteFooterSocialLink[];
+}
+
+function renderLinkGroup(
+  label: string,
+  navLabel: string,
+  linkClassName: string,
+  variant: 'pages' | 'legal',
+  links: SiteFooterLink[],
+) {
+  return (
+    <nav
+      className={`og-site-footer__links-block og-site-footer__links-block--${variant}`}
+      aria-label={navLabel}
+    >
+      <p className="og-site-footer__label">{label}</p>
+      <ul className={`og-site-footer__links og-site-footer__links--${variant}`}>
+        {links.map((link) => (
+          <li key={link.id} className="og-site-footer__link-item">
+            {link.href ? (
+              <a
+                href={link.href}
+                className={`${linkClassName} ${link.active ? 'is-active' : ''}`.trim()}
+                aria-current={link.active ? 'page' : undefined}
+                onClick={(event) => {
+                  if (link.onSelect) {
+                    event.preventDefault();
+                    link.onSelect();
+                  }
+                }}
+              >
+                {link.label}
+              </a>
+            ) : (
+              <button
+                type="button"
+                className={`${linkClassName} ${link.active ? 'is-active' : ''}`.trim()}
+                onClick={link.onSelect}
+              >
+                {link.label}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
 }
 
 export function SiteFooter({
   meta,
   links = [],
+  legalLinks = [],
   socialLinks = [],
 }: SiteFooterProps) {
   return (
     <footer className="og-site-footer">
       <div className="og-site-footer__inner">
-        {links.length > 0 ? (
-          <nav className="og-site-footer__links-block" aria-label="Footer">
-            <p className="og-site-footer__label">Pages</p>
-              <ul className="og-site-footer__links">
-                {links.map((link) => (
-                  <li key={link.id} className="og-site-footer__link-item">
-                    {link.href ? (
-                      <a
-                        href={link.href}
-                        className={`og-site-footer__link ${link.active ? 'is-active' : ''}`.trim()}
-                        aria-current={link.active ? 'page' : undefined}
-                        onClick={(event) => {
-                          if (link.onSelect) {
-                            event.preventDefault();
-                            link.onSelect();
-                          }
-                        }}
-                      >
-                        {link.label}
-                      </a>
-                    ) : (
-                      <button
-                        type="button"
-                        className={`og-site-footer__link ${link.active ? 'is-active' : ''}`.trim()}
-                        onClick={link.onSelect}
-                      >
-                        {link.label}
-                      </button>
-                    )}
-                  </li>
-                ))}
-              </ul>
-          </nav>
-        ) : null}
+        {links.length > 0
+          ? renderLinkGroup('Pages', 'Footer', 'og-site-footer__link', 'pages', links)
+          : null}
 
         {socialLinks.length > 0 ? (
           <div className="og-site-footer__social-block">
@@ -95,6 +112,10 @@ export function SiteFooter({
             </div>
           </div>
         ) : null}
+        {legalLinks.length > 0
+          ? renderLinkGroup('Legal', 'Legal', 'og-site-footer__link og-site-footer__link--legal', 'legal', legalLinks)
+          : null}
+
         <p className="og-site-footer__meta">{meta}</p>
       </div>
     </footer>

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -416,6 +416,39 @@ body {
   text-decoration: none;
 }
 
+.og-site-footer__links-block--legal {
+  border-top: 1px solid rgba(255, 250, 241, 0.14);
+  padding-top: 0.7rem;
+  margin-top: 0.25rem;
+}
+
+.og-site-footer__links--legal {
+  gap: 0.2rem 1rem;
+}
+
+.og-site-footer__link--legal {
+  color: rgba(255, 250, 241, 0.58);
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+}
+
+.og-site-footer__link--legal:hover {
+  color: rgba(255, 250, 241, 0.88);
+}
+
+.og-site-footer__link--legal.is-active {
+  color: rgba(255, 250, 241, 0.86);
+}
+
+@media (max-width: 720px) {
+  .og-site-footer__links-block--legal {
+    padding-top: 0.4rem;
+  }
+  .og-site-footer__link--legal {
+    font-size: 0.7rem;
+  }
+}
+
 .og-side-layout {
   width: min(1180px, calc(100% - 2rem));
   margin: 0 auto;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -449,6 +449,44 @@ body {
   }
 }
 
+@media (min-width: 800px) {
+  .og-site-footer__inner {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "pages legal"
+      "social social"
+      "meta meta";
+    column-gap: 3rem;
+    row-gap: 1.1rem;
+    align-items: start;
+  }
+
+  .og-site-footer__links-block--pages {
+    grid-area: pages;
+  }
+
+  .og-site-footer__links-block--legal {
+    grid-area: legal;
+    justify-self: end;
+    text-align: right;
+    border-top: 0;
+    padding-top: 0;
+    margin-top: 0;
+  }
+
+  .og-site-footer__links--legal {
+    justify-content: flex-end;
+  }
+
+  .og-site-footer__social-block {
+    grid-area: social;
+  }
+
+  .og-site-footer__meta {
+    grid-area: meta;
+  }
+}
+
 .og-side-layout {
   width: min(1180px, calc(100% - 2rem));
   margin: 0 auto;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -453,16 +453,26 @@ body {
   .og-site-footer__inner {
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
+      "pages social"
       "pages legal"
-      "social social"
       "meta meta";
     column-gap: 3rem;
-    row-gap: 1.1rem;
+    row-gap: 0.75rem;
     align-items: start;
   }
 
   .og-site-footer__links-block--pages {
     grid-area: pages;
+    align-self: start;
+  }
+
+  .og-site-footer__social-block {
+    grid-area: social;
+    justify-self: end;
+  }
+
+  .og-site-footer__social-row {
+    justify-content: flex-end;
   }
 
   .og-site-footer__links-block--legal {
@@ -470,7 +480,7 @@ body {
     justify-self: end;
     text-align: right;
     border-top: 0;
-    padding-top: 0;
+    padding-top: 0.25rem;
     margin-top: 0;
   }
 
@@ -478,12 +488,9 @@ body {
     justify-content: flex-end;
   }
 
-  .og-site-footer__social-block {
-    grid-area: social;
-  }
-
   .og-site-footer__meta {
     grid-area: meta;
+    margin-top: 0.4rem;
   }
 }
 

--- a/postman/collections/Web API/Profile/Delete Profile - Invalid Token.request.yaml
+++ b/postman/collections/Web API/Profile/Delete Profile - Invalid Token.request.yaml
@@ -1,0 +1,25 @@
+$kind: http-request
+name: Delete Profile - Invalid Token
+description: |-
+  Ensure DELETE /profile rejects requests bearing a clearly-invalid bearer token.
+  The Cognito verifier should fail closed before we touch any data.
+method: DELETE
+url: '{{webBaseUrl}}/profile'
+order: 1101
+headers:
+  - key: Authorization
+    value: 'Bearer not-a-real-token'
+  - key: X-Correlation-Id
+    value: postman-delete-profile-invalid
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Invalid tokens are rejected with 400 or 401", function () {
+          pm.expect([400, 401]).to.include(pm.response.code);
+      });
+
+      pm.test("Response body surfaces an error message", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+      });

--- a/postman/collections/Web API/Profile/Delete Profile - Unauthenticated.request.yaml
+++ b/postman/collections/Web API/Profile/Delete Profile - Unauthenticated.request.yaml
@@ -1,0 +1,29 @@
+$kind: http-request
+name: Delete Profile - Unauthenticated
+description: |-
+  Ensure DELETE /profile rejects unauthenticated requests. This satisfies the
+  baseline contract test for the account deletion endpoint used for Facebook app
+  data-deletion compliance.
+method: DELETE
+url: '{{webBaseUrl}}/profile'
+order: 1100
+headers:
+  - key: X-Correlation-Id
+    value: postman-delete-profile-unauth
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("DELETE /profile returns 400 when unauthenticated", function () {
+          pm.expect(pm.response.code).to.equal(400);
+      });
+
+      pm.test("Response body surfaces the missing-auth error", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+          pm.expect(body.error.toLowerCase()).to.include("authorization");
+      });
+
+      pm.test("Response includes correlation id header", function () {
+          pm.expect(pm.response.headers.get("x-correlation-id")).to.be.a("string").and.not.empty;
+      });

--- a/services/web-api/db/migrations/0004_user_account_deletion.sql
+++ b/services/web-api/db/migrations/0004_user_account_deletion.sql
@@ -1,0 +1,11 @@
+-- Account deletion support: allow users to request a full deletion of their data.
+-- The users table already has a `deleted_at` column. Deletion is performed by:
+--   1. Clearing the profile PII fields on the row.
+--   2. Marking deleted_at = now().
+--   3. Severing references from donation_events (user_id set to null; donor_name/donor_email also scrubbed).
+--
+-- This migration only adds supporting indexes. The deletion logic itself lives in the web API.
+
+create index if not exists idx_users_email_active
+  on users(email)
+  where deleted_at is null;

--- a/services/web-api/openapi.yaml
+++ b/services/web-api/openapi.yaml
@@ -25,6 +25,39 @@ paths:
                 $ref: '#/components/schemas/CreateDonationCheckoutSessionResponse'
         '422':
           description: Request validation failed
+  /profile:
+    delete:
+      summary: Permanently delete the signed-in user's account and associated personal data
+      description: |
+        Deletes the authenticated user's Olivia's Garden Foundation account. This endpoint:
+          - Scrubs profile PII (name, bio, location, timezone, website) from the users row.
+          - Clears avatar metadata and S3 references.
+          - Removes donor name/email/dedication notes from donation history and unlinks
+            donation_events.user_id, while keeping anonymized donation records for tax/accounting.
+          - Soft-deletes the users row (sets deleted_at).
+          - Deletes the Cognito user (self-delete via the access token, falling back to
+            admin-delete when the caller presented an ID token).
+
+        The request must include a valid bearer token for the account being deleted. There is no
+        request body; the user's identity is taken from the token.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Account deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    enum: [deleted]
+        '400':
+          description: Missing or invalid authorization header
+        '401':
+          description: Invalid access token
   /donations/checkout-session-status:
     get:
       summary: Read the current Stripe Checkout Session status after return from embedded checkout
@@ -42,6 +75,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DonationCheckoutSessionStatusResponse'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     CreateDonationCheckoutSessionRequest:
       type: object

--- a/services/web-api/src/handlers/api.mjs
+++ b/services/web-api/src/handlers/api.mjs
@@ -8,6 +8,7 @@ import {
   retrieveCheckoutSessionStatus
 } from '../services/donations.mjs';
 import {
+  deleteProfile,
   getProfile,
   getProfileActivity,
   profileUpdateSchema,
@@ -147,6 +148,25 @@ app.put('/profile', async ({ req, event }) => {
       body: profile
     };
   } catch (error) {
+    return mapApiError(error, correlationId);
+  }
+});
+
+app.delete('/profile', async ({ event }) => {
+  const correlationId = getCorrelationId(event);
+  try {
+    const result = await deleteProfile(event);
+    logger.info('Account deletion completed', { correlationId });
+    return {
+      statusCode: 200,
+      headers: { 'x-correlation-id': correlationId },
+      body: result
+    };
+  } catch (error) {
+    logger.error('Account deletion failed', {
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    });
     return mapApiError(error, correlationId);
   }
 });

--- a/services/web-api/src/services/auth.mjs
+++ b/services/web-api/src/services/auth.mjs
@@ -37,6 +37,10 @@ function getBearerToken(headers = {}) {
   return token;
 }
 
+export function extractBearerToken(event) {
+  return getBearerToken(event?.headers ?? {});
+}
+
 function firstNonEmptyString(...values) {
   for (const value of values) {
     if (typeof value === 'string' && value.trim()) {

--- a/services/web-api/src/services/http.mjs
+++ b/services/web-api/src/services/http.mjs
@@ -1,7 +1,7 @@
 export const corsHeaders = {
   'access-control-allow-origin': process.env.ORIGIN ?? '*',
   'access-control-allow-headers': 'Content-Type,Authorization,Idempotency-Key,X-Correlation-Id,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
-  'access-control-allow-methods': 'GET,POST,PUT,OPTIONS',
+  'access-control-allow-methods': 'GET,POST,PUT,DELETE,OPTIONS',
   'access-control-max-age': '3600'
 };
 

--- a/services/web-api/src/services/profile.mjs
+++ b/services/web-api/src/services/profile.mjs
@@ -1,5 +1,19 @@
+import {
+  CognitoIdentityProviderClient,
+  DeleteUserCommand,
+  AdminDeleteUserCommand
+} from '@aws-sdk/client-cognito-identity-provider';
 import { createDbClient } from '../../scripts/db-client.mjs';
-import { resolveOptionalAuthContext } from './auth.mjs';
+import { extractBearerToken, resolveOptionalAuthContext } from './auth.mjs';
+
+let cognitoClient;
+
+function getCognitoClient() {
+  if (!cognitoClient) {
+    cognitoClient = new CognitoIdentityProviderClient();
+  }
+  return cognitoClient;
+}
 
 export const profileUpdateSchema = {
   type: 'object',
@@ -218,6 +232,124 @@ export async function updateProfile(event, payload) {
   } finally {
     await client.end();
   }
+}
+
+async function deleteCognitoUser(event, authContext) {
+  const token = extractBearerToken(event);
+  const client = getCognitoClient();
+
+  if (token) {
+    try {
+      await client.send(new DeleteUserCommand({ AccessToken: token }));
+      return;
+    } catch (error) {
+      // NotAuthorizedException is expected when the caller presented an ID token
+      // instead of an access token; fall through to admin delete in that case.
+      const code = error?.name ?? '';
+      if (code !== 'NotAuthorizedException') {
+        throw error;
+      }
+    }
+  }
+
+  const userPoolId = process.env.OGF_USER_POOL_ID ?? process.env.SHARED_USER_POOL_ID;
+  if (!userPoolId || !authContext?.userId) {
+    return;
+  }
+
+  try {
+    await client.send(new AdminDeleteUserCommand({
+      UserPoolId: userPoolId,
+      Username: authContext.userId
+    }));
+  } catch (error) {
+    // If the Cognito user is already gone we still want the DB redaction to stand.
+    const code = error?.name ?? '';
+    if (code !== 'UserNotFoundException' && code !== 'ResourceNotFoundException') {
+      throw error;
+    }
+  }
+}
+
+export async function deleteProfile(event) {
+  const authContext = await resolveOptionalAuthContext(event);
+  if (!authContext?.userId) {
+    throw new Error('Authorization token is required');
+  }
+
+  const client = await createDbClient();
+  await client.connect();
+
+  try {
+    await client.query('begin');
+    // Scrub PII from the users row and mark it soft-deleted. The actual row is
+    // kept so that historical donation/audit references remain referentially sound.
+    await client.query(
+      `
+        update users
+           set email = null,
+               display_name = null,
+               first_name = null,
+               last_name = null,
+               bio = null,
+               city = null,
+               region = null,
+               country = null,
+               timezone = null,
+               website_url = null,
+               avatar_id = null,
+               avatar_status = 'none',
+               avatar_original_s3_bucket = null,
+               avatar_original_s3_key = null,
+               avatar_s3_bucket = null,
+               avatar_s3_key = null,
+               avatar_thumbnail_s3_bucket = null,
+               avatar_thumbnail_s3_key = null,
+               avatar_mime_type = null,
+               avatar_width = null,
+               avatar_height = null,
+               avatar_byte_size = null,
+               avatar_processing_error = null,
+               avatar_updated_at = null,
+               stripe_donor_customer_id = null,
+               stripe_garden_club_subscription_id = null,
+               deleted_at = coalesce(deleted_at, now()),
+               updated_at = now(),
+               profile_updated_at = now()
+         where id = $1::uuid
+      `,
+      [authContext.userId]
+    );
+
+    // Donation history is retained for tax/record purposes, but donor identifying
+    // fields are scrubbed alongside the account deletion.
+    await client.query(
+      `
+        update donation_events
+           set donor_name = null,
+               donor_email = null,
+               dedication_name = null,
+               user_id = null
+         where user_id = $1::uuid
+      `,
+      [authContext.userId]
+    );
+
+    await client.query('commit');
+  } catch (error) {
+    try {
+      await client.query('rollback');
+    } catch {
+      // ignore rollback failure; surface the original error below
+    }
+    throw error;
+  } finally {
+    await client.end();
+  }
+
+  await deleteCognitoUser(event, authContext);
+
+  return { status: 'deleted' };
 }
 
 export async function getProfileActivity(event) {

--- a/services/web-api/template.yaml
+++ b/services/web-api/template.yaml
@@ -106,7 +106,7 @@ Resources:
       TracingEnabled: false
       StageName: api
       Cors:
-        AllowMethods: "'GET,POST,PUT,OPTIONS'"
+        AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
         AllowHeaders: "'Content-Type,Authorization,Idempotency-Key,X-Correlation-Id,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
         AllowOrigin: !If
           - DeploySharedApiBasePathMapping
@@ -157,6 +157,13 @@ Resources:
               Action:
                 - events:PutEvents
               Resource: !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default'
+            - Effect: Allow
+              Action:
+                - cognito-idp:DeleteUser
+                - cognito-idp:AdminDeleteUser
+              Resource: !Sub
+                - 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}'
+                - UserPoolId: !ImportValue OGF-UserPoolId
       Events:
         ApiProxy:
           Type: Api

--- a/services/web-api/test/profile.test.mjs
+++ b/services/web-api/test/profile.test.mjs
@@ -1,11 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const resolveOptionalAuthContextMock = vi.fn();
+const extractBearerTokenMock = vi.fn();
 const createDbClientMock = vi.fn();
+const cognitoSendMock = vi.fn();
 
 vi.mock('../src/services/auth.mjs', () => ({
-  resolveOptionalAuthContext: resolveOptionalAuthContextMock
+  resolveOptionalAuthContext: resolveOptionalAuthContextMock,
+  extractBearerToken: extractBearerTokenMock
 }));
+
+vi.mock('@aws-sdk/client-cognito-identity-provider', () => {
+  class CognitoIdentityProviderClient {
+    send(command) { return cognitoSendMock(command); }
+  }
+  class DeleteUserCommand {
+    constructor(input) { this.commandName = 'DeleteUserCommand'; this.input = input; }
+  }
+  class AdminDeleteUserCommand {
+    constructor(input) { this.commandName = 'AdminDeleteUserCommand'; this.input = input; }
+  }
+  return {
+    CognitoIdentityProviderClient,
+    DeleteUserCommand,
+    AdminDeleteUserCommand
+  };
+});
 
 vi.mock('../scripts/db-client.mjs', () => ({
   createDbClient: createDbClientMock
@@ -77,7 +97,10 @@ function baseProfileRow(overrides = {}) {
 describe('web-api profile handler', () => {
   beforeEach(() => {
     resolveOptionalAuthContextMock.mockReset();
+    extractBearerTokenMock.mockReset();
     createDbClientMock.mockReset();
+    cognitoSendMock.mockReset();
+    cognitoSendMock.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -383,6 +406,86 @@ describe('web-api profile handler', () => {
       expect(body.avatarStatus).toBe('ready');
 
       delete process.env.MEDIA_CDN_DOMAIN;
+    });
+  });
+
+  describe('DELETE /profile', () => {
+    it('returns 400 with auth error when unauthenticated', async () => {
+      resolveOptionalAuthContextMock.mockResolvedValue(null);
+
+      const response = await handler(createApiGatewayEvent({
+        method: 'DELETE',
+        path: '/profile'
+      }));
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.body).error).toBe('Authorization token is required');
+      expect(createDbClientMock).not.toHaveBeenCalled();
+      expect(cognitoSendMock).not.toHaveBeenCalled();
+    });
+
+    it('redacts profile PII, scrubs donor fields, and self-deletes the Cognito user', async () => {
+      process.env.OGF_USER_POOL_ID = 'us-east-1_abc123';
+      resolveOptionalAuthContextMock.mockResolvedValue({
+        userId: USER_ID,
+        email: 'olivia@example.com',
+        name: 'Olivia'
+      });
+      extractBearerTokenMock.mockReturnValue('access-token-value');
+
+      const client = createClientMock(() => Promise.resolve({ rowCount: 1 }));
+      createDbClientMock.mockResolvedValue(client);
+
+      const response = await handler(createApiGatewayEvent({
+        method: 'DELETE',
+        path: '/profile',
+        headers: { authorization: 'Bearer access-token-value' }
+      }));
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ status: 'deleted' });
+
+      const sqlCalls = client.query.mock.calls.map(([sql]) => sql.trim());
+      expect(sqlCalls.some((sql) => sql.startsWith('begin'))).toBe(true);
+      expect(sqlCalls.some((sql) => sql.includes('update users') && sql.includes('deleted_at = coalesce'))).toBe(true);
+      expect(sqlCalls.some((sql) => sql.includes('update donation_events'))).toBe(true);
+      expect(sqlCalls.some((sql) => sql.startsWith('commit'))).toBe(true);
+
+      expect(cognitoSendMock).toHaveBeenCalledOnce();
+      const command = cognitoSendMock.mock.calls[0][0];
+      expect(command.commandName).toBe('DeleteUserCommand');
+      expect(command.input).toEqual({ AccessToken: 'access-token-value' });
+
+      delete process.env.OGF_USER_POOL_ID;
+    });
+
+    it('falls back to AdminDeleteUser when the caller presented an id token', async () => {
+      process.env.OGF_USER_POOL_ID = 'us-east-1_abc123';
+      resolveOptionalAuthContextMock.mockResolvedValue({ userId: USER_ID });
+      extractBearerTokenMock.mockReturnValue('id-token-value');
+
+      const client = createClientMock(() => Promise.resolve({ rowCount: 1 }));
+      createDbClientMock.mockResolvedValue(client);
+
+      const notAuthorized = new Error('Access token is not valid');
+      notAuthorized.name = 'NotAuthorizedException';
+      cognitoSendMock.mockRejectedValueOnce(notAuthorized);
+      cognitoSendMock.mockResolvedValueOnce({});
+
+      const response = await handler(createApiGatewayEvent({
+        method: 'DELETE',
+        path: '/profile'
+      }));
+
+      expect(response.statusCode).toBe(200);
+      expect(cognitoSendMock).toHaveBeenCalledTimes(2);
+      expect(cognitoSendMock.mock.calls[1][0].commandName).toBe('AdminDeleteUserCommand');
+      expect(cognitoSendMock.mock.calls[1][0].input).toEqual({
+        UserPoolId: 'us-east-1_abc123',
+        Username: USER_ID
+      });
+
+      delete process.env.OGF_USER_POOL_ID;
     });
   });
 


### PR DESCRIPTION
Introduces a user-initiated account deletion path for Facebook app and
general privacy compliance:

- DELETE /profile in the web API scrubs profile PII, clears avatar
  metadata, redacts donor identifying fields on retained donation
  records, soft-deletes the users row, and self-deletes the Cognito
  user (with an admin-delete fallback when the caller's token is an
  ID token).
- Adds CORS DELETE support, Cognito DeleteUser/AdminDeleteUser IAM
  permissions, OpenAPI entry, and Postman contract tests.
- Profile page has a Danger zone section with a typed-confirmation
  dialog; on success the user is signed out and returned home. CSS is
  mobile-first with a bottom-sheet style on small screens.
- Adds a public /data-deletion legal page that spells out both
  self-serve and email deletion paths, what is removed vs retained,
  and how third-party sign-in data (Facebook/Google) is handled.
  Linked from the privacy policy and surfaced in the site footer.