### PR TITLE
Mobile-optimize the admin app

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#3F7D3A" />
+    <meta name="color-scheme" content="light" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Olivia's Garden Admin" />
     <title>Olivia's Garden Admin</title>
     <link rel="icon" type="image/x-icon" href="/icons/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />

--- a/apps/admin/src/pages/OkraQueuePage.tsx
+++ b/apps/admin/src/pages/OkraQueuePage.tsx
@@ -7,18 +7,34 @@ import {
 } from '../api';
 import type { AdminSession } from '../auth/session';
 
-const VISIBLE_PHOTOS = 3;
+const DEFAULT_VISIBLE_PHOTOS = 3;
+const MOBILE_PHOTO_QUERY = '(max-width: 640px)';
 
 function PhotoCarousel({ photos, alt }: { photos: string[]; alt: string }) {
   const [startIndex, setStartIndex] = useState(0);
+  const [visiblePhotos, setVisiblePhotos] = useState<number>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return DEFAULT_VISIBLE_PHOTOS;
+    }
+    return window.matchMedia(MOBILE_PHOTO_QUERY).matches ? 1 : DEFAULT_VISIBLE_PHOTOS;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia(MOBILE_PHOTO_QUERY);
+    const update = () => setVisiblePhotos(mq.matches ? 1 : DEFAULT_VISIBLE_PHOTOS);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
 
   if (photos.length === 0) return null;
 
   const total = photos.length;
-  const canScroll = total > VISIBLE_PHOTOS;
-  const maxStart = Math.max(0, total - VISIBLE_PHOTOS);
+  const canScroll = total > visiblePhotos;
+  const maxStart = Math.max(0, total - visiblePhotos);
   const clampedStart = Math.min(startIndex, maxStart);
-  const visible = photos.slice(clampedStart, clampedStart + VISIBLE_PHOTOS);
+  const visible = photos.slice(clampedStart, clampedStart + visiblePhotos);
   const atStart = clampedStart === 0;
   const atEnd = clampedStart >= maxStart;
 
@@ -59,7 +75,9 @@ function PhotoCarousel({ photos, alt }: { photos: string[]; alt: string }) {
             </svg>
           </button>
           <div className="admin-photo-carousel__counter" aria-hidden="true">
-            {clampedStart + 1}–{Math.min(clampedStart + VISIBLE_PHOTOS, total)} of {total}
+            {visiblePhotos === 1
+              ? `${clampedStart + 1} of ${total}`
+              : `${clampedStart + 1}–${Math.min(clampedStart + visiblePhotos, total)} of ${total}`}
           </div>
         </>
       ) : null}

--- a/apps/admin/src/shell/AppShell.tsx
+++ b/apps/admin/src/shell/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { AvatarMenu, SiteFooter, SiteHeader } from '@olivias/ui';
 import { signOut } from 'aws-amplify/auth';
 import type { AdminSession } from '../auth/session';
@@ -118,6 +118,8 @@ export interface AppShellProps {
 
 export function AppShell({ session, children }: AppShellProps) {
   const [expanded, setExpanded] = useState<boolean>(() => readStoredExpanded());
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const location = useLocation();
 
   useEffect(() => {
     try {
@@ -126,6 +128,26 @@ export function AppShell({ session, children }: AppShellProps) {
       // ignore storage errors
     }
   }, [expanded]);
+
+  // Close the mobile drawer whenever the route changes.
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
+
+  // Escape key dismissal + lock background scroll while the drawer is open.
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMobileNavOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [mobileNavOpen]);
 
   const handleLogout = async () => {
     try {
@@ -165,11 +187,53 @@ export function AppShell({ session, children }: AppShellProps) {
           </div>
         )}
       />
-      <div className={`admin-shell-body ${expanded ? 'is-expanded' : 'is-collapsed'}`}>
+      <div
+        className={`admin-shell-body ${expanded ? 'is-expanded' : 'is-collapsed'} ${mobileNavOpen ? 'is-mobile-nav-open' : ''}`.trim()}
+      >
+        <button
+          type="button"
+          className="admin-mobile-nav-trigger"
+          aria-expanded={mobileNavOpen}
+          aria-controls="admin-vertical-nav"
+          aria-label="Open admin sections"
+          onClick={() => setMobileNavOpen(true)}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M4 7h16v2H4V7Zm0 4h16v2H4v-2Zm0 4h16v2H4v-2Z" fill="currentColor" />
+          </svg>
+          <span>Sections</span>
+        </button>
+
+        <button
+          type="button"
+          className="admin-mobile-nav-backdrop"
+          aria-label="Close admin sections"
+          tabIndex={mobileNavOpen ? 0 : -1}
+          onClick={() => setMobileNavOpen(false)}
+        />
+
         <aside
-          className={`admin-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'}`}
+          id="admin-vertical-nav"
+          className={`admin-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'} ${mobileNavOpen ? 'is-mobile-open' : ''}`.trim()}
           aria-label="Admin sections"
         >
+          <div className="admin-vertical-nav__mobile-header">
+            <span className="admin-vertical-nav__mobile-title">Admin sections</span>
+            <button
+              type="button"
+              className="admin-vertical-nav__mobile-close"
+              aria-label="Close admin sections"
+              onClick={() => setMobileNavOpen(false)}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M6.4 5 5 6.4 10.6 12 5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4L13.4 12 19 6.4 17.6 5 12 10.6 6.4 5Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+
           <ul className="admin-vertical-nav__list" role="list">
             {navItems.map((item) => (
               <li key={item.id}>
@@ -180,6 +244,7 @@ export function AppShell({ session, children }: AppShellProps) {
                     `admin-vertical-nav__link ${isActive ? 'is-active' : ''}`.trim()
                   }
                   title={expanded ? undefined : item.label}
+                  onClick={() => setMobileNavOpen(false)}
                 >
                   <span className="admin-vertical-nav__icon" aria-hidden="true">{item.icon}</span>
                   <span className="admin-vertical-nav__label">{item.label}</span>

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -62,6 +62,100 @@ body {
   align-content: start;
 }
 
+/* ── Mobile drawer trigger + backdrop (hidden on desktop) ─────────── */
+
+.admin-mobile-nav-trigger {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 252, 246, 0.95);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(38, 23, 15, 0.08);
+  touch-action: manipulation;
+}
+
+.admin-mobile-nav-trigger:hover,
+.admin-mobile-nav-trigger:focus-visible {
+  background: var(--og-color-paper);
+  border-color: var(--og-color-moss);
+  color: var(--og-color-moss);
+  outline: none;
+}
+
+.admin-mobile-nav-trigger svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.admin-mobile-nav-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  background: rgba(38, 23, 15, 0.45);
+  cursor: pointer;
+  z-index: 40;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-base, 200ms) var(--easing-out, ease);
+}
+
+.admin-shell-body.is-mobile-nav-open .admin-mobile-nav-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.admin-vertical-nav__mobile-header {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.35rem 0.85rem;
+  border-bottom: 1px solid rgba(79, 56, 37, 0.08);
+  margin-bottom: 0.5rem;
+}
+
+.admin-vertical-nav__mobile-title {
+  font-family: var(--og-font-display);
+  font-size: 1.1rem;
+  color: var(--og-color-soil);
+}
+
+.admin-vertical-nav__mobile-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--og-color-soil);
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.admin-vertical-nav__mobile-close:hover,
+.admin-vertical-nav__mobile-close:focus-visible {
+  background: rgba(79, 56, 37, 0.08);
+  outline: none;
+}
+
+.admin-vertical-nav__mobile-close svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 /* ── Left-docked vertical nav ─────────────────────────────────────── */
 
 .admin-vertical-nav {
@@ -226,28 +320,51 @@ body {
   height: 0.8rem;
 }
 
-/* ── Mobile: horizontal scroll fallback ───────────────────────────── */
+/* ── Mobile: off-canvas drawer (matches web app's 799px breakpoint) ─ */
 
-@media (max-width: 720px) {
+@media (max-width: 799px) {
   .admin-shell-body {
     flex-direction: column;
+  }
+
+  .admin-mobile-nav-trigger {
+    display: inline-flex;
+    align-self: flex-start;
+    margin: 0.85rem 0 0 clamp(0.75rem, 3vw, 1.25rem);
+    z-index: 30;
+  }
+
+  .admin-mobile-nav-backdrop {
+    display: block;
   }
 
   .admin-vertical-nav,
   .admin-vertical-nav.is-expanded,
   .admin-vertical-nav.is-collapsed {
-    position: static;
-    top: auto;
-    width: 100%;
-    max-height: none;
-    flex-direction: row;
-    gap: 0.4rem;
-    padding: 0.65rem 0.75rem;
-    border-right: none;
-    border-bottom: 1px solid rgba(79, 56, 37, 0.1);
-    box-shadow: 0 2px 16px rgba(38, 23, 15, 0.05);
-    overflow-x: auto;
-    overflow-y: hidden;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100dvh;
+    width: min(18rem, 84vw);
+    flex-direction: column;
+    padding: calc(env(safe-area-inset-top, 0px) + 1rem) 0.85rem
+             calc(env(safe-area-inset-bottom, 0px) + 1rem);
+    border-right: 1px solid rgba(79, 56, 37, 0.12);
+    border-bottom: none;
+    box-shadow: 6px 0 24px rgba(38, 23, 15, 0.18);
+    transform: translateX(-100%);
+    transition: transform var(--duration-base, 200ms) var(--easing-out, ease);
+    z-index: 50;
+    overflow-y: auto;
+  }
+
+  .admin-vertical-nav.is-mobile-open {
+    transform: translateX(0);
+  }
+
+  .admin-vertical-nav__mobile-header {
+    display: flex;
   }
 
   .admin-vertical-nav__toggle {
@@ -255,34 +372,33 @@ body {
   }
 
   .admin-vertical-nav__list {
-    flex: 1;
-    display: flex;
-    gap: 0.4rem;
-    overflow-x: auto;
-    overflow-y: hidden;
-  }
-
-  .admin-vertical-nav__list li {
-    flex-shrink: 0;
+    flex: 0 0 auto;
+    gap: 0.25rem;
+    overflow: visible;
   }
 
   .admin-vertical-nav__link {
-    min-height: 2.5rem;
-    padding: 0.4rem 0.85rem;
+    justify-content: flex-start;
+    gap: 0.85rem;
+    width: 100%;
+    min-height: 3rem;
+    padding: 0.65rem 0.85rem;
+    touch-action: manipulation;
   }
 
   .admin-vertical-nav__label {
+    display: inline;
     opacity: 1;
     transform: none;
   }
 
   .admin-vertical-nav__icon {
-    width: 1.9rem;
-    height: 1.9rem;
+    width: 1.6rem;
+    height: 1.6rem;
   }
 
   .admin-shell-main__inner {
-    padding: 1rem clamp(0.75rem, 3vw, 1.5rem) 2rem;
+    padding: 0.5rem clamp(0.75rem, 3vw, 1.5rem) 2rem;
   }
 }
 
@@ -342,11 +458,11 @@ body {
 .admin-stat-grid {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 }
 
 .admin-stat {
-  padding: 1.25rem 1.35rem;
+  padding: clamp(0.95rem, 3vw, 1.25rem) clamp(1rem, 3vw, 1.35rem);
   display: grid;
   gap: 0.35rem;
 }
@@ -542,8 +658,28 @@ body {
 }
 
 @media (max-width: 640px) {
+  .admin-photo-carousel {
+    padding: 0 2.75rem;
+  }
+
   .admin-photo-carousel__viewport {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .admin-photo-carousel__thumb {
+    aspect-ratio: 4 / 3;
+    max-height: 18rem;
+  }
+
+  .admin-photo-carousel__nav {
+    width: 2.5rem;
+    height: 2.5rem;
+    touch-action: manipulation;
+  }
+
+  .admin-photo-carousel__nav svg {
+    width: 1.15rem;
+    height: 1.15rem;
   }
 }
 
@@ -690,5 +826,76 @@ body {
 @media (max-width: 860px) {
   .admin-store-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ── Phone-sized refinements (≤640px) ─────────────────────────────── */
+
+@media (max-width: 640px) {
+  /* Section header: title + refresh button stack cleanly. */
+  .admin-section__header {
+    align-items: flex-start;
+  }
+
+  /* Stat tiles: one per row on phones for readability. */
+  .admin-stat-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* Request / submission card meta: name on top, date below. */
+  .admin-request-card__meta,
+  .admin-submission-card__meta {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.35rem;
+  }
+
+  .admin-request-card__meta > span,
+  .admin-submission-card__meta > span {
+    white-space: normal;
+  }
+
+  /* Definition-list rows: stack label above value. */
+  .admin-request-card__details > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.2rem;
+  }
+
+  /* Stretch action buttons across the card on phones. */
+  .admin-request-card__actions,
+  .admin-submission-card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .admin-request-card__actions > *,
+  .admin-submission-card__actions > * {
+    width: 100%;
+  }
+
+  /* Store: list rows shrink padding; price column sits below name. */
+  .admin-store-row {
+    padding: 0.75rem 0.85rem;
+    gap: 0.4rem;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .admin-store-row span {
+    width: 100%;
+  }
+
+  .admin-store-form__actions {
+    justify-content: stretch;
+  }
+
+  .admin-store-form__actions > * {
+    width: 100%;
+  }
+
+  /* Pagination wraps on tiny screens. */
+  .admin-pagination {
+    flex-wrap: wrap;
+    gap: 0.65rem;
   }
 }


### PR DESCRIPTION
## Summary
- Replace the admin nav's horizontal-scroll mobile fallback with an off-canvas drawer (hamburger trigger + backdrop, Escape/route-change dismissal, scroll lock) using the same 799px breakpoint the public site already uses.
- Phone-sized refinements across pages: dashboard stat tiles stack one-up, seed-request card meta/details stack label-over-value with full-width actions, okra photo carousel switches to single-photo view with larger touch targets and a `matchMedia`-aware visible count so the last photos remain reachable, store list rows and form action buttons go full-width.
- Bring `apps/admin/index.html` meta tags up to parity with the web app (`viewport-fit=cover`, `theme-color`, mobile-web-app meta).

## Why
After #260 the admin app got a real left-docked nav, but it was unusable on phones — the side rail compressed main content, the 720px fallback was a horizontally-scrolling pill list, and several pages had fixed grids (stat tiles, request detail rows, store form, photo carousel) that overflowed or cramped at phone widths. This PR reuses the patterns the public site already validated.

## Test plan
- [ ] Open admin app at <640px width — hamburger appears, drawer slides in from the left, backdrop dismiss works, Escape closes it, selecting a section auto-closes.
- [ ] Dashboard stat tiles render one per row at ≤640px.
- [ ] Seed-request cards: name/date stack vertically, detail rows label-above-value, "Mark as done" full-width.
- [ ] Okra queue photo carousel shows one photo at a time on phones; prev/next can reach the final photo; counter reads "X of N".
- [ ] Store catalog: product list rows stack name/price columns, form selects single-column, save button full-width.
- [ ] At ≥800px the desktop left-docked nav and grids look unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)