### PR TITLE
Add product variations (color, ink, etc.) to store

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1178,7 +1178,7 @@ jobs:
   deploy-store-frontend:
     name: Deploy Store Frontend
     runs-on: ubuntu-latest
-    needs: [deploy-store-backend, deploy-foundation, deploy-backend]
+    needs: [deploy-store-backend, deploy-foundation, deploy-backend, deploy-admin-backend]
 
     steps:
       - name: Checkout code
@@ -1219,6 +1219,7 @@ jobs:
           VITE_STORE_API_URL=${{ needs.deploy-store-backend.outputs.api-url }}
           VITE_FOUNDATION_URL=${{ steps.get-foundation-url.outputs.url }}
           VITE_GRN_URL=${{ needs.deploy-backend.outputs.frontend-url }}
+          VITE_ADMIN_URL=${{ needs.deploy-admin-backend.outputs.frontend-url }}
           EOF
 
       - name: Build store frontend

--- a/.github/workflows/pull-request-staging-validation-reusable.yml
+++ b/.github/workflows/pull-request-staging-validation-reusable.yml
@@ -938,7 +938,7 @@ jobs:
   deploy-staging-store-frontend:
     name: Deploy Store Staging Frontend
     runs-on: ubuntu-latest
-    needs: [deploy-staging-store-backend, deploy-staging-foundation]
+    needs: [deploy-staging-store-backend, deploy-staging-foundation, deploy-staging-admin-backend]
     if: inputs.shared_all == 'true' || inputs.store_backend == 'true' || inputs.store_frontend == 'true'
     env:
       AWS_REGION: us-east-1
@@ -972,6 +972,7 @@ jobs:
           VITE_STORE_API_URL=${{ needs.deploy-staging-store-backend.outputs.api-url }}
           VITE_FOUNDATION_URL=${{ needs.deploy-staging-foundation.outputs.web-frontend-url }}
           VITE_GRN_URL=${{ needs.deploy-staging-backend.outputs.frontend-url }}
+          VITE_ADMIN_URL=${{ needs.deploy-staging-admin-backend.outputs.frontend-url }}
           EOF
 
       - name: Build store frontend

--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -42,6 +42,7 @@ export interface StoreProductImage {
   byte_size: number | null;
   sort_order: number;
   alt_text: string | null;
+  variation_match: Record<string, string>;
   processing_error: string | null;
   created_at: string;
   updated_at: string;
@@ -119,7 +120,12 @@ export interface UpsertStoreProductRequest {
   nonprofit_program: string | null;
   impact_summary: string | null;
   image_url: string | null;
-  images?: Array<{ id: string; sort_order?: number; alt_text?: string | null }>;
+  images?: Array<{
+    id: string;
+    sort_order?: number;
+    alt_text?: string | null;
+    variation_match?: Record<string, string>;
+  }>;
   metadata: Record<string, unknown>;
   variations?: ProductVariation[];
 }

--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -19,10 +19,16 @@ export interface StoreProduct {
   image_urls: string[];
   images: StoreProductImage[];
   metadata: Record<string, unknown>;
+  variations: ProductVariation[];
   stripe_product_id: string;
   stripe_price_id: string;
   created_at: string;
   updated_at: string;
+}
+
+export interface ProductVariation {
+  name: string;
+  values: string[];
 }
 
 export interface StoreProductImage {
@@ -115,6 +121,7 @@ export interface UpsertStoreProductRequest {
   image_url: string | null;
   images?: Array<{ id: string; sort_order?: number; alt_text?: string | null }>;
   metadata: Record<string, unknown>;
+  variations?: ProductVariation[];
 }
 
 export interface StoreProductImageUploadIntent {
@@ -163,6 +170,7 @@ export interface StoreOrderItem {
   quantity: number;
   unitAmountCents: number;
   totalCents: number;
+  selectedVariations: Record<string, string> | null;
 }
 
 export interface StoreOrder {

--- a/apps/admin/src/pages/StoreOrdersPage.tsx
+++ b/apps/admin/src/pages/StoreOrdersPage.tsx
@@ -144,6 +144,11 @@ export function StoreOrdersPage({ session }: StoreOrdersPageProps) {
                 <li key={item.id}>
                   <span>
                     {item.quantity} × {item.productName}
+                    {item.selectedVariations
+                      ? ` (${Object.entries(item.selectedVariations)
+                          .map(([name, value]) => `${name}: ${value}`)
+                          .join(', ')})`
+                      : ''}
                   </span>
                   <span>{formatMoney(item.totalCents, order.currency)}</span>
                 </li>

--- a/apps/admin/src/pages/StorePage.tsx
+++ b/apps/admin/src/pages/StorePage.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type FormEvent, useEffect, useState } from 'react';
+import { type ChangeEvent, type FormEvent, type KeyboardEvent, useEffect, useState } from 'react';
 import {
   Button,
   Card,
@@ -14,6 +14,7 @@ import {
   listStoreProducts,
   uploadStoreProductImage,
   updateStoreProduct,
+  type ProductVariation,
   type StoreProduct,
   type StoreProductImage,
   type UpsertStoreProductRequest,
@@ -41,6 +42,7 @@ const emptyProductForm: UpsertStoreProductRequest = {
   impact_summary: '',
   image_url: '',
   metadata: {},
+  variations: [],
 };
 
 const statusOptions = [
@@ -156,6 +158,10 @@ export function StorePage({ session }: StorePageProps) {
       impact_summary: product.impact_summary,
       image_url: product.legacy_image_url,
       metadata: product.metadata,
+      variations: product.variations.map((variation) => ({
+        name: variation.name,
+        values: [...variation.values],
+      })),
     });
     setProductImages(
       product.images.map((image) => ({
@@ -213,6 +219,46 @@ export function StorePage({ session }: StorePageProps) {
     setProductImages((current) => current.filter((image) => image.id !== imageId));
   };
 
+  const variations = productForm.variations ?? [];
+
+  const updateVariations = (next: ProductVariation[]) => {
+    setProductForm((current) => ({ ...current, variations: next }));
+  };
+
+  const addVariation = () => {
+    updateVariations([...variations, { name: '', values: [] }]);
+  };
+
+  const removeVariation = (index: number) => {
+    updateVariations(variations.filter((_, i) => i !== index));
+  };
+
+  const setVariationName = (index: number, name: string) => {
+    updateVariations(variations.map((variation, i) => (i === index ? { ...variation, name } : variation)));
+  };
+
+  const addVariationValue = (index: number, value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    updateVariations(
+      variations.map((variation, i) =>
+        i === index && !variation.values.includes(trimmed)
+          ? { ...variation, values: [...variation.values, trimmed] }
+          : variation
+      )
+    );
+  };
+
+  const removeVariationValue = (index: number, valueIndex: number) => {
+    updateVariations(
+      variations.map((variation, i) =>
+        i === index
+          ? { ...variation, values: variation.values.filter((_, vi) => vi !== valueIndex) }
+          : variation
+      )
+    );
+  };
+
   const moveImage = (imageId: string, direction: -1 | 1) => {
     setProductImages((current) => {
       const index = current.findIndex((image) => image.id === imageId);
@@ -230,6 +276,13 @@ export function StorePage({ session }: StorePageProps) {
     setError(null);
 
     try {
+      const cleanedVariations = (productForm.variations ?? [])
+        .map((variation) => ({
+          name: variation.name.trim(),
+          values: variation.values.map((value) => value.trim()).filter(Boolean),
+        }))
+        .filter((variation) => variation.name && variation.values.length > 0);
+
       const payload: UpsertStoreProductRequest = {
         ...productForm,
         short_description: productForm.short_description || null,
@@ -243,6 +296,7 @@ export function StorePage({ session }: StorePageProps) {
           sort_order: index,
           alt_text: image.alt_text || null,
         })),
+        variations: cleanedVariations,
       };
 
       if (activeProductId) {
@@ -411,6 +465,14 @@ export function StorePage({ session }: StorePageProps) {
               value={productForm.image_url || ''}
               onChange={(event) => setProductForm((current) => ({ ...current, image_url: event.target.value }))}
             />
+            <VariationsEditor
+              variations={variations}
+              onAdd={addVariation}
+              onRemove={removeVariation}
+              onNameChange={setVariationName}
+              onAddValue={addVariationValue}
+              onRemoveValue={removeVariationValue}
+            />
             <div className="admin-store-images">
               <div className="admin-store-images__header">
                 <div>
@@ -499,5 +561,109 @@ export function StorePage({ session }: StorePageProps) {
         </Card>
       </div>
     </section>
+  );
+}
+
+interface VariationsEditorProps {
+  variations: ProductVariation[];
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  onNameChange: (index: number, name: string) => void;
+  onAddValue: (index: number, value: string) => void;
+  onRemoveValue: (index: number, valueIndex: number) => void;
+}
+
+function VariationsEditor({
+  variations,
+  onAdd,
+  onRemove,
+  onNameChange,
+  onAddValue,
+  onRemoveValue,
+}: VariationsEditorProps) {
+  const [drafts, setDrafts] = useState<Record<number, string>>({});
+
+  const submitValue = (index: number) => {
+    const draft = drafts[index];
+    if (!draft) return;
+    onAddValue(index, draft);
+    setDrafts((current) => ({ ...current, [index]: '' }));
+  };
+
+  const handleValueKey = (event: KeyboardEvent<HTMLInputElement>, index: number) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      submitValue(index);
+    }
+  };
+
+  return (
+    <div className="admin-store-variations">
+      <div className="admin-store-variations__header">
+        <div>
+          <p className="og-section-label">Variations (optional)</p>
+          <h4>Customer-selectable options</h4>
+          <small>e.g. Color: Red, Blue · Ink: Black, White. Each option requires a name and at least one value.</small>
+        </div>
+        <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
+          Add variation
+        </Button>
+      </div>
+      {variations.length === 0 ? (
+        <p className="admin-store-variations__empty">No variations. Customers buy a single SKU.</p>
+      ) : (
+        <ul className="admin-store-variations__list">
+          {variations.map((variation, index) => (
+            <li key={index} className="admin-store-variations__item">
+              <div className="admin-store-variations__row">
+                <Input
+                  label="Option name"
+                  placeholder="Color"
+                  value={variation.name}
+                  onChange={(event) => onNameChange(index, event.target.value)}
+                />
+                <Button type="button" variant="secondary" size="sm" onClick={() => onRemove(index)}>
+                  Remove
+                </Button>
+              </div>
+              <div className="admin-store-variations__values">
+                {variation.values.map((value, valueIndex) => (
+                  <span key={valueIndex} className="admin-store-variations__chip">
+                    {value}
+                    <button
+                      type="button"
+                      aria-label={`Remove ${value}`}
+                      onClick={() => onRemoveValue(index, valueIndex)}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <div className="admin-store-variations__row">
+                <Input
+                  label="Add value"
+                  placeholder="Red"
+                  value={drafts[index] ?? ''}
+                  onChange={(event) =>
+                    setDrafts((current) => ({ ...current, [index]: event.target.value }))
+                  }
+                  onKeyDown={(event) => handleValueKey(event, index)}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => submitValue(index)}
+                  disabled={!drafts[index]?.trim()}
+                >
+                  Add value
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/apps/admin/src/pages/StorePage.tsx
+++ b/apps/admin/src/pages/StorePage.tsx
@@ -87,6 +87,9 @@ export function StorePage({ session }: StorePageProps) {
   const [products, setProducts] = useState<StoreProduct[]>([]);
   const [activeProductId, setActiveProductId] = useState<string | null>(null);
   const [productForm, setProductForm] = useState<UpsertStoreProductRequest>(emptyProductForm);
+  // Tracked separately from unit_amount_cents so admins can type "1.5"
+  // without the input snapping to "1.50" mid-keystroke.
+  const [priceInput, setPriceInput] = useState('0.00');
   const [productImages, setProductImages] = useState<ProductImageFormItem[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
@@ -149,6 +152,7 @@ export function StorePage({ session }: StorePageProps) {
   const startCreate = () => {
     setActiveProductId(null);
     setProductForm(emptyProductForm);
+    setPriceInput('0.00');
     setProductImages([]);
   };
 
@@ -176,6 +180,7 @@ export function StorePage({ session }: StorePageProps) {
         values: [...variation.values],
       })),
     });
+    setPriceInput((product.unit_amount_cents / 100).toFixed(2));
     setProductImages(
       product.images.map((image) => ({
         id: image.id,
@@ -457,9 +462,20 @@ export function StorePage({ session }: StorePageProps) {
               />
               <Input
                 type="number"
-                label="Price (cents)"
-                value={productForm.unit_amount_cents}
-                onChange={(event) => setProductForm((current) => ({ ...current, unit_amount_cents: Number(event.target.value) || 0 }))}
+                label="Price (USD)"
+                step="0.01"
+                min="0"
+                value={priceInput}
+                onChange={(event) => {
+                  const raw = event.target.value;
+                  setPriceInput(raw);
+                  const dollars = Number(raw);
+                  setProductForm((current) => ({
+                    ...current,
+                    unit_amount_cents:
+                      Number.isFinite(dollars) && dollars >= 0 ? Math.round(dollars * 100) : 0,
+                  }));
+                }}
               />
             </div>
             <div className="admin-store-grid">
@@ -480,22 +496,6 @@ export function StorePage({ session }: StorePageProps) {
                 Featured
               </label>
             </div>
-            <Input
-              label="Nonprofit program"
-              value={productForm.nonprofit_program || ''}
-              onChange={(event) => setProductForm((current) => ({ ...current, nonprofit_program: event.target.value }))}
-            />
-            <Textarea
-              label="Impact summary"
-              value={productForm.impact_summary || ''}
-              onChange={(event) => setProductForm((current) => ({ ...current, impact_summary: event.target.value }))}
-            />
-            <Input
-              type="url"
-              label="Fallback image URL"
-              value={productForm.image_url || ''}
-              onChange={(event) => setProductForm((current) => ({ ...current, image_url: event.target.value }))}
-            />
             <VariationsEditor
               variations={variations}
               onAdd={addVariation}

--- a/apps/admin/src/pages/StorePage.tsx
+++ b/apps/admin/src/pages/StorePage.tsx
@@ -71,7 +71,14 @@ const MAX_PRODUCT_IMAGE_BYTES = 5 * 1024 * 1024;
 
 type ProductImageFormItem = Pick<
   StoreProductImage,
-  'id' | 'status' | 'url' | 'thumbnail_url' | 'sort_order' | 'alt_text' | 'processing_error'
+  | 'id'
+  | 'status'
+  | 'url'
+  | 'thumbnail_url'
+  | 'sort_order'
+  | 'alt_text'
+  | 'variation_match'
+  | 'processing_error'
 > & {
   localPreviewUrl?: string;
 };
@@ -114,16 +121,22 @@ export function StorePage({ session }: StorePageProps) {
           setProducts(next);
           const activeProduct = next.find((product) => product.id === activeProductId);
           if (activeProduct) {
-            setProductImages(
-              activeProduct.images.map((image) => ({
-                id: image.id,
-                status: image.status,
-                url: image.url,
-                thumbnail_url: image.thumbnail_url,
-                sort_order: image.sort_order,
-                alt_text: image.alt_text,
-                processing_error: image.processing_error,
-              }))
+            setProductImages((current) =>
+              activeProduct.images.map((image) => {
+                // Preserve unsaved variation_match edits while polling for
+                // processing status updates from the server.
+                const local = current.find((item) => item.id === image.id);
+                return {
+                  id: image.id,
+                  status: image.status,
+                  url: image.url,
+                  thumbnail_url: image.thumbnail_url,
+                  sort_order: image.sort_order,
+                  alt_text: image.alt_text,
+                  variation_match: local?.variation_match ?? image.variation_match ?? {},
+                  processing_error: image.processing_error,
+                };
+              })
             );
           }
         })
@@ -171,6 +184,7 @@ export function StorePage({ session }: StorePageProps) {
         thumbnail_url: image.thumbnail_url,
         sort_order: image.sort_order,
         alt_text: image.alt_text,
+        variation_match: image.variation_match ?? {},
         processing_error: image.processing_error,
       }))
     );
@@ -203,6 +217,7 @@ export function StorePage({ session }: StorePageProps) {
             thumbnail_url: null,
             sort_order: current.length,
             alt_text: '',
+            variation_match: {},
             processing_error: null,
             localPreviewUrl,
           },
@@ -283,6 +298,21 @@ export function StorePage({ session }: StorePageProps) {
         }))
         .filter((variation) => variation.name && variation.values.length > 0);
 
+      // Drop any image variation_match entries that no longer line up with
+      // the cleaned variation list (e.g. admin removed a value).
+      const allowedValues = new Map(
+        cleanedVariations.map((variation) => [variation.name, new Set(variation.values)])
+      );
+      const cleanImageVariationMatch = (match: Record<string, string>): Record<string, string> => {
+        const result: Record<string, string> = {};
+        for (const [name, value] of Object.entries(match)) {
+          if (allowedValues.get(name)?.has(value)) {
+            result[name] = value;
+          }
+        }
+        return result;
+      };
+
       const payload: UpsertStoreProductRequest = {
         ...productForm,
         short_description: productForm.short_description || null,
@@ -295,6 +325,7 @@ export function StorePage({ session }: StorePageProps) {
           id: image.id,
           sort_order: index,
           alt_text: image.alt_text || null,
+          variation_match: cleanImageVariationMatch(image.variation_match ?? {}),
         })),
         variations: cleanedVariations,
       };
@@ -519,6 +550,35 @@ export function StorePage({ session }: StorePageProps) {
                           )
                         }
                       />
+                      {variations.length > 0 ? (
+                        <div className="admin-store-images__variation-match">
+                          <p className="og-section-label">Show for</p>
+                          {variations.map((variation) =>
+                            variation.name && variation.values.length > 0 ? (
+                              <Select
+                                key={variation.name}
+                                label={variation.name}
+                                value={image.variation_match[variation.name] ?? ''}
+                                onChange={(value) =>
+                                  setProductImages((current) =>
+                                    current.map((item) => {
+                                      if (item.id !== image.id) return item;
+                                      const next = { ...item.variation_match };
+                                      if (value) next[variation.name] = value;
+                                      else delete next[variation.name];
+                                      return { ...item, variation_match: next };
+                                    })
+                                  )
+                                }
+                                options={[
+                                  { value: '', label: 'Any' },
+                                  ...variation.values.map((value) => ({ value, label: value })),
+                                ]}
+                              />
+                            ) : null
+                          )}
+                        </div>
+                      ) : null}
                       <div className="admin-store-images__actions">
                         <Button
                           type="button"

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -1038,6 +1038,18 @@ body {
   gap: 0.4rem;
 }
 
+.admin-store-images__variation-match {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+  background: rgba(79, 56, 37, 0.04);
+}
+
+.admin-store-images__variation-match .og-section-label {
+  margin: 0;
+}
+
 .admin-store-variations {
   display: grid;
   gap: 0.85rem;

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -1038,6 +1038,89 @@ body {
   gap: 0.4rem;
 }
 
+.admin-store-variations {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.85rem;
+  border: 1px dashed rgba(79, 56, 37, 0.2);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.admin-store-variations__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.admin-store-variations__header small {
+  display: block;
+  color: rgba(79, 56, 37, 0.62);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+.admin-store-variations__empty {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.62);
+  font-size: 0.9rem;
+}
+
+.admin-store-variations__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.admin-store-variations__item {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.65rem;
+  border: 1px solid rgba(79, 56, 37, 0.12);
+  border-radius: 6px;
+  background: #faf7f2;
+}
+
+.admin-store-variations__row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+}
+
+.admin-store-variations__row > .og-input {
+  flex: 1;
+}
+
+.admin-store-variations__values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.admin-store-variations__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: var(--og-color-moss, #6b8b5b);
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+.admin-store-variations__chip button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
 .admin-checkbox {
   display: inline-flex;
   align-items: center;

--- a/apps/store/src/api.ts
+++ b/apps/store/src/api.ts
@@ -42,6 +42,7 @@ export interface StoreProductImage {
   byte_size: number | null;
   sort_order: number;
   alt_text: string | null;
+  variation_match: Record<string, string>;
   processing_error: string | null;
   created_at: string;
   updated_at: string;

--- a/apps/store/src/api.ts
+++ b/apps/store/src/api.ts
@@ -19,10 +19,16 @@ export interface StoreProduct {
   image_urls: string[];
   images: StoreProductImage[];
   metadata: Record<string, unknown>;
+  variations: ProductVariation[];
   stripe_product_id: string;
   stripe_price_id: string;
   created_at: string;
   updated_at: string;
+}
+
+export interface ProductVariation {
+  name: string;
+  values: string[];
 }
 
 export interface StoreProductImage {
@@ -44,6 +50,7 @@ export interface StoreProductImage {
 export interface CheckoutLineItemInput {
   productId: string;
   quantity: number;
+  selectedVariations?: Record<string, string> | null;
 }
 
 export interface CheckoutSessionResponse {
@@ -60,6 +67,7 @@ export interface StoreOrderItem {
   quantity: number;
   unitAmountCents: number;
   totalCents: number;
+  selectedVariations: Record<string, string> | null;
 }
 
 export interface StoreOrder {

--- a/apps/store/src/auth/session.ts
+++ b/apps/store/src/auth/session.ts
@@ -4,6 +4,7 @@ export interface StoreSession {
   accessToken: string;
   email: string | null;
   displayName: string | null;
+  isAdmin: boolean;
 }
 
 async function readSessionTokens() {
@@ -41,10 +42,14 @@ export async function loadStoreSession(): Promise<StoreSession | null> {
           ? (accessPayload.name as string)
           : null;
 
+    const groups = accessPayload['cognito:groups'];
+    const isAdmin = Array.isArray(groups) && groups.includes('Admin');
+
     return {
       accessToken: tokens.accessToken,
       email,
       displayName,
+      isAdmin,
     };
   } catch {
     return null;

--- a/apps/store/src/cart/CartContext.tsx
+++ b/apps/store/src/cart/CartContext.tsx
@@ -39,6 +39,24 @@ function buildLineId(productId: string, selectedVariations: Record<string, strin
   return key ? `${productId}::${key}` : productId;
 }
 
+// Returns true when a stored cart line still satisfies the product's
+// current variation definitions. Used to prune carts that were stashed
+// in localStorage before the admin renamed/removed a variation.
+export function isCartLineValidForProduct(line: CartLine, product: StoreProduct): boolean {
+  if (product.variations.length === 0) {
+    return !line.selectedVariations || Object.keys(line.selectedVariations).length === 0;
+  }
+  if (!line.selectedVariations) return false;
+  for (const variation of product.variations) {
+    const chosen = line.selectedVariations[variation.name];
+    if (typeof chosen !== 'string') return false;
+    if (!variation.values.includes(chosen)) return false;
+  }
+  // Reject lines with extra keys that no longer correspond to a variation.
+  const validNames = new Set(product.variations.map((v) => v.name));
+  return Object.keys(line.selectedVariations).every((key) => validNames.has(key));
+}
+
 interface StoredCart {
   version: 1;
   lines: CartLine[];

--- a/apps/store/src/cart/CartContext.tsx
+++ b/apps/store/src/cart/CartContext.tsx
@@ -12,6 +12,8 @@ import type { StoreProduct } from '../api';
 const STORAGE_KEY = 'og-store-cart-v1';
 
 export interface CartLine {
+  // Stable id used for React keys / mutations; unique per (product, variation) combo.
+  lineId: string;
   productId: string;
   slug: string;
   name: string;
@@ -21,6 +23,20 @@ export interface CartLine {
   fulfillmentType: StoreProduct['fulfillment_type'];
   kind: StoreProduct['kind'];
   quantity: number;
+  selectedVariations: Record<string, string> | null;
+}
+
+function variationKey(selectedVariations: Record<string, string> | null | undefined): string {
+  if (!selectedVariations) return '';
+  return Object.keys(selectedVariations)
+    .sort()
+    .map((key) => `${key}=${selectedVariations[key]}`)
+    .join('|');
+}
+
+function buildLineId(productId: string, selectedVariations: Record<string, string> | null | undefined): string {
+  const key = variationKey(selectedVariations);
+  return key ? `${productId}::${key}` : productId;
 }
 
 interface StoredCart {
@@ -33,9 +49,13 @@ interface CartContextValue {
   itemCount: number;
   subtotalCents: number;
   requiresShipping: boolean;
-  add: (product: StoreProduct, quantity?: number) => void;
-  setQuantity: (productId: string, quantity: number) => void;
-  remove: (productId: string) => void;
+  add: (
+    product: StoreProduct,
+    quantity?: number,
+    selectedVariations?: Record<string, string> | null
+  ) => void;
+  setQuantity: (lineId: string, quantity: number) => void;
+  remove: (lineId: string) => void;
   clear: () => void;
 }
 
@@ -48,12 +68,18 @@ function readStoredCart(): CartLine[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw) as StoredCart;
     if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.lines)) return [];
-    return parsed.lines.filter(
-      (line): line is CartLine =>
-        typeof line.productId === 'string' &&
-        typeof line.quantity === 'number' &&
-        line.quantity > 0
-    );
+    return parsed.lines
+      .filter(
+        (line): line is CartLine =>
+          typeof line.productId === 'string' &&
+          typeof line.quantity === 'number' &&
+          line.quantity > 0
+      )
+      .map((line) => ({
+        ...line,
+        selectedVariations: line.selectedVariations ?? null,
+        lineId: line.lineId ?? buildLineId(line.productId, line.selectedVariations ?? null),
+      }));
   } catch {
     return [];
   }
@@ -75,47 +101,55 @@ export function CartProvider({ children }: { children: ReactNode }) {
     writeStoredCart(lines);
   }, [lines]);
 
-  const add = useCallback((product: StoreProduct, quantity = 1) => {
-    if (quantity <= 0) return;
-    setLines((current) => {
-      const existing = current.find((line) => line.productId === product.id);
-      if (existing) {
-        return current.map((line) =>
-          line.productId === product.id
-            ? { ...line, quantity: line.quantity + quantity }
-            : line
-        );
-      }
-      return [
-        ...current,
-        {
-          productId: product.id,
-          slug: product.slug,
-          name: product.name,
-          imageUrl: product.image_url,
-          unitAmountCents: product.unit_amount_cents,
-          currency: product.currency,
-          fulfillmentType: product.fulfillment_type,
-          kind: product.kind,
-          quantity,
-        },
-      ];
-    });
-  }, []);
+  const add = useCallback(
+    (
+      product: StoreProduct,
+      quantity = 1,
+      selectedVariations: Record<string, string> | null = null
+    ) => {
+      if (quantity <= 0) return;
+      const lineId = buildLineId(product.id, selectedVariations);
+      setLines((current) => {
+        const existing = current.find((line) => line.lineId === lineId);
+        if (existing) {
+          return current.map((line) =>
+            line.lineId === lineId ? { ...line, quantity: line.quantity + quantity } : line
+          );
+        }
+        return [
+          ...current,
+          {
+            lineId,
+            productId: product.id,
+            slug: product.slug,
+            name: product.name,
+            imageUrl: product.image_url,
+            unitAmountCents: product.unit_amount_cents,
+            currency: product.currency,
+            fulfillmentType: product.fulfillment_type,
+            kind: product.kind,
+            quantity,
+            selectedVariations,
+          },
+        ];
+      });
+    },
+    []
+  );
 
-  const setQuantity = useCallback((productId: string, quantity: number) => {
+  const setQuantity = useCallback((lineId: string, quantity: number) => {
     setLines((current) => {
       if (quantity <= 0) {
-        return current.filter((line) => line.productId !== productId);
+        return current.filter((line) => line.lineId !== lineId);
       }
       return current.map((line) =>
-        line.productId === productId ? { ...line, quantity } : line
+        line.lineId === lineId ? { ...line, quantity } : line
       );
     });
   }, []);
 
-  const remove = useCallback((productId: string) => {
-    setLines((current) => current.filter((line) => line.productId !== productId));
+  const remove = useCallback((lineId: string) => {
+    setLines((current) => current.filter((line) => line.lineId !== lineId));
   }, []);
 
   const clear = useCallback(() => {

--- a/apps/store/src/pages/BrowsePage.tsx
+++ b/apps/store/src/pages/BrowsePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Button, Card, FormFeedback, SectionHeading } from '@olivias/ui';
 import { listPublicProducts, type StoreProduct } from '../api';
 import { formatMoney, useCart } from '../cart/CartContext';
@@ -16,6 +16,7 @@ export function BrowsePage() {
   const [products, setProducts] = useState<StoreProduct[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const cart = useCart();
+  const navigate = useNavigate();
 
   useEffect(() => {
     let active = true;
@@ -76,9 +77,13 @@ export function BrowsePage() {
                 <Button
                   size="sm"
                   variant="secondary"
-                  onClick={() => cart.add(product, 1)}
+                  onClick={() =>
+                    product.variations.length > 0
+                      ? navigate(`/products/${product.slug}`)
+                      : cart.add(product, 1)
+                  }
                 >
-                  Add to cart
+                  {product.variations.length > 0 ? 'Choose options' : 'Add to cart'}
                 </Button>
               </div>
             </div>

--- a/apps/store/src/pages/CartPage.tsx
+++ b/apps/store/src/pages/CartPage.tsx
@@ -28,7 +28,11 @@ export function CartPage({ session }: CartPageProps) {
     try {
       const origin = window.location.origin;
       const { url } = await createCheckoutSession(
-        cart.lines.map((line) => ({ productId: line.productId, quantity: line.quantity })),
+        cart.lines.map((line) => ({
+          productId: line.productId,
+          quantity: line.quantity,
+          selectedVariations: line.selectedVariations,
+        })),
         {
           accessToken: session?.accessToken,
           customerEmail: session?.email ?? undefined,
@@ -89,7 +93,7 @@ export function CartPage({ session }: CartPageProps) {
         <Card className="store-cart">
           <ul className="store-cart__lines">
             {cart.lines.map((line) => (
-              <li key={line.productId} className="store-cart__line">
+              <li key={line.lineId} className="store-cart__line">
                 <Link
                   to={`/products/${line.slug}`}
                   className="store-cart__line-media"
@@ -105,6 +109,13 @@ export function CartPage({ session }: CartPageProps) {
                   <h3 className="store-cart__line-name">
                     <Link to={`/products/${line.slug}`}>{line.name}</Link>
                   </h3>
+                  {line.selectedVariations ? (
+                    <p className="store-cart__line-variations">
+                      {Object.entries(line.selectedVariations)
+                        .map(([name, value]) => `${name}: ${value}`)
+                        .join(' · ')}
+                    </p>
+                  ) : null}
                   <p className="store-cart__line-meta">
                     {FULFILLMENT_LABEL[line.fulfillmentType] ?? line.fulfillmentType}
                   </p>
@@ -119,7 +130,7 @@ export function CartPage({ session }: CartPageProps) {
                         className="store-quantity__btn"
                         aria-label="Decrease quantity"
                         onClick={() =>
-                          cart.setQuantity(line.productId, Math.max(0, line.quantity - 1))
+                          cart.setQuantity(line.lineId, Math.max(0, line.quantity - 1))
                         }
                       >
                         −
@@ -134,7 +145,7 @@ export function CartPage({ session }: CartPageProps) {
                         onChange={(event) => {
                           const next = Number(event.target.value);
                           if (Number.isFinite(next)) {
-                            cart.setQuantity(line.productId, Math.max(0, Math.floor(next)));
+                            cart.setQuantity(line.lineId, Math.max(0, Math.floor(next)));
                           }
                         }}
                       />
@@ -143,7 +154,7 @@ export function CartPage({ session }: CartPageProps) {
                         className="store-quantity__btn"
                         aria-label="Increase quantity"
                         onClick={() =>
-                          cart.setQuantity(line.productId, line.quantity + 1)
+                          cart.setQuantity(line.lineId, line.quantity + 1)
                         }
                       >
                         +
@@ -152,7 +163,7 @@ export function CartPage({ session }: CartPageProps) {
                     <button
                       type="button"
                       className="store-cart__line-remove"
-                      onClick={() => cart.remove(line.productId)}
+                      onClick={() => cart.remove(line.lineId)}
                     >
                       Remove
                     </button>

--- a/apps/store/src/pages/CartPage.tsx
+++ b/apps/store/src/pages/CartPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Card, FormFeedback, SectionHeading } from '@olivias/ui';
-import { createCheckoutSession } from '../api';
-import { formatMoney, useCart } from '../cart/CartContext';
+import { createCheckoutSession, listPublicProducts } from '../api';
+import { formatMoney, isCartLineValidForProduct, useCart } from '../cart/CartContext';
 import type { StoreSession } from '../auth/session';
 
 const FULFILLMENT_LABEL: Record<string, string> = {
@@ -20,6 +20,45 @@ export function CartPage({ session }: CartPageProps) {
   const cart = useCart();
   const [error, setError] = useState<string | null>(null);
   const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const [pruneNotice, setPruneNotice] = useState<string | null>(null);
+
+  // Stored cart lines can go stale when an admin renames a variation,
+  // removes a value, or unpublishes a product. Reconcile against the
+  // current public catalog the first time the cart is opened with items
+  // present, then leave the cart alone for the rest of the session.
+  const hasReconciledRef = useRef(false);
+  useEffect(() => {
+    if (hasReconciledRef.current) return;
+    if (cart.lines.length === 0) return;
+    hasReconciledRef.current = true;
+    let cancelled = false;
+    listPublicProducts()
+      .then((products) => {
+        if (cancelled) return;
+        const productById = new Map(products.map((product) => [product.id, product]));
+        const removedNames: string[] = [];
+        for (const line of cart.lines) {
+          const product = productById.get(line.productId);
+          if (!product || !isCartLineValidForProduct(line, product)) {
+            removedNames.push(line.name);
+            cart.remove(line.lineId);
+          }
+        }
+        if (removedNames.length > 0) {
+          const list = removedNames.join(', ');
+          setPruneNotice(
+            `We removed ${list} from your cart because the available options changed. Please reselect.`
+          );
+        }
+      })
+      .catch(() => {
+        // Network failures shouldn't block the cart UI; checkout will
+        // surface a clearer error if the items really are unavailable.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cart]);
 
   const startCheckout = async () => {
     if (cart.lines.length === 0) return;
@@ -54,6 +93,7 @@ export function CartPage({ session }: CartPageProps) {
     return (
       <section className="store-section">
         <Link className="store-back-link" to="/">Back to store</Link>
+        {pruneNotice ? <FormFeedback tone="info">{pruneNotice}</FormFeedback> : null}
         <Card className="store-cart-empty">
           <div className="store-cart-empty__icon" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none">
@@ -87,6 +127,7 @@ export function CartPage({ session }: CartPageProps) {
         body={`${itemCount} ${itemCount === 1 ? 'item' : 'items'} ready for checkout.`}
       />
 
+      {pruneNotice ? <FormFeedback tone="info">{pruneNotice}</FormFeedback> : null}
       {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
 
       <div className="store-cart-layout">

--- a/apps/store/src/pages/OrderCompletePage.tsx
+++ b/apps/store/src/pages/OrderCompletePage.tsx
@@ -132,6 +132,11 @@ export function OrderCompletePage() {
             <li key={item.id}>
               <span>
                 {item.quantity} × {item.productName}
+                {item.selectedVariations
+                  ? ` (${Object.entries(item.selectedVariations)
+                      .map(([name, value]) => `${name}: ${value}`)
+                      .join(', ')})`
+                  : ''}
               </span>
               <span>{formatMoney(item.totalCents, order.currency)}</span>
             </li>

--- a/apps/store/src/pages/OrdersPage.tsx
+++ b/apps/store/src/pages/OrdersPage.tsx
@@ -83,6 +83,11 @@ export function OrdersPage({ session }: OrdersPageProps) {
                 <li key={item.id}>
                   <span>
                     {item.quantity} × {item.productName}
+                    {item.selectedVariations
+                      ? ` (${Object.entries(item.selectedVariations)
+                          .map(([name, value]) => `${name}: ${value}`)
+                          .join(', ')})`
+                      : ''}
                   </span>
                   <span>{formatMoney(item.totalCents, order.currency)}</span>
                 </li>

--- a/apps/store/src/pages/ProductPage.tsx
+++ b/apps/store/src/pages/ProductPage.tsx
@@ -25,6 +25,8 @@ export function ProductPage() {
   const [error, setError] = useState<string | null>(null);
   const [quantity, setQuantity] = useState(1);
   const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+  const [selectedVariations, setSelectedVariations] = useState<Record<string, string>>({});
+  const [variationError, setVariationError] = useState<string | null>(null);
   const cart = useCart();
   const navigate = useNavigate();
 
@@ -32,6 +34,8 @@ export function ProductPage() {
     let active = true;
     setProduct(null);
     setError(null);
+    setSelectedVariations({});
+    setVariationError(null);
 
     getProductBySlug(slug)
       .then((next) => {
@@ -63,7 +67,19 @@ export function ProductPage() {
   }
 
   const onAdd = () => {
-    cart.add(product, quantity);
+    const missing = product.variations
+      .filter((variation) => !selectedVariations[variation.name])
+      .map((variation) => variation.name);
+    if (missing.length > 0) {
+      setVariationError(`Please choose a ${missing.join(' and ')}.`);
+      return;
+    }
+    setVariationError(null);
+    cart.add(
+      product,
+      quantity,
+      product.variations.length > 0 ? { ...selectedVariations } : null
+    );
     navigate('/cart');
   };
   const productImages = product.images.filter((image) => image.url);
@@ -129,6 +145,42 @@ export function ProductPage() {
             <p className="store-product-detail__impact">
               <strong>Your impact:</strong> {product.impact_summary}
             </p>
+          ) : null}
+
+          {product.variations.length > 0 ? (
+            <div className="store-variations">
+              {product.variations.map((variation) => (
+                <div key={variation.name} className="store-variations__group">
+                  <span className="store-variations__label">{variation.name}</span>
+                  <div className="store-variations__options" role="radiogroup" aria-label={variation.name}>
+                    {variation.values.map((value) => {
+                      const isSelected = selectedVariations[variation.name] === value;
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          role="radio"
+                          aria-checked={isSelected}
+                          className={`store-variations__option${isSelected ? ' is-selected' : ''}`}
+                          onClick={() => {
+                            setSelectedVariations((current) => ({
+                              ...current,
+                              [variation.name]: value,
+                            }));
+                            setVariationError(null);
+                          }}
+                        >
+                          {value}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+              {variationError ? (
+                <FormFeedback tone="error">{variationError}</FormFeedback>
+              ) : null}
+            </div>
           ) : null}
 
           <div className="store-quantity">

--- a/apps/store/src/pages/ProductPage.tsx
+++ b/apps/store/src/pages/ProductPage.tsx
@@ -82,8 +82,20 @@ export function ProductPage() {
     );
     navigate('/cart');
   };
-  const productImages = product.images.filter((image) => image.url);
-  const selectedImage = productImages.find((image) => image.id === selectedImageId) ?? productImages[0] ?? null;
+  // An image stays visible as long as none of its variation tags conflict
+  // with what the shopper has chosen so far. Untagged values act as
+  // wildcards, so an image tagged Color: Red shows before any color is
+  // picked and disappears once the shopper picks Blue.
+  const visibleImages = product.images.filter((image) => {
+    if (!image.url) return false;
+    const tags = image.variation_match ?? {};
+    return Object.entries(tags).every(([name, value]) => {
+      const chosen = selectedVariations[name];
+      return chosen === undefined || chosen === value;
+    });
+  });
+  const selectedImage =
+    visibleImages.find((image) => image.id === selectedImageId) ?? visibleImages[0] ?? null;
   const primaryImage = selectedImage?.url ?? product.image_url;
 
   return (
@@ -105,9 +117,9 @@ export function ProductPage() {
                 src={primaryImage}
                 alt={selectedImage?.alt_text || product.name}
               />
-              {productImages.length > 1 ? (
+              {visibleImages.length > 1 ? (
                 <div className="store-product-detail__thumbs" aria-label="Product images">
-                  {productImages.map((image) => (
+                  {visibleImages.map((image) => (
                     <button
                       key={image.id}
                       type="button"

--- a/apps/store/src/shell/AppShell.tsx
+++ b/apps/store/src/shell/AppShell.tsx
@@ -14,6 +14,9 @@ const foundationHomeUrl = import.meta.env.VITE_FOUNDATION_URL
 const grnUrl = (import.meta.env.VITE_GRN_URL as string | undefined)?.replace(/\/+$/, '')
   ?? 'https://grn.oliviasgarden.org';
 
+const adminUrl = (import.meta.env.VITE_ADMIN_URL as string | undefined)?.replace(/\/+$/, '')
+  ?? 'https://admin.oliviasgarden.org';
+
 const instagramUrl = 'https://instagram.com/oliviasgardentx';
 const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
 
@@ -74,6 +77,35 @@ export function AppShell({ session, onSignIn, children }: AppShellProps) {
     window.location.assign(`${foundationHomeUrl}/login`);
   };
 
+  // Mobile-only nav items so signed-in shoppers can reach orders, the
+  // admin app, and sign-out from the hamburger drawer. The desktop
+  // utility area shows the AvatarMenu instead, which hides these on
+  // wider screens via the SiteHeader's `mobileOnly` rule.
+  const navItems = [
+    ...foundationHeaderNav,
+    ...(session
+      ? [
+          { id: 'mobile-orders', label: 'My orders', href: '/orders', mobileOnly: true },
+          ...(session.isAdmin
+            ? [{ id: 'mobile-admin', label: 'Admin', href: adminUrl, mobileOnly: true }]
+            : []),
+          {
+            id: 'mobile-logout',
+            label: 'Sign out',
+            mobileOnly: true,
+            onSelect: handleLogout,
+          },
+        ]
+      : [
+          {
+            id: 'mobile-signin',
+            label: 'Sign in',
+            mobileOnly: true,
+            onSelect: onSignIn,
+          },
+        ]),
+  ];
+
   return (
     <div className="og-app-shell store-app-shell">
       <SiteHeader
@@ -82,7 +114,7 @@ export function AppShell({ session, onSignIn, children }: AppShellProps) {
         brandEyebrow="Olivia's Garden Foundation"
         brandTitle="Merch Store"
         brandHref="/"
-        navItems={foundationHeaderNav}
+        navItems={navItems}
         utility={(
           <div className="og-auth-utility store-utility">
             <CartIndicator />
@@ -94,6 +126,9 @@ export function AppShell({ session, onSignIn, children }: AppShellProps) {
                   { id: 'orders', label: 'My orders', href: '/orders' },
                   { id: 'foundation', label: 'Foundation home', href: foundationHomeUrl },
                   { id: 'grn', label: 'Good Roots Network', href: grnUrl },
+                  ...(session.isAdmin
+                    ? [{ id: 'admin', label: 'Admin', href: adminUrl }]
+                    : []),
                 ]}
                 onLogout={handleLogout}
               />

--- a/apps/store/src/styles.css
+++ b/apps/store/src/styles.css
@@ -437,6 +437,58 @@ body {
   font-size: 0.95rem;
 }
 
+.store-variations {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.store-variations__group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.store-variations__label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--og-color-soil);
+}
+
+.store-variations__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.store-variations__option {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.22);
+  background: #fff;
+  color: var(--og-color-soil);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.store-variations__option:hover {
+  border-color: rgba(79, 56, 37, 0.5);
+}
+
+.store-variations__option.is-selected {
+  background: var(--og-color-moss, #6b8b5b);
+  border-color: var(--og-color-moss, #6b8b5b);
+  color: #fff;
+}
+
+.store-cart__line-variations {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.7);
+}
+
 .store-quantity {
   display: flex;
   align-items: center;

--- a/apps/store/src/vite-env.d.ts
+++ b/apps/store/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_STORE_API_URL: string;
   readonly VITE_FOUNDATION_URL?: string;
   readonly VITE_GRN_URL?: string;
+  readonly VITE_ADMIN_URL?: string;
 }
 
 interface ImportMeta {

--- a/services/admin-api/db/migrations/0029_store_products_variations.sql
+++ b/services/admin-api/db/migrations/0029_store_products_variations.sql
@@ -1,0 +1,6 @@
+alter table store_products
+  add column if not exists variations jsonb not null default '[]'::jsonb;
+
+alter table store_products
+  add constraint store_products_variations_is_array
+  check (jsonb_typeof(variations) = 'array');

--- a/services/admin-api/db/migrations/0030_store_product_images_variation_match.sql
+++ b/services/admin-api/db/migrations/0030_store_product_images_variation_match.sql
@@ -1,0 +1,6 @@
+alter table store_product_images
+  add column if not exists variation_match jsonb not null default '{}'::jsonb;
+
+alter table store_product_images
+  add constraint store_product_images_variation_match_is_object
+  check (jsonb_typeof(variation_match) = 'object');

--- a/services/admin-api/src/services/store-images.mjs
+++ b/services/admin-api/src/services/store-images.mjs
@@ -73,9 +73,50 @@ export function normalizeProductImageInputs(images) {
     return {
       id: image.id,
       sort_order: Number.isInteger(image.sort_order) ? image.sort_order : index,
-      alt_text: image.alt_text ?? null
+      alt_text: image.alt_text ?? null,
+      variation_match: normalizeVariationMatch(image.variation_match)
     };
   });
+}
+
+function normalizeVariationMatch(value) {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('image variation_match must be an object');
+  }
+  const normalized = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 60) {
+      throw new Error('image variation_match keys must be 1–60 character strings');
+    }
+    if (typeof raw !== 'string' || raw.length === 0 || raw.length > 100) {
+      throw new Error('image variation_match values must be 1–100 character strings');
+    }
+    normalized[key] = raw;
+  }
+  return normalized;
+}
+
+// Cross-checks each image's variation_match against the product's defined
+// variations so we never persist tags pointing at options that don't exist.
+// Called from create/update after both the variations and image inputs have
+// been validated in isolation.
+export function assertImageVariationMatchesAreValid(imageInputs, variations = []) {
+  const allowed = new Map(
+    (variations ?? []).map((variation) => [variation.name, new Set(variation.values)])
+  );
+  for (const image of imageInputs) {
+    const match = image.variation_match ?? {};
+    for (const [name, value] of Object.entries(match)) {
+      const values = allowed.get(name);
+      if (!values) {
+        throw new Error(`image references variation "${name}" that is not defined on the product`);
+      }
+      if (!values.has(value)) {
+        throw new Error(`image references "${value}" which is not a value of "${name}"`);
+      }
+    }
+  }
 }
 
 function mapImageRow(row) {
@@ -92,6 +133,7 @@ function mapImageRow(row) {
     byte_size: row.byte_size === null || row.byte_size === undefined ? null : Number(row.byte_size),
     sort_order: row.sort_order,
     alt_text: row.alt_text,
+    variation_match: row.variation_match ?? {},
     processing_error: row.processing_error,
     created_at: row.created_at?.toISOString?.() ?? row.created_at,
     updated_at: row.updated_at?.toISOString?.() ?? row.updated_at
@@ -194,6 +236,7 @@ export async function associateProductImages(productId, imageInputs, db = { quer
            set product_id = $2::uuid,
                sort_order = $3,
                alt_text = $4,
+               variation_match = $5::jsonb,
                deleted_at = null,
                expires_at = null,
                updated_at = now()
@@ -201,7 +244,13 @@ export async function associateProductImages(productId, imageInputs, db = { quer
            and (product_id is null or product_id = $2::uuid)
          returning id
       `,
-      [image.id, productId, image.sort_order, image.alt_text]
+      [
+        image.id,
+        productId,
+        image.sort_order,
+        image.alt_text,
+        JSON.stringify(image.variation_match ?? {})
+      ]
     );
 
     if (result.rowCount === 0) {
@@ -260,7 +309,8 @@ export async function listProductImages(productIds) {
     `
       select id::text as id, product_id::text as product_id, status,
              normalized_s3_key, thumbnail_s3_key, width, height, byte_size,
-             sort_order, alt_text, processing_error, created_at, updated_at
+             sort_order, alt_text, variation_match, processing_error,
+             created_at, updated_at
         from store_product_images
        where product_id = any($1::uuid[])
        order by product_id, sort_order asc, created_at asc

--- a/services/admin-api/src/services/store.mjs
+++ b/services/admin-api/src/services/store.mjs
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { extractAuthContext, requireAdmin } from './auth.mjs';
 import { query, withTransaction } from './db.mjs';
 import {
+  assertImageVariationMatchesAreValid,
   associateProductImages,
   getReadyProductImageUrls,
   listProductImages,
@@ -321,6 +322,7 @@ export async function createStoreProduct(event, payload, options = {}) {
   requireAdmin(auth);
   validatePayload(payload);
   const imageInputs = normalizeProductImageInputs(payload.images);
+  assertImageVariationMatchesAreValid(imageInputs, payload.variations ?? []);
   const idempotentWrite = await beginIdempotentWrite('create', event, payload, auth);
   if (idempotentWrite?.replay) return idempotentWrite.product;
 
@@ -409,6 +411,7 @@ export async function updateStoreProduct(event, payload, productId, options = {}
 
   validatePayload(payload);
   const imageInputs = normalizeProductImageInputs(payload.images);
+  assertImageVariationMatchesAreValid(imageInputs, payload.variations ?? []);
   const idempotentWrite = await beginIdempotentWrite('update', event, { productId, ...payload }, auth);
   if (idempotentWrite?.replay) return idempotentWrite.product;
 

--- a/services/admin-api/src/services/store.mjs
+++ b/services/admin-api/src/services/store.mjs
@@ -19,9 +19,14 @@ const PRODUCT_SELECT_COLUMNS = `
   kind::text as kind, fulfillment_type::text as fulfillment_type,
   is_public, is_featured, currency, unit_amount_cents,
   statement_descriptor, nonprofit_program, impact_summary,
-  image_url, metadata, stripe_product_id, stripe_price_id,
+  image_url, metadata, variations, stripe_product_id, stripe_price_id,
   created_at, updated_at
 `;
+
+const MAX_VARIATIONS = 5;
+const MAX_VARIATION_VALUES = 50;
+const MAX_VARIATION_NAME_LENGTH = 40;
+const MAX_VARIATION_VALUE_LENGTH = 60;
 
 function getHeader(event, name) {
   const headers = event?.headers ?? {};
@@ -167,6 +172,69 @@ export function validatePayload(payload) {
   if (!isPlainObject(payload.metadata ?? {})) {
     throw new Error('metadata must be a JSON object');
   }
+
+  if (payload.variations !== undefined && payload.variations !== null) {
+    validateVariations(payload.variations);
+  }
+}
+
+function validateVariations(variations) {
+  if (!Array.isArray(variations)) {
+    throw new Error('variations must be an array');
+  }
+  if (variations.length > MAX_VARIATIONS) {
+    throw new Error(`variations may have at most ${MAX_VARIATIONS} options`);
+  }
+  const seenNames = new Set();
+  for (const variation of variations) {
+    if (!isPlainObject(variation)) {
+      throw new Error('each variation must be an object');
+    }
+    const name = typeof variation.name === 'string' ? variation.name.trim() : '';
+    if (name.length === 0) {
+      throw new Error('variation name is required');
+    }
+    if (name.length > MAX_VARIATION_NAME_LENGTH) {
+      throw new Error(`variation name must be ${MAX_VARIATION_NAME_LENGTH} characters or fewer`);
+    }
+    const lower = name.toLowerCase();
+    if (seenNames.has(lower)) {
+      throw new Error('variation names must be unique');
+    }
+    seenNames.add(lower);
+    if (!Array.isArray(variation.values) || variation.values.length === 0) {
+      throw new Error(`variation "${name}" must have at least one value`);
+    }
+    if (variation.values.length > MAX_VARIATION_VALUES) {
+      throw new Error(`variation "${name}" may have at most ${MAX_VARIATION_VALUES} values`);
+    }
+    const seenValues = new Set();
+    for (const value of variation.values) {
+      if (typeof value !== 'string') {
+        throw new Error(`variation "${name}" values must be strings`);
+      }
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        throw new Error(`variation "${name}" values must not be empty`);
+      }
+      if (trimmed.length > MAX_VARIATION_VALUE_LENGTH) {
+        throw new Error(`variation "${name}" values must be ${MAX_VARIATION_VALUE_LENGTH} characters or fewer`);
+      }
+      const lowerValue = trimmed.toLowerCase();
+      if (seenValues.has(lowerValue)) {
+        throw new Error(`variation "${name}" values must be unique`);
+      }
+      seenValues.add(lowerValue);
+    }
+  }
+}
+
+function normalizeVariations(variations) {
+  if (!Array.isArray(variations)) return [];
+  return variations.map((variation) => ({
+    name: variation.name.trim(),
+    values: variation.values.map((value) => value.trim())
+  }));
 }
 
 function isSlug(value) {
@@ -206,6 +274,7 @@ function mapStoreProduct(row, images = []) {
     image_urls: row.image_url ? [row.image_url, ...readyImageUrls] : readyImageUrls,
     images,
     metadata: row.metadata ?? {},
+    variations: Array.isArray(row.variations) ? row.variations : [],
     stripe_product_id: row.stripe_product_id,
     stripe_price_id: row.stripe_price_id,
     created_at: row.created_at?.toISOString?.() ?? row.created_at,
@@ -270,12 +339,13 @@ export async function createStoreProduct(event, payload, options = {}) {
           insert into store_products (
             slug, name, short_description, description, status, kind, fulfillment_type,
             is_public, is_featured, currency, unit_amount_cents, statement_descriptor,
-            nonprofit_program, impact_summary, image_url, metadata,
+            nonprofit_program, impact_summary, image_url, metadata, variations,
             stripe_product_id, stripe_price_id
           )
           values (
             $1, $2, $3, $4, $5::store_product_status, $6::store_product_kind,
-            $7::store_fulfillment_type, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
+            $7::store_fulfillment_type, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+            $17::jsonb, $18, $19
           )
           returning ${PRODUCT_SELECT_COLUMNS}
         `,
@@ -296,6 +366,7 @@ export async function createStoreProduct(event, payload, options = {}) {
           payload.impact_summary ?? null,
           payload.image_url ?? null,
           payload.metadata ?? {},
+          JSON.stringify(normalizeVariations(payload.variations)),
           stripeProductId,
           stripePriceId
         ]
@@ -389,7 +460,8 @@ export async function updateStoreProduct(event, payload, productId, options = {}
                  impact_summary = $15,
                  image_url = $16,
                  metadata = $17,
-                 stripe_price_id = $18,
+                 variations = $18::jsonb,
+                 stripe_price_id = $19,
                  updated_at = now()
            where id = $1
            returning ${PRODUCT_SELECT_COLUMNS}
@@ -412,6 +484,7 @@ export async function updateStoreProduct(event, payload, productId, options = {}
           payload.impact_summary ?? null,
           payload.image_url ?? null,
           payload.metadata ?? {},
+          JSON.stringify(normalizeVariations(payload.variations)),
           stripePriceId
         ]
       );

--- a/services/admin-api/test/run-tests.mjs
+++ b/services/admin-api/test/run-tests.mjs
@@ -102,6 +102,42 @@ async function testStoreHelpers() {
     /metadata must be a JSON object/
   );
 
+  // variations is optional but, if provided, must be a well-formed array
+  // of { name, values: string[] }. Empty value lists and duplicate names
+  // are rejected up-front so we never persist garbage.
+  assert.doesNotThrow(() =>
+    validatePayload({
+      ...payload,
+      variations: [
+        { name: 'Color', values: ['Red', 'Blue'] },
+        { name: 'Ink', values: ['Black'] }
+      ]
+    })
+  );
+  assert.throws(
+    () => validatePayload({ ...payload, variations: 'nope' }),
+    /variations must be an array/
+  );
+  assert.throws(
+    () => validatePayload({ ...payload, variations: [{ name: '', values: ['Red'] }] }),
+    /variation name is required/
+  );
+  assert.throws(
+    () => validatePayload({ ...payload, variations: [{ name: 'Color', values: [] }] }),
+    /at least one value/
+  );
+  assert.throws(
+    () =>
+      validatePayload({
+        ...payload,
+        variations: [
+          { name: 'Color', values: ['Red'] },
+          { name: 'color', values: ['Blue'] }
+        ]
+      }),
+    /variation names must be unique/
+  );
+
   const requests = [];
   const stripe = new StripeStoreClient('sk_test_123', async (_url, init) => {
     requests.push(init);

--- a/services/admin-api/test/run-tests.mjs
+++ b/services/admin-api/test/run-tests.mjs
@@ -4,6 +4,7 @@ import { extractAuthContext, requireAdmin } from '../src/services/auth.mjs';
 import { mapApiError, normalizeRoutePath } from '../src/services/http.mjs';
 import { StripeStoreClient, validatePayload } from '../src/services/store.mjs';
 import {
+  assertImageVariationMatchesAreValid,
   completeStoreProductImageUpload,
   createStoreProductImageUploadIntent,
   normalizeProductImageInputs
@@ -180,7 +181,65 @@ async function testStoreImageHelpers() {
 
   assert.deepEqual(
     normalizeProductImageInputs([{ id: '00000000-0000-4000-8000-000000000001', alt_text: 'Okra seeds' }]),
-    [{ id: '00000000-0000-4000-8000-000000000001', sort_order: 0, alt_text: 'Okra seeds' }]
+    [
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        sort_order: 0,
+        alt_text: 'Okra seeds',
+        variation_match: {}
+      }
+    ]
+  );
+
+  // variation_match passes through when valid and is rejected up-front when
+  // it isn't an object of strings.
+  assert.deepEqual(
+    normalizeProductImageInputs([
+      {
+        id: '00000000-0000-4000-8000-000000000002',
+        variation_match: { Color: 'Red' }
+      }
+    ]),
+    [
+      {
+        id: '00000000-0000-4000-8000-000000000002',
+        sort_order: 0,
+        alt_text: null,
+        variation_match: { Color: 'Red' }
+      }
+    ]
+  );
+  assert.throws(
+    () =>
+      normalizeProductImageInputs([
+        { id: '00000000-0000-4000-8000-000000000003', variation_match: { Color: 123 } }
+      ]),
+    /variation_match values must be 1–100 character strings/
+  );
+
+  // Cross-validation against a product's variations rejects tags that
+  // reference an option or value that doesn't exist.
+  const tagged = normalizeProductImageInputs([
+    { id: '00000000-0000-4000-8000-000000000004', variation_match: { Color: 'Red' } }
+  ]);
+  assert.doesNotThrow(() =>
+    assertImageVariationMatchesAreValid(tagged, [
+      { name: 'Color', values: ['Red', 'Blue'] }
+    ])
+  );
+  assert.throws(
+    () =>
+      assertImageVariationMatchesAreValid(tagged, [
+        { name: 'Color', values: ['Blue'] }
+      ]),
+    /not a value of "Color"/
+  );
+  assert.throws(
+    () =>
+      assertImageVariationMatchesAreValid(tagged, [
+        { name: 'Ink', values: ['Black'] }
+      ]),
+    /variation "Color" that is not defined/
   );
 
   const queries = [];

--- a/services/store-api/db/migrations/0002_store_order_items_variations.sql
+++ b/services/store-api/db/migrations/0002_store_order_items_variations.sql
@@ -1,0 +1,6 @@
+alter table store_order_items
+  add column if not exists selected_variations jsonb;
+
+alter table store_order_items
+  add constraint store_order_items_selected_variations_is_object
+  check (selected_variations is null or jsonb_typeof(selected_variations) = 'object');

--- a/services/store-api/src/services/orders.mjs
+++ b/services/store-api/src/services/orders.mjs
@@ -22,8 +22,78 @@ const ORDER_SELECT_COLUMNS = `
 
 const ORDER_ITEM_SELECT_COLUMNS = `
   i.id, i.order_id, i.product_id, i.product_slug, i.product_name, i.product_kind,
-  i.quantity, i.unit_amount_cents, i.total_cents, i.stripe_price_id
+  i.quantity, i.unit_amount_cents, i.total_cents, i.stripe_price_id,
+  i.selected_variations
 `;
+
+function resolveSelectedVariations(product, selected) {
+  const definedVariations = Array.isArray(product.variations) ? product.variations : [];
+  const hasSelection = selected && typeof selected === 'object' && Object.keys(selected).length > 0;
+
+  if (definedVariations.length === 0) {
+    if (hasSelection) {
+      throw new Error(`Product ${product.name} does not accept variations.`);
+    }
+    return null;
+  }
+
+  if (!hasSelection) {
+    throw new Error(`Please choose ${definedVariations.map((v) => v.name).join(' and ')} for ${product.name}.`);
+  }
+
+  const resolved = {};
+  for (const variation of definedVariations) {
+    const chosen = selected[variation.name];
+    if (typeof chosen !== 'string' || chosen.trim().length === 0) {
+      throw new Error(`Please choose a ${variation.name} for ${product.name}.`);
+    }
+    const match = variation.values.find(
+      (value) => value.toLowerCase() === chosen.trim().toLowerCase()
+    );
+    if (!match) {
+      throw new Error(`"${chosen}" is not a valid ${variation.name} for ${product.name}.`);
+    }
+    resolved[variation.name] = match;
+  }
+  return resolved;
+}
+
+// Stripe Checkout doesn't support per-line metadata when referencing an
+// existing Price, so we encode the cart's variation selections into session
+// metadata. Keys are namespaced as og_var_<index> with values "<productId>|<json>"
+// to keep within Stripe's 500-char-per-value / 50-key limits while preserving
+// per-line ordering. recordPaidOrder() reads these back when persisting items.
+function buildVariationMetadata(lineItems) {
+  const metadata = {};
+  lineItems.forEach((line, index) => {
+    if (!line.selectedVariations) return;
+    metadata[`og_var_${index}`] = `${line.product.id}|${JSON.stringify(line.selectedVariations)}`;
+  });
+  return metadata;
+}
+
+function parseVariationMetadata(sessionMetadata) {
+  // Returns a list aligned to the cart's original order: [{ productId, variations }].
+  // Falls back to empty when no variation keys are present.
+  if (!sessionMetadata) return [];
+  const entries = [];
+  for (const [key, value] of Object.entries(sessionMetadata)) {
+    const match = /^og_var_(\d+)$/.exec(key);
+    if (!match || typeof value !== 'string') continue;
+    const sep = value.indexOf('|');
+    if (sep < 0) continue;
+    const productId = value.slice(0, sep);
+    try {
+      const variations = JSON.parse(value.slice(sep + 1));
+      if (variations && typeof variations === 'object' && !Array.isArray(variations)) {
+        entries.push({ index: Number(match[1]), productId, variations });
+      }
+    } catch {
+      // Bad metadata — skip rather than failing the order recording.
+    }
+  }
+  return entries.sort((a, b) => a.index - b.index);
+}
 
 function mapOrder(orderRow, items) {
   return {
@@ -52,7 +122,8 @@ function mapOrder(orderRow, items) {
       quantity: item.quantity,
       unitAmountCents: item.unit_amount_cents,
       totalCents: item.total_cents,
-      stripePriceId: item.stripe_price_id
+      stripePriceId: item.stripe_price_id,
+      selectedVariations: item.selected_variations ?? null
     })),
     createdAt: orderRow.created_at?.toISOString?.() ?? orderRow.created_at,
     updatedAt: orderRow.updated_at?.toISOString?.() ?? orderRow.updated_at,
@@ -146,6 +217,22 @@ function validateCheckoutPayload(payload, options = {}) {
     if (!Number.isInteger(item.quantity) || item.quantity < 1 || item.quantity > 999) {
       throw new Error('Quantity must be an integer between 1 and 999');
     }
+    if (item.selectedVariations !== undefined && item.selectedVariations !== null) {
+      if (
+        typeof item.selectedVariations !== 'object'
+        || Array.isArray(item.selectedVariations)
+      ) {
+        throw new Error('Validation: selectedVariations must be an object');
+      }
+      for (const [key, value] of Object.entries(item.selectedVariations)) {
+        if (typeof key !== 'string' || key.length === 0 || key.length > 60) {
+          throw new Error('Validation: variation name is invalid');
+        }
+        if (typeof value !== 'string' || value.length === 0 || value.length > 100) {
+          throw new Error('Validation: variation value is invalid');
+        }
+      }
+    }
   }
 
   const allowedOrigins = [...(options.allowedRedirectOrigins ?? getAllowedRedirectOrigins())];
@@ -182,7 +269,8 @@ export async function createCheckoutSession(event, payload, options = {}) {
     if (product.status !== 'active' || !product.is_public) {
       throw new Error(`Product ${product.name} is no longer available.`);
     }
-    return { product, quantity: item.quantity };
+    const selectedVariations = resolveSelectedVariations(product, item.selectedVariations);
+    return { product, quantity: item.quantity, selectedVariations };
   });
 
   const currencies = new Set(lineItems.map((line) => line.product.currency.toLowerCase()));
@@ -201,6 +289,8 @@ export async function createCheckoutSession(event, payload, options = {}) {
       ? payload.customer_email.trim()
       : auth.email ?? undefined;
 
+  const variationMetadata = buildVariationMetadata(lineItems);
+
   const session = await stripe.createCheckoutSession({
     items: lineItems.map((line) => ({
       priceId: line.product.stripe_price_id,
@@ -213,7 +303,8 @@ export async function createCheckoutSession(event, payload, options = {}) {
     metadata: {
       og_kind: 'store',
       og_user_id: auth.userId ?? '',
-      og_product_ids: lineItems.map((line) => line.product.id).join(',')
+      og_product_ids: lineItems.map((line) => line.product.id).join(','),
+      ...variationMetadata
     }
   });
 
@@ -297,6 +388,10 @@ export async function recordPaidOrder(stripeSession, options = {}) {
   const shippingAddress = extractShippingAddress(stripeSession);
 
   const lineItems = stripeSession.line_items?.data ?? [];
+  const variationEntries = parseVariationMetadata(stripeSession.metadata);
+  // Track which entries we've consumed so two cart lines for the same product
+  // (different variations) each get their own selection rather than colliding.
+  const consumedVariationIndexes = new Set();
 
   return db.withTransaction(async (client) => {
     const existing = await client.query(
@@ -355,12 +450,25 @@ export async function recordPaidOrder(stripeSession, options = {}) {
       const unitAmountCents = line.price?.unit_amount ?? Math.round((line.amount_total ?? 0) / quantity);
       const totalLineCents = line.amount_total ?? unitAmountCents * quantity;
 
+      let selectedVariations = null;
+      if (product?.id) {
+        const matchIndex = variationEntries.findIndex(
+          (entry) => entry.productId === product.id && !consumedVariationIndexes.has(entry.index)
+        );
+        if (matchIndex >= 0) {
+          const entry = variationEntries[matchIndex];
+          consumedVariationIndexes.add(entry.index);
+          selectedVariations = entry.variations;
+        }
+      }
+
       await client.query(
         `insert into store_order_items (
            order_id, product_id, product_slug, product_name, product_kind,
-           quantity, unit_amount_cents, total_cents, stripe_price_id
+           quantity, unit_amount_cents, total_cents, stripe_price_id,
+           selected_variations
          )
-         values ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+         values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)`,
         [
           orderId,
           product?.id ?? null,
@@ -370,7 +478,8 @@ export async function recordPaidOrder(stripeSession, options = {}) {
           quantity,
           unitAmountCents,
           totalLineCents,
-          stripePriceId
+          stripePriceId,
+          selectedVariations ? JSON.stringify(selectedVariations) : null
         ]
       );
     }

--- a/services/store-api/src/services/products.mjs
+++ b/services/store-api/src/services/products.mjs
@@ -61,6 +61,7 @@ function mapImageRow(row) {
     byte_size: row.byte_size === null || row.byte_size === undefined ? null : Number(row.byte_size),
     sort_order: row.sort_order,
     alt_text: row.alt_text,
+    variation_match: row.variation_match ?? {},
     processing_error: null,
     created_at: row.created_at?.toISOString?.() ?? row.created_at,
     updated_at: row.updated_at?.toISOString?.() ?? row.updated_at
@@ -73,7 +74,7 @@ async function listProductImages(productIds) {
     `
       select id::text as id, product_id::text as product_id, status,
              normalized_s3_key, thumbnail_s3_key, width, height, byte_size,
-             sort_order, alt_text, created_at, updated_at
+             sort_order, alt_text, variation_match, created_at, updated_at
         from store_product_images
        where product_id = any($1::uuid[])
          and status = 'ready'

--- a/services/store-api/src/services/products.mjs
+++ b/services/store-api/src/services/products.mjs
@@ -5,7 +5,7 @@ const PRODUCT_SELECT_COLUMNS = `
   kind::text as kind, fulfillment_type::text as fulfillment_type,
   is_public, is_featured, currency, unit_amount_cents,
   statement_descriptor, nonprofit_program, impact_summary,
-  image_url, metadata, stripe_product_id, stripe_price_id,
+  image_url, metadata, variations, stripe_product_id, stripe_price_id,
   created_at, updated_at
 `;
 
@@ -34,6 +34,7 @@ export function mapProduct(row) {
     image_urls: row.image_url ? [row.image_url, ...readyImageUrls] : readyImageUrls,
     images,
     metadata: row.metadata ?? {},
+    variations: Array.isArray(row.variations) ? row.variations : [],
     stripe_product_id: row.stripe_product_id,
     stripe_price_id: row.stripe_price_id,
     created_at: row.created_at?.toISOString?.() ?? row.created_at,

--- a/services/store-api/test/run-tests.mjs
+++ b/services/store-api/test/run-tests.mjs
@@ -584,6 +584,64 @@ async function testCheckoutRejectsNonHttpScheme() {
   );
 }
 
+async function testRecordPaidOrderCapturesVariations() {
+  // Two cart lines for the same product but different variations should
+  // each get their own selection captured on the order item.
+  const fake = makeFakeDb({
+    productLookup: {
+      price_shirt: {
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        slug: 'tee',
+        name: 'Tee',
+        kind: 'merchandise'
+      },
+      __userByEmail: { 'alice@example.com': 'user-alice' }
+    }
+  });
+
+  const session = {
+    ...sampleStripeSession,
+    metadata: {
+      og_kind: 'store',
+      og_var_0: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb|{"Color":"Red","Ink":"Black"}',
+      og_var_1: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb|{"Color":"Blue","Ink":"White"}'
+    },
+    line_items: {
+      data: [
+        { price: { id: 'price_shirt', unit_amount: 2500 }, quantity: 1, amount_total: 2500 },
+        { price: { id: 'price_shirt', unit_amount: 2500 }, quantity: 1, amount_total: 2500 }
+      ]
+    }
+  };
+
+  await recordPaidOrder(session, { db: fake.db });
+  assert.equal(fake.calls.inserts.items.length, 2);
+  const firstSelection = JSON.parse(fake.calls.inserts.items[0][9]);
+  const secondSelection = JSON.parse(fake.calls.inserts.items[1][9]);
+  assert.deepEqual(firstSelection, { Color: 'Red', Ink: 'Black' });
+  assert.deepEqual(secondSelection, { Color: 'Blue', Ink: 'White' });
+}
+
+async function testRecordPaidOrderHandlesMissingVariationMetadata() {
+  // Backwards-compat: existing sessions without og_var_* keys still record
+  // cleanly, with selected_variations stored as null.
+  const fake = makeFakeDb({
+    productLookup: {
+      price_seed: {
+        id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        slug: 'okra-seed-pack',
+        name: 'Okra Seed Pack',
+        kind: 'merchandise'
+      },
+      __userByEmail: { 'alice@example.com': 'user-alice' }
+    }
+  });
+
+  await recordPaidOrder(sampleStripeSession, { db: fake.db });
+  const itemParams = fake.calls.inserts.items[0];
+  assert.equal(itemParams[9], null);
+}
+
 await testResolveOptionalAuthContextAnonymous();
 await testResolveOptionalAuthContextUser();
 await testResolveOptionalAuthContextAdmin();
@@ -615,4 +673,6 @@ await testCheckoutRejectsAttackerControlledSuccessUrl();
 await testCheckoutRejectsAttackerControlledCancelUrl();
 await testCheckoutRejectsMalformedRedirectUrl();
 await testCheckoutRejectsNonHttpScheme();
+await testRecordPaidOrderCapturesVariations();
+await testRecordPaidOrderHandlesMissingVariationMetadata();
 console.log('store api tests passed');


### PR DESCRIPTION
Lets admins define optional variation options like Color and Ink on
clothing/merch products and forces customers to pick a value before
adding to cart. Selections are passed to Stripe via session metadata
keyed per cart line, then captured back on order_items so fulfillment
sees exactly what was bought.

Stripe doesn't have a native variation concept, so we keep one Stripe
Price per product (variations don't change price for our use case) and
record the chosen options as line-scoped session metadata that
recordPaidOrder maps onto store_order_items.selected_variations.