### PR TITLE
Add foundation EIN disclosures

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1661,6 +1661,14 @@ html {
   font-size: clamp(1.7rem, 3vw, 2.2rem);
 }
 
+.donate-form-card__legal-note {
+  margin: 0;
+  color: var(--site-muted);
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
 .donate-form-card__cta-group {
   display: grid;
   gap: 0.65rem;
@@ -1682,6 +1690,14 @@ html {
 .donate-alternate__actions .site-cta,
 .donate-embedded-checkout__header .site-cta {
   min-height: 2.9rem;
+}
+
+.donate-alternate__actions .site-cta {
+  text-decoration: none;
+}
+
+.donate-alternate__actions .site-cta:hover {
+  text-decoration: none;
 }
 
 .donate-form-card__checkout-note {

--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -16,6 +16,7 @@ import {
   legalFooterRoutes,
   navRoutes,
 } from './routes';
+import { foundationOrganization } from './organization';
 
 export function buildCrossAppUrl(targetUrl: string, session: AuthSession) {
   try {
@@ -31,8 +32,6 @@ export function buildCrossAppUrl(targetUrl: string, session: AuthSession) {
     return targetUrl;
   }
 }
-
-const foundationLogo = '/images/icons/logo.svg';
 
 export function getUserInitials(session: AuthSession | null) {
   if (!session) {
@@ -97,9 +96,9 @@ export function SiteHeader({
 
   return (
     <SharedSiteHeader
-      brandLogoSrc={foundationLogo}
+      brandLogoSrc={foundationOrganization.logoImage}
       brandLogoAlt=""
-      brandEyebrow="Olivia's Garden Foundation"
+      brandEyebrow={foundationOrganization.name}
       brandTitle="Homesteading, growing, and community"
       brandHref="/"
       onBrandClick={() => onNavigate('/')}
@@ -172,20 +171,20 @@ export function SiteFooter({
 
   return (
     <SharedSiteFooter
-      meta={`${new Date().getFullYear()} Olivia's Garden Foundation. All rights reserved.`}
+      meta={`${foundationOrganization.name} is a 501(c)(3) nonprofit organization, EIN ${foundationOrganization.ein}. Donations are tax-deductible. ©2026 ${foundationOrganization.name}. All rights reserved.`}
       links={footerLinks}
       legalLinks={legalFooterLinks}
       socialLinks={[
         {
           id: 'instagram',
           href: instagramUrl,
-          label: "Follow Olivia's Garden Foundation on Instagram",
+          label: `Follow ${foundationOrganization.name} on Instagram`,
           icon: 'instagram',
         },
         {
           id: 'facebook',
           href: facebookUrl,
-          label: "Follow Olivia's Garden Foundation on Facebook",
+          label: `Follow ${foundationOrganization.name} on Facebook`,
           icon: 'facebook',
         },
       ]}

--- a/apps/web/src/site/organization.ts
+++ b/apps/web/src/site/organization.ts
@@ -1,0 +1,7 @@
+export const foundationOrganization = {
+  name: "Olivia's Garden Foundation",
+  legalName: "Olivia's Garden Foundation",
+  ein: '33-3101032',
+  contactEmail: 'allen@oliviasgarden.org',
+  logoImage: '/images/icons/logo.svg',
+} as const;

--- a/apps/web/src/site/pages/DonatePage.tsx
+++ b/apps/web/src/site/pages/DonatePage.tsx
@@ -3,6 +3,7 @@ import { loadStripe, type StripeEmbeddedCheckout } from '@stripe/stripe-js';
 import { Button, FormFeedback } from '@olivias/ui';
 import type { AuthSession } from '../../auth/session';
 import { CtaButton, PageHero } from '../chrome';
+import { foundationOrganization } from '../organization';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
 import { stripePublishableKey, webApiBase } from '../routes';
 
@@ -604,6 +605,9 @@ export function DonatePage({
                     <p className="donate-form-card__summary-eyebrow">Gift summary</p>
                     <p className="donate-form-card__summary">
                       {selectedMode === 'recurring' ? 'Garden Club' : 'One-time donation'}: ${(effectiveAmount / 100).toFixed(2)}
+                    </p>
+                    <p className="donate-form-card__legal-note">
+                      {foundationOrganization.legalName}, EIN {foundationOrganization.ein}
                     </p>
                     <p className="page-text">
                       {selectedMode === 'recurring'

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -11,10 +11,11 @@ import {
   Section,
   WorkIcon,
 } from '../chrome';
+import { foundationOrganization } from '../organization';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
 import { facebookUrl, goodRootsNetworkUrl, instagramUrl, webApiBase } from '../routes';
 
-const CONTACT_EMAIL = 'allen@oliviasgarden.org';
+const CONTACT_EMAIL = foundationOrganization.contactEmail;
 
 const OkraExperience = lazy(async () => {
   const module = await import('../../okra/OkraExperience');
@@ -1544,6 +1545,11 @@ export function ContactPage() {
             <a className="contact-meta__link" href={`mailto:${CONTACT_EMAIL}`}>
               {CONTACT_EMAIL}
             </a>
+          </p>
+          <p className="contact-meta">
+            Legal name: {foundationOrganization.legalName}
+            <br />
+            EIN: {foundationOrganization.ein}
           </p>
           <ul className="site-list contact-card__list">
             <li>

--- a/apps/web/src/site/seo.ts
+++ b/apps/web/src/site/seo.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
+import { foundationOrganization } from './organization';
 import type { AppRoute } from './routes';
 import { facebookUrl, instagramUrl, siteUrl, socialShareImage } from './routes';
 
 const socialShareImageAlt = "Olivia's Garden Foundation social sharing image.";
-const logoImage = '/images/icons/logo.svg';
 
 type GtagCommand = (
   command: 'event' | 'config' | 'js',
@@ -80,7 +80,7 @@ export function useRouteSeo(route: AppRoute, pathname: string) {
     ensureMeta('meta[name="description"]', { name: 'description' }, route.description);
     ensureMeta('meta[name="robots"]', { name: 'robots' }, robots);
     ensureMeta('meta[property="og:type"]', { property: 'og:type' }, 'website');
-    ensureMeta('meta[property="og:site_name"]', { property: 'og:site_name' }, "Olivia's Garden Foundation");
+    ensureMeta('meta[property="og:site_name"]', { property: 'og:site_name' }, foundationOrganization.name);
     ensureMeta('meta[property="og:title"]', { property: 'og:title' }, pageTitle);
     ensureMeta('meta[property="og:description"]', { property: 'og:description' }, route.description);
     ensureMeta('meta[property="og:url"]', { property: 'og:url' }, pageUrl);
@@ -96,9 +96,12 @@ export function useRouteSeo(route: AppRoute, pathname: string) {
     ensureStructuredData('organization', {
       '@context': 'https://schema.org',
       '@type': 'NonprofitOrganization',
-      name: "Olivia's Garden Foundation",
+      name: foundationOrganization.name,
+      legalName: foundationOrganization.legalName,
+      taxID: foundationOrganization.ein,
+      email: foundationOrganization.contactEmail,
       url: siteUrl,
-      logo: absoluteUrl(logoImage),
+      logo: absoluteUrl(foundationOrganization.logoImage),
       sameAs: [instagramUrl, facebookUrl],
     });
 
@@ -110,7 +113,7 @@ export function useRouteSeo(route: AppRoute, pathname: string) {
       url: pageUrl,
       isPartOf: {
         '@type': 'WebSite',
-        name: "Olivia's Garden Foundation",
+        name: foundationOrganization.name,
         url: siteUrl,
       },
     });

--- a/apps/web/tests/foundation-disclosures.spec.ts
+++ b/apps/web/tests/foundation-disclosures.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { gotoAndWait } from './test-helpers';
+
+const FOUNDATION_EIN = '33-3101032';
+
+test.describe('foundation disclosures', () => {
+  test('footer lists nonprofit status, EIN, and tax-deductible language', async ({ page }) => {
+    await gotoAndWait(page, '/');
+
+    const footer = page.locator('footer');
+    await expect(footer).toContainText(
+      `Olivia's Garden Foundation is a 501(c)(3) nonprofit organization, EIN ${FOUNDATION_EIN}.`,
+    );
+    await expect(footer).toContainText('Donations are tax-deductible.');
+    await expect(footer).toContainText("©2026 Olivia's Garden Foundation. All rights reserved.");
+  });
+
+  test('donate page surfaces the EIN near the gift action', async ({ page }) => {
+    await gotoAndWait(page, '/donate');
+
+    const donateForm = page.locator('.donate-form-card');
+    await expect(donateForm).toContainText(`Olivia's Garden Foundation, EIN ${FOUNDATION_EIN}`);
+    await expect(donateForm.getByRole('button', { name: 'Make donation' })).toBeVisible();
+  });
+
+  test('contact page lists the legal name and EIN with direct contact details', async ({ page }) => {
+    await gotoAndWait(page, '/contact');
+
+    const contactCard = page.locator('.contact-card').filter({ hasText: 'Reach us directly' });
+    await expect(contactCard).toContainText("Legal name: Olivia's Garden Foundation");
+    await expect(contactCard).toContainText(`EIN: ${FOUNDATION_EIN}`);
+    await expect(contactCard.getByRole('link', { name: 'allen@oliviasgarden.org' })).toBeVisible();
+  });
+});

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -14,6 +14,21 @@ test('homepage and donate page expose core metadata', async ({ page }) => {
   expect(await readMetaContent(page, 'meta[property="og:image:alt"]')).toBeTruthy();
   expect(await readMetaContent(page, 'meta[property="og:url"]')).toBeTruthy();
 
+  const organizationJsonLd = await page
+    .locator('script[type="application/ld+json"][data-seo-id="organization"]')
+    .textContent();
+  expect(organizationJsonLd).toBeTruthy();
+  const organization = JSON.parse(organizationJsonLd ?? '{}') as {
+    '@type'?: string;
+    legalName?: string;
+    taxID?: string;
+    email?: string;
+  };
+  expect(organization['@type']).toBe('NonprofitOrganization');
+  expect(organization.legalName).toBe("Olivia's Garden Foundation");
+  expect(organization.taxID).toBe('33-3101032');
+  expect(organization.email).toBe('allen@oliviasgarden.org');
+
   await gotoAndWait(page, '/donate');
   await expect(page).toHaveTitle(/Support Olivia's Garden/i);
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', /\/donate$/);

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -206,7 +206,7 @@ body {
   }
 
   .og-site-footer__inner {
-    width: min(100%, calc(100% - 1.5rem));
+    width: min(100%, calc(100% - 1rem));
     gap: 0.55rem;
     padding: 0.8rem 0 0.9rem;
   }
@@ -284,7 +284,7 @@ body {
 }
 
 .og-site-footer__inner {
-  width: min(1180px, calc(100% - 3rem));
+  width: min(1180px, calc(100% - 2rem));
   margin: 0 auto;
   display: grid;
   gap: 0.65rem;
@@ -445,7 +445,7 @@ body {
 
 @media (min-width: 800px) {
   .og-site-footer__inner {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(14rem, 1fr) minmax(18rem, 1.15fr) minmax(7rem, 0.85fr);
     grid-template-areas:
       "pages meta social";
     column-gap: 3rem;
@@ -970,8 +970,8 @@ body {
   }
 
   .og-site-footer__inner {
-    width: min(1180px, calc(100% - 3rem));
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: min(1180px, calc(100% - 2rem));
+    grid-template-columns: minmax(14rem, 1fr) minmax(18rem, 1.15fr) minmax(7rem, 0.85fr);
     align-items: start;
     column-gap: 3rem;
     padding-left: 0;


### PR DESCRIPTION
## Summary
- Centralizes Olivia's Garden Foundation legal metadata in `apps/web/src/site/organization.ts`.
- Updates the footer to the requested 501(c)(3), EIN, tax-deductible, and copyright copy without adding a mailing address.
- Reduces footer horizontal gutters and rebalances the desktop footer grid so the first column has more room while the disclosure column stays wider.
- Surfaces the EIN near the donate checkout CTA and on the contact page.
- Removes underline styling from the donate page's Get involved and Contact us directly alternate-action buttons.
- Adds EIN/legal metadata to the NonprofitOrganization JSON-LD for SEO.
- Adds Playwright coverage for footer, donate, contact, and JSON-LD disclosures.

Closes #274.

## Tests
- PASS: `npm --workspace @olivias/web run typecheck`
- BLOCKED locally: `npm --workspace @olivias/web run build` cannot write `apps/web/node_modules/.tmp/tsconfig.app.tsbuildinfo` in this environment (`EPERM`).
- BLOCKED locally: `npm --workspace @olivias/web run test:e2e -- foundation-disclosures.spec.ts` requires `PLAYWRIGHT_BASE_URL` to point at staging.

## Notes
- Per request, this PR does not add a mailing address.