### PR TITLE
Garden Club subscription cancel + resume flow (#283)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2840,3 +2840,125 @@ html {
     max-height: 90vh;
   }
 }
+
+/* ── Garden Club section ────────────────────────────────────────────── */
+
+.profile-garden-club__panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.profile-garden-club__body p {
+  margin: 0;
+  color: var(--site-ink);
+  line-height: 1.55;
+  font-size: 0.98rem;
+}
+
+.profile-garden-club__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 600px) {
+  .profile-garden-club__actions {
+    justify-content: stretch;
+  }
+
+  .profile-garden-club__actions > * {
+    flex: 1 1 100%;
+  }
+}
+
+/* ── Garden Club cancel dialog (mirrors delete dialog styling) ─────── */
+
+.profile-cancel-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.profile-cancel-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 20, 20, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.profile-cancel-dialog__panel {
+  position: relative;
+  background: var(--site-paper, #fbf7ef);
+  border-radius: 1rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  padding: 1.5rem;
+  max-width: 32rem;
+  width: 100%;
+  display: grid;
+  gap: 0.8rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.profile-cancel-dialog__title {
+  margin: 0;
+  font-family: var(--site-display);
+  font-size: 1.35rem;
+  color: var(--site-ink);
+}
+
+.profile-cancel-dialog__body {
+  margin: 0;
+  color: var(--site-ink);
+  line-height: 1.55;
+  font-size: 0.96rem;
+}
+
+.profile-cancel-dialog__actions {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+.profile-cancel-dialog__actions > * {
+  width: 100%;
+  min-height: 2.75rem;
+}
+
+@media (min-width: 520px) {
+  .profile-cancel-dialog__actions {
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .profile-cancel-dialog__actions > * {
+    width: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .profile-cancel-dialog {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .profile-cancel-dialog__panel {
+    max-width: 100%;
+    border-radius: 1rem 1rem 0 0;
+    padding: 1.25rem 1.1rem calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    max-height: 90vh;
+  }
+}
+
+.donate-form-card__cancel-note {
+  margin-top: 0.4rem;
+  font-size: 0.88rem;
+  color: var(--site-ink-muted, rgba(76, 52, 38, 0.7));
+}

--- a/apps/web/src/site/pages/DonatePage.tsx
+++ b/apps/web/src/site/pages/DonatePage.tsx
@@ -610,6 +610,21 @@ export function DonatePage({
                         ? 'Begins monthly support and includes your free t-shirt at signup.'
                         : 'Includes a permanent bee placed in the memorial garden in your honor, no matter the amount.'}
                     </p>
+                    {selectedMode === 'recurring' ? (
+                      <p className="page-text donate-form-card__cancel-note">
+                        Cancel anytime from{' '}
+                        <a
+                          href="/profile"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            onNavigate('/profile');
+                          }}
+                        >
+                          your profile
+                        </a>
+                        .
+                      </p>
+                    ) : null}
                   </div>
                   <div className="donate-form-card__cta-group">
                     <Button

--- a/apps/web/src/site/pages/ProfilePage.tsx
+++ b/apps/web/src/site/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type ReactNode } from 'react';
 import { Button, FormFeedback, Input, Panel, Textarea } from '@olivias/ui';
 import type { AuthSession } from '../../auth/session';
 import { createOkraHeaders, okraApiUrl } from '../../okra/api';
@@ -6,6 +6,13 @@ import { PageHero, Section } from '../chrome';
 import { webApiBase } from '../routes';
 
 type AvatarStatus = 'none' | 'uploaded' | 'processing' | 'ready' | 'failed';
+
+type GardenClubStatus = 'none' | 'active' | 'past_due' | 'canceling' | 'canceled';
+
+type GardenClubMutationResponse = {
+  gardenClubStatus: GardenClubStatus;
+  gardenClubCancelAt: string | null;
+};
 
 type ProfileResponse = {
   userId: string | null;
@@ -24,7 +31,8 @@ type ProfileResponse = {
   avatarProcessingError: string | null;
   websiteUrl: string | null;
   tier: string | null;
-  gardenClubStatus: string | null;
+  gardenClubStatus: GardenClubStatus | string | null;
+  gardenClubCancelAt: string | null;
   donationTotalCents: number;
   donationCount: number;
   lastDonatedAt: string | null;
@@ -235,6 +243,26 @@ async function completeAvatarUpload(authSession: AuthSession): Promise<void> {
   }
 }
 
+async function postGardenClubAction(
+  authSession: AuthSession,
+  action: 'cancel' | 'resume',
+): Promise<GardenClubMutationResponse> {
+  const response = await fetch(webApiUrl(`/profile/garden-club/${action}`), {
+    method: 'POST',
+    headers: authHeaders(authSession, false),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const message = body?.error
+      ?? body?.message
+      ?? (action === 'cancel'
+        ? 'Unable to cancel your Garden Club support right now.'
+        : 'Unable to resume your Garden Club support right now.');
+    throw new Error(message);
+  }
+  return (await response.json()) as GardenClubMutationResponse;
+}
+
 async function deleteAccount(authSession: AuthSession): Promise<void> {
   const response = await fetch(webApiUrl('/profile'), {
     method: 'DELETE',
@@ -334,6 +362,10 @@ export function ProfilePage({
   const [deleteConfirmation, setDeleteConfirmation] = useState('');
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const [gardenClubCancelDialogOpen, setGardenClubCancelDialogOpen] = useState(false);
+  const [gardenClubBusy, setGardenClubBusy] = useState(false);
+  const [gardenClubError, setGardenClubError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!authSession) {
@@ -541,6 +573,66 @@ export function ProfilePage({
     };
   }, [deleteDialogOpen, closeDeleteDialog]);
 
+  const closeGardenClubCancelDialog = useCallback(() => {
+    if (gardenClubBusy) return;
+    setGardenClubCancelDialogOpen(false);
+    setGardenClubError(null);
+  }, [gardenClubBusy]);
+
+  const submitGardenClubCancel = useCallback(async () => {
+    if (!authSession) return;
+    setGardenClubBusy(true);
+    setGardenClubError(null);
+    try {
+      const result = await postGardenClubAction(authSession, 'cancel');
+      setProfile((prev) => (prev ? {
+        ...prev,
+        gardenClubStatus: result.gardenClubStatus,
+        gardenClubCancelAt: result.gardenClubCancelAt,
+      } : prev));
+      setGardenClubCancelDialogOpen(false);
+    } catch (error) {
+      setGardenClubError(error instanceof Error ? error.message : 'Unable to cancel right now.');
+    } finally {
+      setGardenClubBusy(false);
+    }
+  }, [authSession]);
+
+  const submitGardenClubResume = useCallback(async () => {
+    if (!authSession) return;
+    setGardenClubBusy(true);
+    setGardenClubError(null);
+    try {
+      const result = await postGardenClubAction(authSession, 'resume');
+      setProfile((prev) => (prev ? {
+        ...prev,
+        gardenClubStatus: result.gardenClubStatus,
+        gardenClubCancelAt: result.gardenClubCancelAt,
+      } : prev));
+    } catch (error) {
+      setGardenClubError(error instanceof Error ? error.message : 'Unable to resume right now.');
+    } finally {
+      setGardenClubBusy(false);
+    }
+  }, [authSession]);
+
+  useEffect(() => {
+    if (!gardenClubCancelDialogOpen) return;
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeGardenClubCancelDialog();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [gardenClubCancelDialogOpen, closeGardenClubCancelDialog]);
+
   const refreshAvatarManually = async () => {
     if (!authSession) return;
     setAvatarPollTimedOut(false);
@@ -747,6 +839,19 @@ export function ProfilePage({
         )}
       </Section>
 
+      <GardenClubSection
+        status={(profile?.gardenClubStatus ?? 'none') as GardenClubStatus}
+        cancelAt={profile?.gardenClubCancelAt ?? null}
+        busy={gardenClubBusy}
+        error={gardenClubError}
+        onCancelRequest={() => {
+          setGardenClubError(null);
+          setGardenClubCancelDialogOpen(true);
+        }}
+        onResume={() => void submitGardenClubResume()}
+        onNavigate={onNavigate}
+      />
+
       <Section
         title="Your activity"
         intro="A running history of seed requests, okra submissions, and donations tied to your account."
@@ -824,6 +929,52 @@ export function ProfilePage({
         </Panel>
       </Section>
 
+      {gardenClubCancelDialogOpen ? (
+        <div
+          className="profile-cancel-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="profile-cancel-dialog-title"
+          aria-describedby="profile-cancel-dialog-description"
+        >
+          <div
+            className="profile-cancel-dialog__backdrop"
+            onClick={closeGardenClubCancelDialog}
+            aria-hidden="true"
+          />
+          <div className="profile-cancel-dialog__panel" role="document">
+            <h2 id="profile-cancel-dialog-title" className="profile-cancel-dialog__title">
+              Cancel monthly support?
+            </h2>
+            <p id="profile-cancel-dialog-description" className="profile-cancel-dialog__body">
+              Your bee stays in the garden — that part is permanent. Your Garden Club membership
+              will continue through the end of your current billing period and then end. You can
+              resume any time before then.
+            </p>
+            {gardenClubError ? <FormFeedback tone="error">{gardenClubError}</FormFeedback> : null}
+            <div className="profile-cancel-dialog__actions">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={closeGardenClubCancelDialog}
+                disabled={gardenClubBusy}
+              >
+                Keep my support
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={() => void submitGardenClubCancel()}
+                disabled={gardenClubBusy}
+                loading={gardenClubBusy}
+              >
+                {gardenClubBusy ? 'Canceling…' : 'Yes, cancel'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       {deleteDialogOpen ? (
         <div
           className="profile-delete-dialog"
@@ -893,6 +1044,96 @@ export function ProfilePage({
         </div>
       ) : null}
     </>
+  );
+}
+
+function GardenClubSection({
+  status,
+  cancelAt,
+  busy,
+  error,
+  onCancelRequest,
+  onResume,
+  onNavigate,
+}: {
+  status: GardenClubStatus;
+  cancelAt: string | null;
+  busy: boolean;
+  error: string | null;
+  onCancelRequest: () => void;
+  onResume: () => void;
+  onNavigate: (path: string) => void;
+}) {
+  if (status === 'none') {
+    return null;
+  }
+
+  const goToDonate = (event: { preventDefault: () => void }) => {
+    event.preventDefault();
+    onNavigate('/donate');
+  };
+
+  let body: ReactNode;
+  let actions: ReactNode = null;
+
+  if (status === 'active') {
+    body = (
+      <p>
+        You&apos;re a Garden Club member. Thank you for keeping the work going every month.
+        Your bee is in the garden.
+      </p>
+    );
+    actions = (
+      <Button type="button" variant="secondary" onClick={onCancelRequest} disabled={busy}>
+        Cancel monthly support
+      </Button>
+    );
+  } else if (status === 'canceling') {
+    body = (
+      <p>
+        Your Garden Club support ends on {formatDate(cancelAt)}. You&apos;ll keep access through
+        that date and your bee stays in the garden either way. Change your mind?
+      </p>
+    );
+    actions = (
+      <Button type="button" onClick={onResume} disabled={busy} loading={busy}>
+        {busy ? 'Resuming…' : 'Resume monthly support'}
+      </Button>
+    );
+  } else if (status === 'past_due') {
+    body = (
+      <p>
+        We couldn&apos;t process your last Garden Club gift. Email{' '}
+        <a href="mailto:allen@oliviasgarden.org">allen@oliviasgarden.org</a> and we&apos;ll help
+        get the payment method updated.
+      </p>
+    );
+  } else {
+    body = (
+      <p>
+        Your Garden Club support has ended. Thank you for being part of the network — you can
+        join again whenever you&apos;d like.
+      </p>
+    );
+    actions = (
+      <a className="site-cta og-button og-button--primary og-button--md" href="/donate" onClick={goToDonate}>
+        Become a member again
+      </a>
+    );
+  }
+
+  return (
+    <Section
+      title="Garden Club"
+      intro="Your monthly support of Olivia's Garden Foundation."
+      className="profile-garden-club"
+    >
+      <Panel tone="paper" className="profile-garden-club__panel">
+        <div className="profile-garden-club__body">{body}</div>
+        {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
+        {actions ? <div className="profile-garden-club__actions">{actions}</div> : null}
+      </Panel>
+    </Section>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -596,6 +596,7 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -839,6 +840,7 @@
     "apps/grn/node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -926,6 +928,7 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -1528,6 +1531,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.2.tgz",
       "integrity": "sha512-tH4WddhIJQPGhdOlQJJrPbHF0HWnQO43ivyMVK9iauPFtWmmI4wZn1NiTjV1YDbrOWyJvbcE20WpugP2CB96hA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "^3.973.6",
@@ -2134,6 +2138,7 @@
       "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/jmespath/-/jmespath-2.32.0.tgz",
       "integrity": "sha512-jHtETqs2hJbhNIM4hmGlVOxbEbgUwOxoVU6yBiekRd9UjHby3CsWjQUFluj93qeOFcK17iotczGzwTbVw4i6jg==",
       "license": "MIT-0",
+      "peer": true,
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.32.0"
       }
@@ -3254,6 +3259,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3615,6 +3621,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -3663,6 +3670,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -6680,7 +6688,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@stripe/stripe-js": {
       "version": "7.9.0",
@@ -6856,8 +6865,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -7037,6 +7045,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7112,6 +7121,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -7504,6 +7514,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7615,6 +7626,7 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.4.tgz",
       "integrity": "sha512-BeeLmYMz+J9BLsKHOW/iMrewyG9GwlkmIyqYRcfByo6RHNOz5BFgKn+ASo0RtbMX+duBK1llNWcjfdTbGMcTBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.94",
         "@aws-amplify/api": "6.3.25",
@@ -7722,6 +7734,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8221,8 +8234,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8344,6 +8356,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9081,6 +9094,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9176,7 +9190,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
@@ -9271,7 +9286,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9532,6 +9546,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9712,6 +9727,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9776,7 +9792,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9792,7 +9807,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9882,6 +9896,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9891,6 +9906,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9919,8 +9935,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -10673,6 +10688,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10879,6 +10895,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11193,6 +11210,7 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -11326,6 +11344,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/postman/collections/Web API/Profile/Cancel Garden Club - Invalid Token.request.yaml
+++ b/postman/collections/Web API/Profile/Cancel Garden Club - Invalid Token.request.yaml
@@ -1,0 +1,26 @@
+$kind: http-request
+name: Cancel Garden Club - Invalid Token
+description: |-
+  Ensure POST /profile/garden-club/cancel rejects requests bearing a clearly-
+  invalid bearer token. The Cognito verifier should fail closed before any
+  Stripe call is made.
+method: POST
+url: '{{webBaseUrl}}/profile/garden-club/cancel'
+order: 1201
+headers:
+  - key: Authorization
+    value: 'Bearer not-a-real-token'
+  - key: X-Correlation-Id
+    value: postman-cancel-gc-invalid
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Invalid tokens are rejected with 400 or 401", function () {
+          pm.expect([400, 401]).to.include(pm.response.code);
+      });
+
+      pm.test("Response body surfaces an error message", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+      });

--- a/postman/collections/Web API/Profile/Cancel Garden Club - Unauthenticated.request.yaml
+++ b/postman/collections/Web API/Profile/Cancel Garden Club - Unauthenticated.request.yaml
@@ -1,0 +1,28 @@
+$kind: http-request
+name: Cancel Garden Club - Unauthenticated
+description: |-
+  Ensure POST /profile/garden-club/cancel rejects unauthenticated requests. The
+  endpoint must require a Cognito bearer token before contacting Stripe.
+method: POST
+url: '{{webBaseUrl}}/profile/garden-club/cancel'
+order: 1200
+headers:
+  - key: X-Correlation-Id
+    value: postman-cancel-gc-unauth
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("POST /profile/garden-club/cancel returns 400 when unauthenticated", function () {
+          pm.expect(pm.response.code).to.equal(400);
+      });
+
+      pm.test("Response body surfaces the missing-auth error", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+          pm.expect(body.error.toLowerCase()).to.include("authorization");
+      });
+
+      pm.test("Response includes correlation id header", function () {
+          pm.expect(pm.response.headers.get("x-correlation-id")).to.be.a("string").and.not.empty;
+      });

--- a/postman/collections/Web API/Profile/Resume Garden Club - Invalid Token.request.yaml
+++ b/postman/collections/Web API/Profile/Resume Garden Club - Invalid Token.request.yaml
@@ -1,0 +1,26 @@
+$kind: http-request
+name: Resume Garden Club - Invalid Token
+description: |-
+  Ensure POST /profile/garden-club/resume rejects requests bearing a clearly-
+  invalid bearer token. The Cognito verifier should fail closed before any
+  Stripe call is made.
+method: POST
+url: '{{webBaseUrl}}/profile/garden-club/resume'
+order: 1211
+headers:
+  - key: Authorization
+    value: 'Bearer not-a-real-token'
+  - key: X-Correlation-Id
+    value: postman-resume-gc-invalid
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Invalid tokens are rejected with 400 or 401", function () {
+          pm.expect([400, 401]).to.include(pm.response.code);
+      });
+
+      pm.test("Response body surfaces an error message", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+      });

--- a/postman/collections/Web API/Profile/Resume Garden Club - Unauthenticated.request.yaml
+++ b/postman/collections/Web API/Profile/Resume Garden Club - Unauthenticated.request.yaml
@@ -1,0 +1,28 @@
+$kind: http-request
+name: Resume Garden Club - Unauthenticated
+description: |-
+  Ensure POST /profile/garden-club/resume rejects unauthenticated requests. The
+  endpoint must require a Cognito bearer token before contacting Stripe.
+method: POST
+url: '{{webBaseUrl}}/profile/garden-club/resume'
+order: 1210
+headers:
+  - key: X-Correlation-Id
+    value: postman-resume-gc-unauth
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("POST /profile/garden-club/resume returns 400 when unauthenticated", function () {
+          pm.expect(pm.response.code).to.equal(400);
+      });
+
+      pm.test("Response body surfaces the missing-auth error", function () {
+          const body = pm.response.json();
+          pm.expect(body.error).to.be.a("string").and.not.empty;
+          pm.expect(body.error.toLowerCase()).to.include("authorization");
+      });
+
+      pm.test("Response includes correlation id header", function () {
+          pm.expect(pm.response.headers.get("x-correlation-id")).to.be.a("string").and.not.empty;
+      });

--- a/services/notifications/src/services/renderers.mjs
+++ b/services/notifications/src/services/renderers.mjs
@@ -135,6 +135,54 @@ function renderDonationCompleted(detail) {
   };
 }
 
+function formatCancelDate(value) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function renderGardenClubCancellationScheduled(detail) {
+  const donor = detail.donorEmail ?? 'unknown donor';
+  const cancelDate = formatCancelDate(detail.cancelAt);
+  const lines = [':calendar: Garden Club cancellation scheduled', `Donor: ${donor}`];
+  if (cancelDate) lines.push(`Ends on: ${cancelDate}`);
+  lines.push(`Subscription: ${detail.stripeSubscriptionId ?? 'unknown'}`);
+
+  return {
+    summary: `Garden Club cancellation scheduled for ${donor}${cancelDate ? ` (ends ${cancelDate})` : ''}`,
+    slack: { text: lines.join('\n') }
+  };
+}
+
+function renderGardenClubCancellationReverted(detail) {
+  const donor = detail.donorEmail ?? 'unknown donor';
+  const lines = [
+    ':seedling: Garden Club cancellation reverted',
+    `Donor: ${donor}`,
+    `Subscription: ${detail.stripeSubscriptionId ?? 'unknown'}`
+  ];
+
+  return {
+    summary: `Garden Club cancellation reverted for ${donor}`,
+    slack: { text: lines.join('\n') }
+  };
+}
+
+function renderGardenClubCanceled(detail) {
+  const donor = detail.donorEmail ?? 'unknown donor';
+  const lines = [
+    ':wave: Garden Club ended',
+    `Donor: ${donor}`,
+    `Subscription: ${detail.stripeSubscriptionId ?? 'unknown'}`
+  ];
+
+  return {
+    summary: `Garden Club ended for ${donor}`,
+    slack: { text: lines.join('\n') }
+  };
+}
+
 function renderUserSignedUp(detail) {
   const env = process.env.FOUNDATION_ENVIRONMENT ?? 'unknown';
   const lines = [
@@ -175,6 +223,9 @@ const renderers = new Map([
   ['okra.submissions|submission.created', renderOkraSubmissionCreated],
   ['okra.seed-requests|seed-request.created', renderSeedRequestCreated],
   ['ogf.donations|donation.completed', renderDonationCompleted],
+  ['ogf.donations|garden-club.cancellation_scheduled', renderGardenClubCancellationScheduled],
+  ['ogf.donations|garden-club.cancellation_reverted', renderGardenClubCancellationReverted],
+  ['ogf.donations|garden-club.canceled', renderGardenClubCanceled],
   ['ogf.signups|user.signed-up', renderUserSignedUp],
   ['ogf.contact|org-inquiry.received', renderOrgInquiryReceived]
 ]);

--- a/services/notifications/template.yaml
+++ b/services/notifications/template.yaml
@@ -149,6 +149,9 @@ Resources:
                 - submission.created
                 - seed-request.created
                 - donation.completed
+                - garden-club.cancellation_scheduled
+                - garden-club.cancellation_reverted
+                - garden-club.canceled
                 - user.signed-up
                 - org-inquiry.received
 

--- a/services/notifications/test/renderers.test.mjs
+++ b/services/notifications/test/renderers.test.mjs
@@ -134,6 +134,35 @@ describe('renderEvent', () => {
     expect(result.summary).toContain('(no organization name)');
     expect(result.slack.text).not.toContain('Location:');
   });
+
+  it('renders Garden Club cancellation_scheduled with formatted end date', () => {
+    const result = renderEvent('ogf.donations', 'garden-club.cancellation_scheduled', {
+      donorEmail: 'donor@example.com',
+      stripeSubscriptionId: 'sub_123',
+      cancelAt: '2027-05-15T00:00:00.000Z'
+    });
+    expect(result.summary).toBe('Garden Club cancellation scheduled for donor@example.com (ends May 14, 2027)');
+    expect(result.slack.text).toContain('Donor: donor@example.com');
+    expect(result.slack.text).toContain('Ends on: May 14, 2027');
+  });
+
+  it('renders Garden Club cancellation_reverted', () => {
+    const result = renderEvent('ogf.donations', 'garden-club.cancellation_reverted', {
+      donorEmail: 'donor@example.com',
+      stripeSubscriptionId: 'sub_123'
+    });
+    expect(result.summary).toBe('Garden Club cancellation reverted for donor@example.com');
+    expect(result.slack.text).toContain('Subscription: sub_123');
+  });
+
+  it('renders Garden Club canceled', () => {
+    const result = renderEvent('ogf.donations', 'garden-club.canceled', {
+      donorEmail: 'donor@example.com',
+      stripeSubscriptionId: 'sub_123'
+    });
+    expect(result.summary).toBe('Garden Club ended for donor@example.com');
+    expect(result.slack.text).toContain('Garden Club ended');
+  });
 });
 
 describe('isContactEvent', () => {

--- a/services/web-api/db/migrations/0005_garden_club_canceling_state.sql
+++ b/services/web-api/db/migrations/0005_garden_club_canceling_state.sql
@@ -1,0 +1,17 @@
+-- Garden Club cancel-at-period-end support.
+--
+-- Stripe's `cancel_at_period_end = true` means the subscription stays active
+-- until the end of the current billing period, then transitions to canceled.
+-- We model that with a new `canceling` status plus a `garden_club_cancel_at`
+-- timestamp so the profile UI can show "ends on {date}" without inferring it
+-- from other fields.
+
+alter table users
+  drop constraint if exists users_garden_club_status_check;
+
+alter table users
+  add constraint users_garden_club_status_check
+  check (garden_club_status in ('none', 'active', 'past_due', 'canceling', 'canceled'));
+
+alter table users
+  add column if not exists garden_club_cancel_at timestamptz;

--- a/services/web-api/openapi.yaml
+++ b/services/web-api/openapi.yaml
@@ -58,6 +58,59 @@ paths:
           description: Missing or invalid authorization header
         '401':
           description: Invalid access token
+  /profile/garden-club/cancel:
+    post:
+      summary: Schedule a Garden Club cancellation at the end of the current billing period
+      description: |
+        Sets the authenticated user's Garden Club Stripe subscription to
+        `cancel_at_period_end=true`. The donor keeps access through the end of
+        the period they paid for, then the subscription transitions to canceled
+        when Stripe sends `customer.subscription.deleted`.
+
+        Returns the cancellation date so the client can update its UI without a
+        round-trip through the webhook. A `garden-club.cancellation_scheduled`
+        event is published for downstream notifications.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Cancellation scheduled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GardenClubMutationResponse'
+        '400':
+          description: Missing or invalid authorization header
+        '401':
+          description: Invalid access token
+        '409':
+          description: User has no active Garden Club subscription on file
+  /profile/garden-club/resume:
+    post:
+      summary: Reverse a scheduled Garden Club cancellation
+      description: |
+        Sets the authenticated user's Garden Club Stripe subscription back to
+        `cancel_at_period_end=false`. Only valid while the subscription is in
+        the `canceling` state — once Stripe has actually deleted the
+        subscription the donor must start a new Garden Club through the
+        donate flow.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Subscription resumed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GardenClubMutationResponse'
+        '400':
+          description: Missing or invalid authorization header
+        '401':
+          description: Invalid access token
+        '409':
+          description: |
+            User has no Garden Club subscription that can be resumed (already
+            active, fully canceled, or never enrolled).
   /donations/checkout-session-status:
     get:
       summary: Read the current Stripe Checkout Session status after return from embedded checkout
@@ -128,3 +181,16 @@ components:
           type: [string, 'null']
         customerEmail:
           type: [string, 'null']
+    GardenClubMutationResponse:
+      type: object
+      required: [gardenClubStatus, gardenClubCancelAt]
+      properties:
+        gardenClubStatus:
+          type: string
+          enum: [none, active, past_due, canceling, canceled]
+        gardenClubCancelAt:
+          type: [string, 'null']
+          format: date-time
+          description: |
+            ISO 8601 timestamp when the Garden Club access ends, when the
+            subscription is in the `canceling` state. Null otherwise.

--- a/services/web-api/src/handlers/api.mjs
+++ b/services/web-api/src/handlers/api.mjs
@@ -3,8 +3,10 @@ import { Logger } from '@aws-lambda-powertools/logger';
 import { validate } from '@aws-lambda-powertools/validation';
 import { SchemaValidationError } from '@aws-lambda-powertools/validation/errors';
 import {
+  cancelGardenClubSubscription,
   createDonationCheckoutSession,
   donationCheckoutSessionSchema,
+  resumeGardenClubSubscription,
   retrieveCheckoutSessionStatus
 } from '../services/donations.mjs';
 import {
@@ -230,6 +232,42 @@ app.post('/profile/avatar/complete', async ({ event }) => {
       body: result
     };
   } catch (error) {
+    return mapApiError(error, correlationId);
+  }
+});
+
+app.post('/profile/garden-club/cancel', async ({ event }) => {
+  const correlationId = getCorrelationId(event);
+  try {
+    const result = await cancelGardenClubSubscription(event, correlationId);
+    return {
+      statusCode: 200,
+      headers: { 'x-correlation-id': correlationId },
+      body: result
+    };
+  } catch (error) {
+    logger.warn('Garden Club cancel request failed', {
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return mapApiError(error, correlationId);
+  }
+});
+
+app.post('/profile/garden-club/resume', async ({ event }) => {
+  const correlationId = getCorrelationId(event);
+  try {
+    const result = await resumeGardenClubSubscription(event, correlationId);
+    return {
+      statusCode: 200,
+      headers: { 'x-correlation-id': correlationId },
+      body: result
+    };
+  } catch (error) {
+    logger.warn('Garden Club resume request failed', {
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    });
     return mapApiError(error, correlationId);
   }
 });

--- a/services/web-api/src/services/donations.mjs
+++ b/services/web-api/src/services/donations.mjs
@@ -544,21 +544,25 @@ async function persistInvoicePaid(client, eventId, object, correlationId) {
   );
 }
 
-async function markGardenClubStatus(client, subscriptionId, nextStatus) {
+async function setGardenClubStatusBySubscription(client, subscriptionId, nextStatus, cancelAt = null) {
   if (!subscriptionId) {
-    return;
+    return null;
   }
 
-  await client.query(
+  const result = await client.query(
     `
       update users
          set garden_club_status = $2,
+             garden_club_cancel_at = $3,
              updated_at = now()
        where stripe_garden_club_subscription_id = $1
          and deleted_at is null
+       returning id::text as id, email::text as email, garden_club_cancel_at
     `,
-    [subscriptionId, nextStatus]
+    [subscriptionId, nextStatus, cancelAt]
   );
+
+  return result.rows[0] ?? null;
 }
 
 async function persistInvoicePaymentFailed(client, object, correlationId) {
@@ -567,7 +571,7 @@ async function persistInvoicePaymentFailed(client, object, correlationId) {
     return;
   }
 
-  await markGardenClubStatus(client, subscriptionId, 'past_due');
+  await setGardenClubStatusBySubscription(client, subscriptionId, 'past_due');
 
   console.info(JSON.stringify({
     level: 'info',
@@ -577,13 +581,80 @@ async function persistInvoicePaymentFailed(client, object, correlationId) {
   }));
 }
 
+function epochSecondsToIsoString(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return new Date(value * 1000).toISOString();
+}
+
+async function persistSubscriptionUpdated(client, object, correlationId) {
+  const subscriptionId = object.id ?? null;
+  if (!subscriptionId) {
+    return;
+  }
+
+  const cancelAtPeriodEnd = object.cancel_at_period_end === true;
+  const stripeStatus = typeof object.status === 'string' ? object.status : null;
+
+  // Stripe sends `customer.subscription.updated` for many reasons: price changes,
+  // metadata edits, status transitions, etc. We only react to the cancel-at-
+  // period-end toggle and to past_due/active flips. Everything else we ignore so
+  // we don't accidentally overwrite local state.
+  if (cancelAtPeriodEnd) {
+    const cancelAtIso = epochSecondsToIsoString(object.cancel_at)
+      ?? epochSecondsToIsoString(object.current_period_end);
+    const updated = await setGardenClubStatusBySubscription(client, subscriptionId, 'canceling', cancelAtIso);
+
+    console.info(JSON.stringify({
+      level: 'info',
+      correlationId,
+      subscriptionId,
+      cancelAt: cancelAtIso,
+      message: 'Marked Garden Club subscription as canceling after customer.subscription.updated'
+    }));
+
+    if (updated) {
+      await publishGardenClubLifecycleEvent('garden-club.cancellation_scheduled', {
+        userId: updated.id,
+        donorEmail: updated.email,
+        stripeSubscriptionId: subscriptionId,
+        cancelAt: cancelAtIso
+      }, correlationId);
+    }
+    return;
+  }
+
+  // cancel_at_period_end is false. Either the donor never asked to cancel, or
+  // they reversed a pending cancellation. Re-active only when Stripe also says
+  // the subscription is active, otherwise leave whatever local status (e.g.
+  // past_due) alone.
+  if (stripeStatus === 'active') {
+    const updated = await setGardenClubStatusBySubscription(client, subscriptionId, 'active', null);
+    console.info(JSON.stringify({
+      level: 'info',
+      correlationId,
+      subscriptionId,
+      message: 'Reverted Garden Club subscription to active after customer.subscription.updated'
+    }));
+
+    if (updated) {
+      await publishGardenClubLifecycleEvent('garden-club.cancellation_reverted', {
+        userId: updated.id,
+        donorEmail: updated.email,
+        stripeSubscriptionId: subscriptionId
+      }, correlationId);
+    }
+  }
+}
+
 async function persistSubscriptionDeleted(client, object, correlationId) {
   const subscriptionId = object.id ?? null;
   if (!subscriptionId) {
     return;
   }
 
-  await markGardenClubStatus(client, subscriptionId, 'canceled');
+  const updated = await setGardenClubStatusBySubscription(client, subscriptionId, 'canceled', null);
 
   console.info(JSON.stringify({
     level: 'info',
@@ -591,6 +662,46 @@ async function persistSubscriptionDeleted(client, object, correlationId) {
     subscriptionId,
     message: 'Marked Garden Club subscription as canceled after customer.subscription.deleted'
   }));
+
+  if (updated) {
+    await publishGardenClubLifecycleEvent('garden-club.canceled', {
+      userId: updated.id,
+      donorEmail: updated.email,
+      stripeSubscriptionId: subscriptionId
+    }, correlationId);
+  }
+}
+
+async function publishGardenClubLifecycleEvent(detailType, detail, correlationId) {
+  try {
+    const result = await eventBridge.send(new PutEventsCommand({
+      Entries: [
+        {
+          Source: 'ogf.donations',
+          DetailType: detailType,
+          Detail: JSON.stringify({ ...detail, correlationId })
+        }
+      ]
+    }));
+
+    if ((result?.FailedEntryCount ?? 0) > 0) {
+      console.error(JSON.stringify({
+        level: 'error',
+        correlationId,
+        detailType,
+        message: 'Garden Club lifecycle event publish reported failed entries',
+        failedEntryCount: result.FailedEntryCount
+      }));
+    }
+  } catch (error) {
+    console.error(JSON.stringify({
+      level: 'error',
+      correlationId,
+      detailType,
+      message: 'Failed to publish Garden Club lifecycle event',
+      error: error instanceof Error ? error.message : String(error)
+    }));
+  }
 }
 
 async function processStripeEvent(event, correlationId) {
@@ -622,6 +733,11 @@ async function processStripeEvent(event, correlationId) {
 
     if (eventType === 'invoice.payment_failed') {
       await persistInvoicePaymentFailed(client, object, correlationId);
+      return;
+    }
+
+    if (eventType === 'customer.subscription.updated') {
+      await persistSubscriptionUpdated(client, object, correlationId);
       return;
     }
 
@@ -721,3 +837,181 @@ export async function retrieveCheckoutSessionStatus(sessionId) {
     customerEmail: stripePayload.customer_details?.email ?? stripePayload.customer_email ?? null
   };
 }
+
+class GardenClubMembershipNotFoundError extends Error {
+  constructor() {
+    super('No active Garden Club membership for this account');
+    this.code = 'GardenClubMembershipNotFound';
+  }
+}
+
+class GardenClubAlreadyActiveError extends Error {
+  constructor() {
+    super('Garden Club membership is already active');
+    this.code = 'GardenClubAlreadyActive';
+  }
+}
+
+async function fetchGardenClubMembership(client, userId) {
+  const result = await client.query(
+    `
+      select id::text as id,
+             email::text as email,
+             stripe_garden_club_subscription_id,
+             garden_club_status,
+             garden_club_cancel_at
+        from users
+       where id = $1::uuid
+         and deleted_at is null
+    `,
+    [userId]
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function updateStripeSubscriptionCancelAtPeriodEnd(stripeSecretKey, subscriptionId, cancelAtPeriodEnd) {
+  const params = new URLSearchParams();
+  params.set('cancel_at_period_end', cancelAtPeriodEnd ? 'true' : 'false');
+
+  const response = await fetch(`https://api.stripe.com/v1/subscriptions/${encodeURIComponent(subscriptionId)}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Basic ${Buffer.from(`${stripeSecretKey}:`).toString('base64')}`,
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: params
+  });
+
+  if (!response.ok) {
+    throw new Error(`Stripe subscription update failed (${response.status}): ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+export async function cancelGardenClubSubscription(event, correlationId) {
+  const authContext = await resolveOptionalAuthContext(event);
+  if (!authContext?.userId) {
+    throw new Error('Authorization token is required');
+  }
+
+  const stripeSecretKey = requiredEnvVar('STRIPE_SECRET_KEY');
+  const client = await createDbClient();
+  await client.connect();
+
+  try {
+    const membership = await fetchGardenClubMembership(client, authContext.userId);
+    if (!membership?.stripe_garden_club_subscription_id) {
+      throw new GardenClubMembershipNotFoundError();
+    }
+
+    const stripeSubscription = await updateStripeSubscriptionCancelAtPeriodEnd(
+      stripeSecretKey,
+      membership.stripe_garden_club_subscription_id,
+      true
+    );
+
+    const cancelAtIso = epochSecondsToIsoString(stripeSubscription.cancel_at)
+      ?? epochSecondsToIsoString(stripeSubscription.current_period_end);
+
+    const updated = await setGardenClubStatusBySubscription(
+      client,
+      membership.stripe_garden_club_subscription_id,
+      'canceling',
+      cancelAtIso
+    );
+
+    console.info(JSON.stringify({
+      level: 'info',
+      correlationId,
+      userId: authContext.userId,
+      subscriptionId: membership.stripe_garden_club_subscription_id,
+      cancelAt: cancelAtIso,
+      message: 'Scheduled Garden Club cancellation at period end'
+    }));
+
+    if (updated) {
+      await publishGardenClubLifecycleEvent('garden-club.cancellation_scheduled', {
+        userId: updated.id,
+        donorEmail: updated.email,
+        stripeSubscriptionId: membership.stripe_garden_club_subscription_id,
+        cancelAt: cancelAtIso
+      }, correlationId);
+    }
+
+    return {
+      gardenClubStatus: 'canceling',
+      gardenClubCancelAt: cancelAtIso
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+export async function resumeGardenClubSubscription(event, correlationId) {
+  const authContext = await resolveOptionalAuthContext(event);
+  if (!authContext?.userId) {
+    throw new Error('Authorization token is required');
+  }
+
+  const stripeSecretKey = requiredEnvVar('STRIPE_SECRET_KEY');
+  const client = await createDbClient();
+  await client.connect();
+
+  try {
+    const membership = await fetchGardenClubMembership(client, authContext.userId);
+    if (!membership?.stripe_garden_club_subscription_id) {
+      throw new GardenClubMembershipNotFoundError();
+    }
+
+    if (membership.garden_club_status === 'active') {
+      throw new GardenClubAlreadyActiveError();
+    }
+
+    if (membership.garden_club_status !== 'canceling') {
+      // Only `canceling` is reversible from the donor side. `canceled` means
+      // Stripe already deleted the subscription and they would need to start
+      // a new Garden Club from the donate page.
+      throw new GardenClubMembershipNotFoundError();
+    }
+
+    await updateStripeSubscriptionCancelAtPeriodEnd(
+      stripeSecretKey,
+      membership.stripe_garden_club_subscription_id,
+      false
+    );
+
+    const updated = await setGardenClubStatusBySubscription(
+      client,
+      membership.stripe_garden_club_subscription_id,
+      'active',
+      null
+    );
+
+    console.info(JSON.stringify({
+      level: 'info',
+      correlationId,
+      userId: authContext.userId,
+      subscriptionId: membership.stripe_garden_club_subscription_id,
+      message: 'Reverted scheduled Garden Club cancellation'
+    }));
+
+    if (updated) {
+      await publishGardenClubLifecycleEvent('garden-club.cancellation_reverted', {
+        userId: updated.id,
+        donorEmail: updated.email,
+        stripeSubscriptionId: membership.stripe_garden_club_subscription_id
+      }, correlationId);
+    }
+
+    return {
+      gardenClubStatus: 'active',
+      gardenClubCancelAt: null
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+export { GardenClubMembershipNotFoundError, GardenClubAlreadyActiveError };

--- a/services/web-api/src/services/http.mjs
+++ b/services/web-api/src/services/http.mjs
@@ -74,6 +74,13 @@ export function mapApiError(error, correlationId) {
     return errorResponse(404, message, correlationId);
   }
 
+  if (
+    message.includes('No active Garden Club membership for this account')
+    || message.includes('Garden Club membership is already active')
+  ) {
+    return errorResponse(409, message, correlationId);
+  }
+
   if (message.includes('is not configured')) {
     return errorResponse(503, 'Service not configured in this environment', correlationId);
   }

--- a/services/web-api/src/services/profile.mjs
+++ b/services/web-api/src/services/profile.mjs
@@ -92,6 +92,7 @@ function mapProfileRow(row, authContext) {
       websiteUrl: null,
       tier: null,
       gardenClubStatus: 'none',
+      gardenClubCancelAt: null,
       donationTotalCents: 0,
       donationCount: 0,
       lastDonatedAt: null,
@@ -119,6 +120,7 @@ function mapProfileRow(row, authContext) {
     websiteUrl: row.website_url,
     tier: row.tier,
     gardenClubStatus: row.garden_club_status ?? 'none',
+    gardenClubCancelAt: row.garden_club_cancel_at,
     donationTotalCents: Number(row.donation_total_cents ?? 0),
     donationCount: Number(row.donation_count ?? 0),
     lastDonatedAt: row.last_donated_at,
@@ -131,7 +133,7 @@ function mapProfileRow(row, authContext) {
 const PROFILE_SELECT_COLUMNS = `
   id::text as id, email::text as email, display_name, tier,
   first_name, last_name, bio, city, region, country, timezone,
-  website_url, garden_club_status,
+  website_url, garden_club_status, garden_club_cancel_at,
   avatar_s3_key, avatar_thumbnail_s3_key, avatar_status, avatar_processing_error,
   donation_total_cents, donation_count, last_donated_at,
   created_at, updated_at, profile_updated_at

--- a/services/web-api/template.yaml
+++ b/services/web-api/template.yaml
@@ -251,6 +251,7 @@ Resources:
                 - checkout.session.completed
                 - checkout.session.expired
                 - customer.subscription.deleted
+                - customer.subscription.updated
                 - invoice.paid
                 - invoice.payment_failed
 

--- a/services/web-api/test/donations.test.mjs
+++ b/services/web-api/test/donations.test.mjs
@@ -22,7 +22,12 @@ vi.mock('@aws-sdk/client-eventbridge', async () => {
   };
 });
 
-const { createDonationCheckoutSession, handleEventBridgeEvent } = await import('../src/services/donations.mjs');
+const {
+  cancelGardenClubSubscription,
+  createDonationCheckoutSession,
+  handleEventBridgeEvent,
+  resumeGardenClubSubscription
+} = await import('../src/services/donations.mjs');
 
 describe('donations service', () => {
   beforeEach(() => {
@@ -325,5 +330,307 @@ describe('donations service', () => {
     expect(detail.anonymous).toBe(true);
     expect(detail.donorEmail).toBeNull();
     expect(detail.dedicationName).toBe('Anonymous donor');
+  });
+
+  it('schedules Garden Club cancellation at period end and returns the cancel date', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    resolveOptionalAuthContextMock.mockResolvedValue({
+      userId: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+    });
+
+    const cancelAtSeconds = 1_900_000_000;
+    const queryMock = vi.fn((sql) => {
+      if (sql.includes('select id::text as id') && sql.includes('from users')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+              email: 'donor@example.com',
+              stripe_garden_club_subscription_id: 'sub_123',
+              garden_club_status: 'active',
+              garden_club_cancel_at: null,
+            },
+          ],
+        });
+      }
+
+      if (sql.includes('update users') && sql.includes('garden_club_status')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+              email: 'donor@example.com',
+              garden_club_cancel_at: new Date(cancelAtSeconds * 1000).toISOString(),
+            },
+          ],
+        });
+      }
+
+      return Promise.resolve({ rowCount: 0 });
+    });
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    };
+    createDbClientMock.mockResolvedValue(client);
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'sub_123',
+        cancel_at_period_end: true,
+        cancel_at: cancelAtSeconds,
+        current_period_end: cancelAtSeconds,
+        status: 'active',
+      }),
+    });
+
+    const result = await cancelGardenClubSubscription({ headers: {} }, 'corr-cancel-1');
+
+    expect(result.gardenClubStatus).toBe('canceling');
+    expect(result.gardenClubCancelAt).toBe(new Date(cancelAtSeconds * 1000).toISOString());
+
+    const [stripeUrl, stripeOptions] = vi.mocked(fetch).mock.calls[0];
+    expect(stripeUrl).toBe('https://api.stripe.com/v1/subscriptions/sub_123');
+    expect(stripeOptions.method).toBe('POST');
+    expect(stripeOptions.body).toBeInstanceOf(URLSearchParams);
+    expect(stripeOptions.body.get('cancel_at_period_end')).toBe('true');
+
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    const entry = eventBridgeSendMock.mock.calls[0][0].input.Entries[0];
+    expect(entry.DetailType).toBe('garden-club.cancellation_scheduled');
+    const detail = JSON.parse(entry.Detail);
+    expect(detail.userId).toBe('cf399090-0f65-4d15-bd10-50944ce0ff9b');
+    expect(detail.donorEmail).toBe('donor@example.com');
+    expect(detail.cancelAt).toBe(new Date(cancelAtSeconds * 1000).toISOString());
+  });
+
+  it('rejects cancel requests when the user has no Garden Club subscription on file', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    resolveOptionalAuthContextMock.mockResolvedValue({ userId: 'cf399090-0f65-4d15-bd10-50944ce0ff9b' });
+
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+          email: 'donor@example.com',
+          stripe_garden_club_subscription_id: null,
+          garden_club_status: 'none',
+          garden_club_cancel_at: null,
+        },
+      ],
+    });
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    });
+
+    await expect(cancelGardenClubSubscription({ headers: {} }, 'corr-cancel-2'))
+      .rejects.toThrow('No active Garden Club membership');
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('reverts a scheduled cancellation when the donor resumes monthly support', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    resolveOptionalAuthContextMock.mockResolvedValue({ userId: 'cf399090-0f65-4d15-bd10-50944ce0ff9b' });
+
+    const queryMock = vi.fn((sql) => {
+      if (sql.includes('select id::text as id') && sql.includes('from users')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+              email: 'donor@example.com',
+              stripe_garden_club_subscription_id: 'sub_123',
+              garden_club_status: 'canceling',
+              garden_club_cancel_at: '2027-05-15T00:00:00.000Z',
+            },
+          ],
+        });
+      }
+
+      if (sql.includes('update users') && sql.includes('garden_club_status')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+              email: 'donor@example.com',
+              garden_club_cancel_at: null,
+            },
+          ],
+        });
+      }
+
+      return Promise.resolve({ rowCount: 0 });
+    });
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    });
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: 'sub_123',
+        cancel_at_period_end: false,
+        status: 'active',
+      }),
+    });
+
+    const result = await resumeGardenClubSubscription({ headers: {} }, 'corr-resume-1');
+
+    expect(result.gardenClubStatus).toBe('active');
+    expect(result.gardenClubCancelAt).toBeNull();
+    expect(vi.mocked(fetch).mock.calls[0][1].body.get('cancel_at_period_end')).toBe('false');
+
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    expect(eventBridgeSendMock.mock.calls[0][0].input.Entries[0].DetailType).toBe('garden-club.cancellation_reverted');
+  });
+
+  it('rejects resume when the membership is already active', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    resolveOptionalAuthContextMock.mockResolvedValue({ userId: 'cf399090-0f65-4d15-bd10-50944ce0ff9b' });
+
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+            email: 'donor@example.com',
+            stripe_garden_club_subscription_id: 'sub_123',
+            garden_club_status: 'active',
+            garden_club_cancel_at: null,
+          },
+        ],
+      }),
+    });
+
+    await expect(resumeGardenClubSubscription({ headers: {} }, 'corr-resume-2'))
+      .rejects.toThrow('already active');
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('marks the user as canceling when customer.subscription.updated arrives with cancel_at_period_end', async () => {
+    const cancelAtSeconds = 1_900_000_000;
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+          email: 'donor@example.com',
+          garden_club_cancel_at: new Date(cancelAtSeconds * 1000).toISOString(),
+        },
+      ],
+    });
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    });
+
+    await handleEventBridgeEvent({
+      id: 'evtbridge-canceling-1',
+      'detail-type': 'customer.subscription.updated',
+      detail: {
+        id: 'evt_canceling_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_123',
+            cancel_at_period_end: true,
+            cancel_at: cancelAtSeconds,
+            current_period_end: cancelAtSeconds,
+            status: 'active',
+          },
+        },
+      },
+    });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('update users'),
+      ['sub_123', 'canceling', new Date(cancelAtSeconds * 1000).toISOString()],
+    );
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    expect(eventBridgeSendMock.mock.calls[0][0].input.Entries[0].DetailType).toBe('garden-club.cancellation_scheduled');
+  });
+
+  it('reverts to active when customer.subscription.updated reports cancel_at_period_end=false on an active sub', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+          email: 'donor@example.com',
+          garden_club_cancel_at: null,
+        },
+      ],
+    });
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    });
+
+    await handleEventBridgeEvent({
+      id: 'evtbridge-active-1',
+      'detail-type': 'customer.subscription.updated',
+      detail: {
+        id: 'evt_active_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_123',
+            cancel_at_period_end: false,
+            status: 'active',
+          },
+        },
+      },
+    });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('update users'),
+      ['sub_123', 'active', null],
+    );
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    expect(eventBridgeSendMock.mock.calls[0][0].input.Entries[0].DetailType).toBe('garden-club.cancellation_reverted');
+  });
+
+  it('clears cancel_at when customer.subscription.deleted finalizes the cancellation', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          id: 'cf399090-0f65-4d15-bd10-50944ce0ff9b',
+          email: 'donor@example.com',
+          garden_club_cancel_at: null,
+        },
+      ],
+    });
+    createDbClientMock.mockResolvedValue({
+      connect: vi.fn().mockResolvedValue(undefined),
+      end: vi.fn().mockResolvedValue(undefined),
+      query: queryMock,
+    });
+
+    await handleEventBridgeEvent({
+      id: 'evtbridge-deleted-1',
+      'detail-type': 'customer.subscription.deleted',
+      detail: {
+        id: 'evt_deleted_1',
+        type: 'customer.subscription.deleted',
+        data: {
+          object: { id: 'sub_123' },
+        },
+      },
+    });
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('update users'),
+      ['sub_123', 'canceled', null],
+    );
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    expect(eventBridgeSendMock.mock.calls[0][0].input.Entries[0].DetailType).toBe('garden-club.canceled');
   });
 });


### PR DESCRIPTION
Closes #283.

## Summary
- Donors can cancel monthly Garden Club support from their profile and resume any time before the billing period ends
- Cancellation is period-end (donor keeps access through the month they paid for) and fully reversible while in the new `canceling` state
- Adds end-to-end backend, webhook, frontend, and notification plumbing — out of one PR by design so reviewers can see the full state machine in one place

## What changed

**Data model**
- Migration `0005_garden_club_canceling_state.sql`: adds `canceling` to the `garden_club_status` enum and a new `garden_club_cancel_at timestamptz` column

**`services/web-api`**
- `POST /profile/garden-club/cancel` — schedules `cancel_at_period_end=true` on the user's Stripe sub, persists the new state, publishes `garden-club.cancellation_scheduled`
- `POST /profile/garden-club/resume` — reverses a scheduled cancellation while still in `canceling`. 409 once Stripe has actually deleted the sub
- New `persistSubscriptionUpdated` webhook handler covering both cancel-flip directions; `customer.subscription.updated` added to the EventBridge rule
- Existing `persistSubscriptionDeleted` now clears `cancel_at` and publishes `garden-club.canceled`
- Profile API surfaces `gardenClubCancelAt`
- 7 new vitest cases. `web-api` test suite: 38/38

**`services/notifications`**
- Slack renderers + EventBridge subscriptions for the three new lifecycle events
- 3 new vitest cases. `notifications` test suite: 19/19

**`apps/web`**
- New `GardenClubSection` on the profile page with status-specific copy + actions (cancel / resume / past-due "email us" stopgap / "join again")
- Cancel confirmation modal mirroring the existing delete-account pattern
- "Cancel anytime from your profile" hint on the donate page in Garden Club mode
- Type + build clean

**Contracts**
- OpenAPI documents both endpoints and a `GardenClubMutationResponse` schema
- 4 new Postman YAML cases for unauth + invalid-token coverage

## Why
[#283](https://github.com/allenheltondev/olivias-garden-foundation/issues/283) is a launch-blocker from the recent readiness audit: a recurring charge donors can't cancel from the site is both a UX problem and a CCPA/auto-renew-law problem. This is the smallest end-to-end slice that solves it cleanly.

## Out of scope (intentional)
- **Past-due recovery** (Stripe Customer Portal for self-serve payment-method updates) — flagged as a follow-up. The profile UI shows a "email us" stopgap for `past_due` until that ships.
- **Donor cancellation email** — Stripe sends one through its built-in customer emails when `cancel_at_period_end` is set; we publish an internal Slack notification.

## Reviewer notes
1. The `canceling` state was a deliberate design choice over inferring from `cancel_at` alone — keeps donor-visible status (`Active` / `Ending {date}` / `Past due` / `Canceled`) clean and lets the frontend logic stay simple.
2. The Stripe partner event integration must include `customer.subscription.updated` in the events forwarded to our event bus. The new EventBridge rule entry is a no-op until that's confirmed in the Stripe Dashboard.
3. Migration runs cleanly: drops the existing anonymous CHECK constraint by name (`users_garden_club_status_check` is the PG-default for an inline column-level CHECK from `ADD COLUMN ... CHECK (...)`) and adds the new one with the extra value.

## Test plan
- [ ] Confirm `customer.subscription.updated` is in the Stripe → EventBridge event types
- [ ] Run `services/web-api/db/migrations/0005_garden_club_canceling_state.sql` on staging
- [ ] Smoke test on staging: enroll in Garden Club with a Stripe test card → cancel from profile → verify status flips to `canceling` and `garden_club_cancel_at` is set → resume → verify `active` again
- [ ] Advance Stripe test-mode time past period end → verify `customer.subscription.deleted` flips status to `canceled`
- [ ] Verify Slack channel receives the three lifecycle messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)