### PR TITLE
Fix homepage CTAs and prerender/sitemap drift (#277, #278)

### DIFF
--- a/apps/web/scripts/seo-data.mjs
+++ b/apps/web/scripts/seo-data.mjs
@@ -204,24 +204,6 @@ export const seoRoutes = [
     `,
   },
   {
-    path: '/seeds',
-    title: 'Request free okra seeds',
-    description:
-      "Request free okra seeds from Olivia's Garden Foundation and join a growing food project rooted in Olivia's seed line.",
-    seoImage: defaultImage,
-    prerender: true,
-    canonicalPath: '/okra',
-    sitemap: { changefreq: 'weekly', priority: 0.6 },
-    bodyFallback: `
-      <h1>Request free okra seeds</h1>
-      <p>
-        Olivia's Garden Foundation mails free okra seeds, grown from Olivia Helton's own
-        seed line, to anyone who wants to grow them. Visit <a href="/okra">The Okra Project</a>
-        to fill out the short request form.
-      </p>
-    `,
-  },
-  {
     path: '/okra',
     title: 'The Okra Project',
     description:

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -34,9 +34,11 @@ export function HomePage({ onNavigate }: { onNavigate: (path: string) => void; }
         actions={(
           <a
             className="home-hero__cta"
-            href="https://instagram.com/oliviasgardentx"
-            target="_blank"
-            rel="noreferrer"
+            href="/get-involved"
+            onClick={(event) => {
+              event.preventDefault();
+              onNavigate('/get-involved');
+            }}
           >
             Get involved
           </a>
@@ -497,7 +499,7 @@ export function ImpactPage({ onNavigate }: { onNavigate: (path: string) => void;
         title="See it as it happens."
         body="The best way to understand the foundation is to see the work as it happens: what is growing, what is getting built, what worked, and what had to be adjusted."
       >
-        <CtaButton variant="secondary">Follow on Instagram</CtaButton>
+        <CtaButton variant="secondary" href={instagramUrl}>Follow on Instagram</CtaButton>
       </Section>
     </>
   );

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -64,6 +64,7 @@ export const routes: AppRoute[] = [
     title: 'The Okra Project',
     description: 'Explore the Okra Project map, request seeds, and follow a public invitation to grow food and share the story back.',
     seoImage: socialShareImage,
+    prerender: true,
   },
   {
     path: '/good-roots',
@@ -90,6 +91,7 @@ export const routes: AppRoute[] = [
     title: "Support Olivia's Garden",
     description: "Donate to Olivia's Garden Foundation through one-time gifts or Garden Club recurring support, with a permanent named garden marker for every donor.",
     seoImage: socialShareImage,
+    prerender: true,
   },
   {
     path: '/profile',


### PR DESCRIPTION
## Summary
- **#277 Bug 1**: Impact page "Follow on Instagram" `CtaButton` had no `href` — clicking did nothing. Wired to the existing `instagramUrl` constant, matching the pattern already used on the Get Involved page.
- **#277 Bug 2**: Home hero "Get involved" was labelled for `/get-involved` but the `<a>` linked to Instagram. Now navigates to `/get-involved` via `onNavigate`, so the label and destination agree.
- **#278**: Removed the stale `/seeds` entry from `seo-data.mjs` (it's a runtime redirect to `/okra` in `App.tsx`, not a real page — prerender was still emitting `dist/seeds/index.html`). Added `prerender: true` to `/okra` and `/donate` in `routes.ts` so the runtime route table matches what the build actually prerenders.

## Why
Both issues were P0 launch-readiness audit findings.

The `/donate` social-card concern in #278 was already silently fine (seo-data.mjs prerenders `/donate` even though `routes.ts` didn't claim it did). The drift between the two files is the real risk — these patches eliminate it on the routes the issue called out.

## Notes for reviewer
- `routes.ts` and `apps/web/scripts/seo-data.mjs` are still maintained as parallel sources. The issue author noted a CI guard for this drift as a follow-up — not addressed here.
- The `canonicalPath` mechanism in the prerender/sitemap scripts is now unused (no remaining alias routes). Left in place; it's a general feature.
- No browser verification on the CTA changes — they're simple href swaps that should be spot-checked before merging.

## Test plan
- [ ] `cd apps/web && npm run typecheck` (passes locally)
- [ ] Build the web app and confirm `dist/seeds/index.html` is no longer produced
- [ ] Confirm `dist/sitemap.xml` lists `/`, `/about`, `/get-involved`, `/okra`, `/impact`, `/donate`, `/contact`, `/privacy`, `/terms`, `/data` (and excludes `/good-roots`)
- [ ] Spot-check homepage hero — clicking "Get involved" routes to `/get-involved`
- [ ] Spot-check Impact page — clicking "Follow on Instagram" opens Instagram

Closes #277
Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)