### PR TITLE
GA4 cookieless consent mode + privacy policy update (#279)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -41,11 +41,22 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js) — Consent Mode v2, default denied (cookieless analytics) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-MKLN0PPMJZ"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+
+      gtag('consent', 'default', {
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'denied',
+        personalization_storage: 'denied',
+        security_storage: 'granted',
+      });
+
       gtag('js', new Date());
 
       gtag('config', 'G-MKLN0PPMJZ', { send_page_view: false });

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -524,7 +524,7 @@ export function PrivacyPolicyPage() {
   return (
     <LegalDocument
       title="Privacy Policy"
-      effectiveDate="April 23, 2026"
+      effectiveDate="April 30, 2026"
       intro={(
         <p>
           This policy explains what information Olivia&apos;s Garden Foundation collects, how we
@@ -596,10 +596,15 @@ export function PrivacyPolicyPage() {
 
       <LegalSection id="cookies-and-analytics" number={6} title="Cookies and analytics">
         <p>
-          We and our service providers may use cookies, local storage, pixels, and similar
-          technologies to keep you signed in, remember preferences, understand site usage, measure
-          campaign effectiveness, and improve performance. You can control cookies through your
-          browser settings, though some site features may not function properly if disabled.
+          We use Google Analytics 4 to understand site usage in aggregate. Analytics runs in
+          cookieless mode by default through Google Consent Mode v2: storage of analytics and
+          advertising identifiers is denied unless you tell us otherwise, and Google receives only
+          anonymous, aggregated pings without writing analytics cookies to your device.
+        </p>
+        <p>
+          When you sign in to an account, we use storage that is strictly necessary to keep you
+          signed in and remember session preferences. You can further control storage through your
+          browser settings, though some signed-in features may not function properly if disabled.
         </p>
       </LegalSection>
 

--- a/apps/web/tests/analytics-consent.spec.ts
+++ b/apps/web/tests/analytics-consent.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { gotoAndWait } from './test-helpers';
+
+type DataLayerEntry = unknown[];
+
+test.describe('analytics consent mode', () => {
+  test('default consent is denied before any GA config call, and no GA cookies are written', async ({ page, context }) => {
+    await context.clearCookies();
+    await gotoAndWait(page, '/');
+
+    const dataLayer = (await page.evaluate(() => {
+      const layer = (window as unknown as { dataLayer?: DataLayerEntry[] }).dataLayer;
+      return layer ? layer.map((entry) => Array.from(entry)) : [];
+    })) as DataLayerEntry[];
+
+    const firstConsentDefaultIndex = dataLayer.findIndex(
+      (entry) => entry[0] === 'consent' && entry[1] === 'default',
+    );
+    expect(firstConsentDefaultIndex, 'gtag("consent", "default", ...) must be in dataLayer').toBeGreaterThanOrEqual(0);
+
+    const firstGaConfigIndex = dataLayer.findIndex(
+      (entry) => entry[0] === 'config' && typeof entry[1] === 'string' && entry[1].startsWith('G-'),
+    );
+    if (firstGaConfigIndex >= 0) {
+      expect(firstConsentDefaultIndex).toBeLessThan(firstGaConfigIndex);
+    }
+
+    const consentParams = dataLayer[firstConsentDefaultIndex]?.[2] as Record<string, string> | undefined;
+    expect(consentParams).toBeTruthy();
+    expect(consentParams?.analytics_storage).toBe('denied');
+    expect(consentParams?.ad_storage).toBe('denied');
+    expect(consentParams?.ad_user_data).toBe('denied');
+    expect(consentParams?.ad_personalization).toBe('denied');
+
+    const cookies = await context.cookies();
+    const gaCookies = cookies.filter((cookie) => cookie.name === '_ga' || cookie.name.startsWith('_ga_'));
+    expect(gaCookies, `Unexpected GA cookies set: ${gaCookies.map((c) => c.name).join(', ')}`).toEqual([]);
+  });
+});

--- a/apps/web/tests/legal.spec.ts
+++ b/apps/web/tests/legal.spec.ts
@@ -6,7 +6,7 @@ test.describe('legal pages', () => {
     await gotoAndWait(page, '/privacy');
 
     await expect(page.getByRole('heading', { name: 'Privacy Policy', level: 1 })).toBeVisible();
-    await expect(page.locator('.legal-document__effective')).toContainText('April 23, 2026');
+    await expect(page.locator('.legal-document__effective')).toContainText('April 30, 2026');
 
     const footerLink = page.locator('footer').getByRole('link', { name: 'Terms of Service' });
     await expect(footerLink).toBeVisible();


### PR DESCRIPTION
Closes #279.

## Summary
- Configures Google Consent Mode v2 with all storage defaulted to `denied` (except `security_storage`) before any `gtag` config call, so GA4 runs in **cookieless** mode on first visit. No banner — per the issue's low-friction recommended path.
- Privacy Policy section 6 ("Cookies and analytics") rewritten to accurately describe what we actually do (cookieless GA4 + strictly-necessary storage for sign-in only). Effective date bumped to April 30, 2026.
- New Playwright spec locks in the production guarantee.

## What changed
- `apps/web/index.html` — added `gtag('consent', 'default', { ... })` ahead of `gtag('js', ...)` and `gtag('config', ...)`. Dropped `wait_for_update` since we never call `gtag('consent', 'update', ...)` (no banner = nothing to wait for).
- `apps/web/src/site/pages/content-pages.tsx` — rewrote section 6 of the Privacy Policy; bumped effective date.
- `apps/web/tests/legal.spec.ts` — date assertion follows the bump.
- `apps/web/tests/analytics-consent.spec.ts` — **new** test asserting:
  1. `gtag('consent', 'default', ...)` is in `dataLayer` and runs *before* any `gtag('config', 'G-...')` call (ordering invariant — if a future edit reorders these, GA could initialize before consent is set).
  2. The denied flags (`analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`) are all `'denied'`.
  3. No `_ga` / `_ga_*` cookies exist after page load — the actual production guarantee, not just dataLayer wiring.

## Why no banner
The issue offered two paths and explicitly listed "skip the banner and rely on consent-mode-defaults-denied" as acceptable for nonprofit analytics. GA4 still receives anonymous, aggregated pings, no cookies are written, and there's no UI friction. The privacy policy now matches this behavior.

## Note on stale GA cookies
Returning visitors with pre-existing `_ga` cookies aren't cleaned up by consent-mode-denied alone. **Not an issue here — the page isn't live yet**, so there are no returning visitors. If we ever change consent mode after launch, we'd want to expire those cookies on first load post-deploy.

## Test plan
- [ ] CI Playwright run passes `analytics-consent.spec.ts` against staging.
- [ ] CI Playwright run passes the updated `legal.spec.ts` (April 30, 2026 effective date).
- [ ] Manual: load `/` in a fresh browser session against staging, confirm DevTools → Application → Cookies shows no `_ga*` entries, and DevTools → Network shows GA pings going out (consent-mode pings still fire — just cookieless).
- [ ] Manual: visit `/privacy`, confirm section 6 wording reads correctly and effective date is April 30, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)