### PR TITLE
Gate GRN paid tiers behind 'coming soon' (#288)

### DIFF
--- a/apps/web/scripts/seo-data.mjs
+++ b/apps/web/scripts/seo-data.mjs
@@ -346,10 +346,10 @@ export const seoRoutes = [
         <li>Gather what you need from nearby listings, claim it, and pick it up directly from the grower.</li>
       </ol>
       <p>
-        Tiers: Free includes one garden, basic planner, browsing, and your neighborhood food
-        map. Supporter ($10/month) adds multiple gardens, season history, and advanced planning.
-        Pro ($50/month, 30-day free trial) adds AI planting recommendations based on local gaps,
-        season-aware timing, and troubleshooting help.
+        Free is live today: one garden, basic planner, browsing, and your neighborhood food map.
+        Paid Supporter and Pro tiers are in the works and will add things like multiple gardens,
+        season history, advanced planning, and AI planting recommendations based on local gaps.
+        Sign up on the page to be notified when they open.
       </p>
     `,
   },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -832,6 +832,21 @@ html {
   align-items: stretch;
 }
 
+.good-roots-tiers--two {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr);
+}
+
+.good-roots-tier--coming-soon p {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.good-roots-tier-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
 .good-roots-tier {
   display: grid;
   gap: 0.75rem;
@@ -917,7 +932,8 @@ html {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .good-roots-tiers {
+  .good-roots-tiers,
+  .good-roots-tiers--two {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -1084,18 +1084,95 @@ function heroForSession(session: AuthSession | null): GoodRootsHeroCopy {
   if (tier === 'supporter') {
     return {
       title: 'Thanks for keeping the network growing.',
-      body: 'Want the full toolkit? Pro adds AI planting recommendations and local gap signals for $50/month, with a 30-day free trial on us.',
-      primary: { label: 'Try Pro free for 30 days', href: '#tiers', internal: true },
-      secondary: { label: 'Open Good Roots Network', href: appHref },
+      body: "Pro is in the works — AI planting recommendations and local gap signals are coming soon. We'll let you know the moment they open up.",
+      primary: { label: 'Open Good Roots Network', href: appHref },
+      secondary: { label: 'Hear when Pro opens', href: '#tiers', internal: true },
     };
   }
 
   return {
     title: "You're in. Now grow with the whole network behind you.",
-    body: "Your Olivia's Garden account already works in Good Roots. Upgrade to Pro for AI planting recommendations tuned to your neighborhood — free for 30 days, then $50/month.",
-    primary: { label: 'Start my 30-day Pro trial', href: '#tiers', internal: true },
-    secondary: { label: 'Open Good Roots Network', href: appHref },
+    body: "Your Olivia's Garden account already works in Good Roots. Paid tiers with AI planting recommendations and gap signals are coming — get on the list and we'll tell you when they're live.",
+    primary: { label: 'Open Good Roots Network', href: appHref },
+    secondary: { label: 'Hear when paid tiers open', href: '#tiers', internal: true },
   };
+}
+
+type TierInterestChoice = 'supporter' | 'pro' | 'either';
+
+function TierInterestForm({
+  tier = 'either',
+  source,
+  submitLabel = 'Notify me when paid tiers open',
+}: {
+  tier?: TierInterestChoice;
+  source: string;
+  submitLabel?: string;
+}) {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const canSubmit = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+
+  const clearFeedback = () => {
+    if (feedback) setFeedback(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit || submitting) return;
+
+    setSubmitting(true);
+    setFeedback(null);
+
+    try {
+      const response = await fetch(`${webApiBase}/contact`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          kind: 'tier_interest',
+          email: email.trim(),
+          tier,
+          source,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Submission failed (${response.status})`);
+      }
+
+      setFeedback({
+        type: 'success',
+        message: "Thanks. We'll email you the moment paid tiers open up.",
+      });
+      setEmail('');
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: error instanceof Error ? error.message : "We couldn't sign you up. Please try again.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="contact-form good-roots-tier-form" onSubmit={handleSubmit} noValidate>
+      <Input
+        type="email"
+        label="Email"
+        value={email}
+        onChange={(event) => { clearFeedback(); setEmail(event.target.value); }}
+        required
+        autoComplete="email"
+      />
+      <Button type="submit" disabled={!canSubmit} loading={submitting}>
+        {submitting ? 'Submitting...' : submitLabel}
+      </Button>
+      {feedback ? <FormFeedback tone={feedback.type}>{feedback.message}</FormFeedback> : null}
+    </form>
+  );
 }
 
 function OrganizationInquiryForm() {
@@ -1383,8 +1460,8 @@ export function GoodRootsPage({
         <div className="good-roots-map-placeholder" aria-hidden="true" />
       </Section>
 
-      <Section id="tiers" title="Pick the plot that fits you." intro="All tiers come with your Olivia's Garden account. Supporter and Pro help keep the network free for families and food organizations.">
-        <div className="good-roots-tiers">
+      <Section id="tiers" title="Pick the plot that fits you." intro="Free is live today. Supporter and Pro tiers are on the way — leave your email and we'll tell you the moment they open.">
+        <div className="good-roots-tiers good-roots-tiers--two">
           <article className={`good-roots-tier${tier === 'free' ? ' good-roots-tier--current' : ''}`}>
             <header>
               <p className="good-roots-tier__eyebrow">Free</p>
@@ -1398,37 +1475,17 @@ export function GoodRootsPage({
             </ul>
           </article>
 
-          <article className={`good-roots-tier${tier === 'supporter' ? ' good-roots-tier--current' : ''}`}>
+          <article className="good-roots-tier good-roots-tier--featured good-roots-tier--coming-soon">
             <header>
-              <p className="good-roots-tier__eyebrow">Supporter</p>
-              <p className="good-roots-tier__price">$10/month</p>
+              <p className="good-roots-tier__eyebrow">Supporter & Pro — coming soon</p>
+              <p className="good-roots-tier__price">In the works</p>
             </header>
-            <ul className="site-list">
-              <li>Everything in Free</li>
-              <li>Multiple gardens and season history</li>
-              <li>Advanced planner with crop rotation</li>
-              <li>Priority placement when you have surplus</li>
-              <li>Your support keeps the network free for families and food organizations</li>
-            </ul>
-          </article>
-
-          <article className={`good-roots-tier good-roots-tier--featured${tier === 'pro' ? ' good-roots-tier--current' : ''}`}>
-            <header>
-              <p className="good-roots-tier__eyebrow">Pro</p>
-              <p className="good-roots-tier__price">$50/month · 30-day free trial</p>
-            </header>
-            <ul className="site-list">
-              <li>Everything in Supporter</li>
-              <li>AI planting recommendations based on local gaps</li>
-              <li>Season-aware timing and rotation guidance</li>
-              <li>Scarcity and abundance signals for every crop</li>
-              <li>Troubleshooting help when something's off in the garden</li>
-            </ul>
-            <p className="good-roots-tier__note">
-              {authSession
-                ? 'Start your 30-day trial from inside the app.'
-                : 'Start your 30-day trial after you create your account.'}
+            <p>
+              We're building out the paid tiers that will keep the network free for families and food
+              organizations, with extras like AI planting recommendations, local gap signals, and
+              multi-garden tracking. Get on the list and we'll email you the moment they open.
             </p>
+            <TierInterestForm tier="either" source="good-roots-tiers" />
           </article>
         </div>
       </Section>

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -69,6 +69,7 @@ export const routes: AppRoute[] = [
   {
     path: '/good-roots',
     label: 'Good Roots Network',
+    showInNav: true,
     title: 'Good Roots Network',
     description: 'A community platform that connects home growers with neighbors and organizations who need fresh food. Plan your garden, see local food gaps, and share what you have extra.',
     seoImage: socialShareImage,

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -168,7 +168,8 @@ const primaryPageOrder = new Map([
   ['/', 0],
   ['/okra', 1],
   ['/donate', 2],
-  ['/about', 3],
+  ['/good-roots', 3],
+  ['/about', 4],
 ]);
 
 function byPrimaryPageOrder(left: AppRoute, right: AppRoute) {

--- a/services/web-api/src/handlers/api.mjs
+++ b/services/web-api/src/handlers/api.mjs
@@ -21,7 +21,12 @@ import {
   completeAvatarUpload,
   createAvatarUploadIntent
 } from '../services/avatar.mjs';
-import { contactInquirySchema, submitContactInquiry } from '../services/contact.mjs';
+import {
+  contactInquirySchema,
+  submitContactInquiry,
+  submitTierInterestInquiry,
+  tierInterestSchema
+} from '../services/contact.mjs';
 import {
   corsHeaders,
   errorResponse,
@@ -275,9 +280,11 @@ app.post('/profile/garden-club/resume', async ({ event }) => {
 app.post('/contact', async ({ req, event }) => {
   const correlationId = getCorrelationId(event);
   const payload = await req.json();
+  const isTierInterest = payload?.kind === 'tier_interest';
+  const schema = isTierInterest ? tierInterestSchema : contactInquirySchema;
 
   try {
-    validate({ payload, schema: contactInquirySchema });
+    validate({ payload, schema });
   } catch (error) {
     if (error instanceof SchemaValidationError) {
       logger.warn('Contact inquiry validation failed', {
@@ -300,7 +307,11 @@ app.post('/contact', async ({ req, event }) => {
   }
 
   try {
-    await submitContactInquiry(payload, correlationId);
+    if (isTierInterest) {
+      await submitTierInterestInquiry(payload, correlationId);
+    } else {
+      await submitContactInquiry(payload, correlationId);
+    }
     return {
       statusCode: 204,
       headers: { 'x-correlation-id': correlationId }

--- a/services/web-api/src/services/contact.mjs
+++ b/services/web-api/src/services/contact.mjs
@@ -20,6 +20,18 @@ export const contactInquirySchema = {
   }
 };
 
+export const tierInterestSchema = {
+  type: 'object',
+  required: ['kind', 'email', 'tier'],
+  additionalProperties: false,
+  properties: {
+    kind: { type: 'string', enum: ['tier_interest'] },
+    email: { type: 'string', minLength: 3, maxLength: 320 },
+    tier: { type: 'string', enum: ['supporter', 'pro', 'either'] },
+    source: { type: 'string', maxLength: 80 }
+  }
+};
+
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function sanitize(value) {
@@ -102,6 +114,41 @@ async function publishGeneralInquiryEvent(payload, correlationId, eventBridgeCli
   }
 }
 
+async function publishTierInterestEvent(payload, correlationId, eventBridgeClient) {
+  try {
+    const result = await eventBridgeClient.send(new PutEventsCommand({
+      Entries: [
+        {
+          Source: 'ogf.contact',
+          DetailType: 'tier-interest.received',
+          Detail: JSON.stringify({
+            email: sanitize(payload.email),
+            tier: sanitize(payload.tier),
+            source: sanitize(payload.source) || null,
+            correlationId
+          })
+        }
+      ]
+    }));
+
+    if ((result?.FailedEntryCount ?? 0) > 0) {
+      console.error(JSON.stringify({
+        level: 'error',
+        correlationId,
+        message: 'Tier interest EventBridge publish reported failed entries',
+        failedEntryCount: result.FailedEntryCount
+      }));
+    }
+  } catch (error) {
+    console.error(JSON.stringify({
+      level: 'error',
+      correlationId,
+      message: 'Tier interest EventBridge publish failed',
+      error: error instanceof Error ? error.message : String(error)
+    }));
+  }
+}
+
 export async function submitContactInquiry(payload, correlationId, { eventBridgeClient = eventBridge } = {}) {
   if (!['organization_inquiry', 'general_inquiry'].includes(payload?.kind)) {
     throw new Error('Unsupported contact kind');
@@ -125,4 +172,20 @@ export async function submitContactInquiry(payload, correlationId, { eventBridge
   }
 
   await publishGeneralInquiryEvent(payload, correlationId, eventBridgeClient);
+}
+
+export async function submitTierInterestInquiry(payload, correlationId, { eventBridgeClient = eventBridge } = {}) {
+  if (payload?.kind !== 'tier_interest') {
+    throw new Error('Unsupported contact kind');
+  }
+
+  if (!EMAIL_PATTERN.test(sanitize(payload.email))) {
+    throw new Error('email must be a valid email address');
+  }
+
+  if (!['supporter', 'pro', 'either'].includes(sanitize(payload.tier))) {
+    throw new Error('tier must be one of supporter, pro, either');
+  }
+
+  await publishTierInterestEvent(payload, correlationId, eventBridgeClient);
 }

--- a/services/web-api/src/services/http.mjs
+++ b/services/web-api/src/services/http.mjs
@@ -63,6 +63,7 @@ export function mapApiError(error, correlationId) {
     || message.includes('email must be a valid email address')
     || message.includes('contactName is required')
     || message.includes('message is required')
+    || message.includes('tier must be one of supporter, pro, either')
   ) {
     return errorResponse(400, message, correlationId);
   }

--- a/services/web-api/test/contact.test.mjs
+++ b/services/web-api/test/contact.test.mjs
@@ -124,4 +124,45 @@ describe('POST /contact', () => {
     expect(response.statusCode).toBe(400);
     expect(eventBridgeSendMock).not.toHaveBeenCalled();
   });
+
+  it('accepts a tier_interest signup and publishes a tier-interest event', async () => {
+    const response = await handler(createEvent({
+      kind: 'tier_interest',
+      email: 'grower@example.com',
+      tier: 'pro',
+      source: 'good-roots-tiers'
+    }));
+
+    expect(response.statusCode).toBe(204);
+    expect(eventBridgeSendMock).toHaveBeenCalledTimes(1);
+    const command = eventBridgeSendMock.mock.calls[0][0];
+    const entry = command.input.Entries[0];
+    expect(entry.Source).toBe('ogf.contact');
+    expect(entry.DetailType).toBe('tier-interest.received');
+    const detail = JSON.parse(entry.Detail);
+    expect(detail.email).toBe('grower@example.com');
+    expect(detail.tier).toBe('pro');
+    expect(detail.source).toBe('good-roots-tiers');
+  });
+
+  it('returns 422 when tier_interest is missing the tier field', async () => {
+    const response = await handler(createEvent({
+      kind: 'tier_interest',
+      email: 'grower@example.com'
+    }));
+
+    expect(response.statusCode).toBe(422);
+    expect(eventBridgeSendMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when tier_interest tier is invalid', async () => {
+    const response = await handler(createEvent({
+      kind: 'tier_interest',
+      email: 'grower@example.com',
+      tier: 'enterprise'
+    }));
+
+    expect(response.statusCode).toBe(422);
+    expect(eventBridgeSendMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Replaces the Supporter and Pro tier cards on `/good-roots` with a single "Supporter & Pro — coming soon" card that captures email signups via a new `tier_interest` kind on `POST /contact`.
- Drops the "30-day free trial" promises from the hero CTAs (free + supporter session variants) since the auth context reads tier from Cognito groups and Stripe webhooks only update the DB — a Pro checkout doesn't currently unlock Pro in-session.
- Updates the prerendered `noscript` body fallback in `seo-data.mjs` so crawlers/LLMs see the new coming-soon copy instead of the old pricing.

The full instrumentation work (Cognito↔DB tier sync, Supporter checkout, trial UX, tier-gated endpoints) is tracked in #303.

Closes #288.

## Test plan
- [x] `npm --workspace @olivias/web-api run test` — 43/43 pass, including 3 new `tier_interest` cases (success, missing tier → 422, invalid tier value → 422)
- [x] `npm --workspace @olivias/web run typecheck`
- [x] `npm --workspace @olivias/web run build` — `check-prerender-drift` clean, prerender + sitemap regenerated
- [x] Manual smoke at `/good-roots` in `vite dev`: two cards render with right copy, email-capture form present, no "30-day" text remains anywhere on the page
- [ ] Reviewer: confirm hero CTA copy lands well for free / supporter / pro signed-in states

🤖 Generated with [Claude Code](https://claude.com/claude-code)