### PR TITLE
Donate flow: tax-deductible language + receipt promise (#275)

### DIFF
--- a/apps/web/src/site/pages/DonatePage.tsx
+++ b/apps/web/src/site/pages/DonatePage.tsx
@@ -438,8 +438,16 @@ export function DonatePage({
               to add the donor&apos;s permanent bee to the garden.
             </p>
             {checkoutStatus.customerEmail ? (
-              <p>A receipt should be on its way to {checkoutStatus.customerEmail}.</p>
-            ) : null}
+              <p>
+                A tax-deductible receipt has been emailed to {checkoutStatus.customerEmail}.{' '}
+                {foundationOrganization.legalName}, EIN {foundationOrganization.ein}.
+              </p>
+            ) : (
+              <p>
+                A tax-deductible receipt is on its way. {foundationOrganization.legalName},
+                EIN {foundationOrganization.ein}.
+              </p>
+            )}
             <div className="donate-status-card__actions">
               <Button className="site-cta" variant="secondary" onClick={resetCheckoutExperience}>Make another gift</Button>
               <CtaButton
@@ -607,7 +615,8 @@ export function DonatePage({
                       {selectedMode === 'recurring' ? 'Garden Club' : 'One-time donation'}: ${(effectiveAmount / 100).toFixed(2)}
                     </p>
                     <p className="donate-form-card__legal-note">
-                      {foundationOrganization.legalName}, EIN {foundationOrganization.ein}
+                      {foundationOrganization.legalName} is a 501(c)(3) nonprofit (EIN {foundationOrganization.ein}).
+                      Donations are tax-deductible to the extent permitted by law.
                     </p>
                     <p className="page-text">
                       {selectedMode === 'recurring'

--- a/apps/web/tests/foundation-disclosures.spec.ts
+++ b/apps/web/tests/foundation-disclosures.spec.ts
@@ -15,11 +15,13 @@ test.describe('foundation disclosures', () => {
     await expect(footer).toContainText("©2026 Olivia's Garden Foundation. All rights reserved.");
   });
 
-  test('donate page surfaces the EIN near the gift action', async ({ page }) => {
+  test('donate page surfaces the EIN and tax-deductible language near the gift action', async ({ page }) => {
     await gotoAndWait(page, '/donate');
 
     const donateForm = page.locator('.donate-form-card');
-    await expect(donateForm).toContainText(`Olivia's Garden Foundation, EIN ${FOUNDATION_EIN}`);
+    await expect(donateForm).toContainText('501(c)(3)');
+    await expect(donateForm).toContainText(`EIN ${FOUNDATION_EIN}`);
+    await expect(donateForm).toContainText('tax-deductible');
     await expect(donateForm.getByRole('button', { name: 'Make donation' })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- The donate form's legal note now explicitly states the foundation is a 501(c)(3) and donations are tax-deductible to the extent permitted by law (previously just legal name + EIN, no tax-deductible language anywhere on the page).
- The success state replaces the vague "A receipt should be on its way to {email}" with an explicit "A tax-deductible receipt has been emailed to {email}. {legalName}, EIN {ein}." plus a fallback path for cases where Stripe doesn't return a customer email.
- The Garden Club cancel-anytime mention from #275's third bullet already shipped, so this finishes the remaining two acceptance items.

Closes #275.

## Test plan
- [x] `npm --workspace @olivias/web run typecheck`
- [x] `npm --workspace @olivias/web run build` (drift check + prerender + sitemap clean)
- [x] Manual smoke at `/donate` in `vite dev`: form-side legal note renders with "501(c)(3)", "tax-deductible", and EIN `33-3101032`. Success-state JSX is a static string render of the same `foundationOrganization` constants used on the form, so verified by inspection rather than mocking the Stripe redirect.
- [ ] Reviewer: confirm the wording is acceptable for IRS substantiation (no specific phrasing required, but "to the extent permitted by law" is the conventional hedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)