### PR TITLE
Fix okra photo uploads: strip /okra base path before router resolves

### DIFF
--- a/services/okra-api/src/handlers/admin-api.mjs
+++ b/services/okra-api/src/handlers/admin-api.mjs
@@ -23,4 +23,4 @@ app.notFound(() => {
   );
 });
 
-export const handler = createHttpRouterHandler({ app, handlerName: 'admin-api' });
+export const handler = createHttpRouterHandler({ app, handlerName: 'admin-api', basePath: '/okra-admin' });

--- a/services/okra-api/src/handlers/api.mjs
+++ b/services/okra-api/src/handlers/api.mjs
@@ -359,7 +359,7 @@ app.post('/requests', async ({ req, event }) => {
   }
 });
 
-app.get('/okra', async () => {
+app.get('/', async () => {
   const cdnDomain = process.env.MEDIA_CDN_DOMAIN;
   if (!cdnDomain) {
     console.error(JSON.stringify({
@@ -451,7 +451,7 @@ app.get('/okra', async () => {
   }
 });
 
-app.get('/okra/stats', async () => {
+app.get('/stats', async () => {
   const client = await createDbClient();
   await client.connect();
   try {
@@ -649,4 +649,4 @@ app.notFound(() => {
   );
 });
 
-export const handler = createHttpRouterHandler({ app, handlerName: 'public-api' });
+export const handler = createHttpRouterHandler({ app, handlerName: 'public-api', basePath: '/okra' });

--- a/services/okra-api/src/services/http-handler.mjs
+++ b/services/okra-api/src/services/http-handler.mjs
@@ -1,20 +1,35 @@
 import { corsHeaders, errorResponse } from './pagination.mjs';
 
-function normalizePath(path, stage) {
-  if (!path || !stage) {
+function stripPrefix(path, prefix) {
+  if (!path || !prefix) {
     return path;
   }
 
-  const stagePrefix = `/${stage}`;
-  if (path === stagePrefix) {
+  if (path === prefix) {
     return '/';
   }
 
-  if (path.startsWith(`${stagePrefix}/`)) {
-    return path.slice(stagePrefix.length);
+  if (path.startsWith(`${prefix}/`)) {
+    return path.slice(prefix.length);
   }
 
   return path;
+}
+
+function normalizePath(path, stage, basePath) {
+  // Strip both the stage and the API Gateway custom-domain base path so the
+  // router resolves consistently whether the request arrives via the raw
+  // invoke URL (path includes `/${stage}`) or the custom domain (path
+  // includes the base path because REST API base-path mapping does not
+  // strip it before invoking the integration).
+  let normalized = path;
+  if (stage) {
+    normalized = stripPrefix(normalized, `/${stage}`);
+  }
+  if (basePath) {
+    normalized = stripPrefix(normalized, basePath);
+  }
+  return normalized;
 }
 
 function hasHeader(headers = {}, name) {
@@ -31,10 +46,11 @@ export function getCorrelationId(event = {}) {
   );
 }
 
-export function normalizeRouterEvent(event = {}) {
+export function normalizeRouterEvent(event = {}, options = {}) {
   const normalizedPath = normalizePath(
     event.path ?? event.rawPath ?? event.requestContext?.path,
-    event.requestContext?.stage
+    event.requestContext?.stage,
+    options.basePath
   );
 
   return {
@@ -116,10 +132,10 @@ function logHandlerError(handlerName, error, event) {
   }));
 }
 
-export function createHttpRouterHandler({ app, handlerName }) {
+export function createHttpRouterHandler({ app, handlerName, basePath }) {
   return async (event, context) => {
     const normalizedEvent = {
-      ...normalizeRouterEvent(event),
+      ...normalizeRouterEvent(event, { basePath }),
       lambdaContext: context
     };
 

--- a/services/okra-api/test/api/api-handler.test.ts
+++ b/services/okra-api/test/api/api-handler.test.ts
@@ -69,4 +69,20 @@ describe('api handler wrapper', () => {
     });
     expect(res.headers['x-correlation-id']).toBe('corr-123');
   });
+
+  it('strips the /okra base path so custom-domain requests reach the right route', async () => {
+    // Reproduces the prod symptom: API Gateway custom-domain base-path
+    // mapping forwards `/okra/photos` to the integration without stripping
+    // `/okra`, so the router must strip it before resolving the route.
+    const res = await handler(
+      makeRestApiEvent('/okra/photos', 'POST', {
+        'content-type': 'application/json'
+      })
+    );
+
+    // Without the basePath strip this returns 404 NOT_FOUND from
+    // app.notFound(); with it the request reaches POST /photos and is
+    // rejected only because the empty body fails JSON parsing.
+    expect(res.statusCode).not.toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary

- In production, `POST https://api.oliviasgarden.org/okra/photos` returns `404 {"error":{"code":"NOT_FOUND","message":"Route not found"}}` from the Powertools router's `app.notFound()`. The Lambda is reached, but the path the router sees doesn't match `/photos`.
- Root cause: the okra public API and admin API live behind a REST API custom-domain base-path mapping (`/okra` → stage `api`, `/okra-admin` → stage `admin`), but the base path is **not** stripped before the request reaches the integration. So `event.path` arrives as `/okra/photos`, not `/photos`.
- Confirmed empirically — the only routes that work in prod are the two that happen to include the prefix in their definition (`app.get('/okra')` and `app.get('/okra/stats')`, both returning 200 in prod). Every route registered without the prefix (`/photos`, `/submissions`, `/requests`, `/me/activity`, `/me/submissions`, `/me/submissions/:id`) is broken.

## Fix

- `normalizePath` in `services/okra-api/src/services/http-handler.mjs` now strips an optional `basePath` after the stage prefix. Helper `stripPrefix` is the shared building block.
- `createHttpRouterHandler` accepts a `basePath` option. The public API passes `'/okra'`; the admin API passes `'/okra-admin'`.
- The two prefixed routes (`app.get('/okra', …)` and `app.get('/okra/stats', …)`) are renamed to `/` and `/stats` so every route is now defined without the prefix and the strip happens once at the edge.

The strip is a no-op when the prefix isn't present, so raw invoke-URL requests (used by CI integration tests when `DomainName` isn't set) keep resolving correctly.

## Test plan

- [x] All 197 okra-api unit tests pass (`npm --prefix services/okra-api test`).
- [x] Lint clean (`npm --prefix services/okra-api run lint`).
- [x] New regression test in `test/api/api-handler.test.ts` invokes the handler with the exact prod path (`POST /okra/photos`) and asserts the response is not a 404 — only possible with the basePath strip in place.
- [ ] After deploy: hit `https://api.oliviasgarden.org/okra/photos` end-to-end via the upload flow and confirm a 201 with `photoId` / `uploadUrl`.
- [ ] After deploy: confirm `https://api.oliviasgarden.org/okra` and `/okra/stats` still return 200 (routes were renamed, behavior should be identical because the basePath strip turns the inbound `/okra` and `/okra/stats` into `/` and `/stats`).
- [ ] After deploy: spot-check at least one other previously-broken route (e.g. `GET /okra/me/submissions` or `POST /okra/submissions`) to confirm the fix is general, not just for `/photos`.

## Heads-up for reviewer

The admin API got the same treatment (`basePath: '/okra-admin'`) on the assumption it has the same custom-domain wiring. If admin endpoints have been quietly broken in prod with the same symptom, this fixes them too. If admin was somehow working, the change is still safe — the strip only triggers when the prefix is actually present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)