### PR TITLE
Okra: contributor delete + admin URL deduplication

### DIFF
--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -145,7 +145,11 @@ function getAdminApiBaseUrl(): string {
   if (!baseUrl) {
     throw new Error('Missing VITE_ADMIN_API_URL for admin app.');
   }
-  return trimTrailingSlash(baseUrl);
+  // Production deploys set this to `https://api.<domain>/admin` (the
+  // shared-API base-path mapping). Every call site appends `/admin/...`,
+  // so strip a trailing `/admin` here to avoid `/admin/admin/...` URLs.
+  // In dev (raw invoke URL ends in `/api`) the strip is a no-op.
+  return trimTrailingSlash(baseUrl).replace(/\/admin$/, '');
 }
 
 function getOkraAdminApiBaseUrl(): string {

--- a/apps/web/src/site/pages/OkraSubmissionsPage.tsx
+++ b/apps/web/src/site/pages/OkraSubmissionsPage.tsx
@@ -42,6 +42,18 @@ async function fetchOkraSubmissions(authSession: AuthSession): Promise<OkraSubmi
   return body.submissions ?? [];
 }
 
+async function deleteOkraSubmission(authSession: AuthSession, submissionId: string): Promise<void> {
+  const response = await fetch(okraApiUrl(`/me/submissions/${submissionId}`), {
+    method: 'DELETE',
+    headers: createOkraHeaders({ accessToken: authSession.accessToken }),
+  });
+
+  if (!response.ok && response.status !== 204) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.message ?? body?.error?.message ?? body?.error ?? 'Unable to delete your okra submission.');
+  }
+}
+
 function formatDate(value: string | null) {
   if (!value) return '';
   const date = new Date(value);
@@ -102,6 +114,17 @@ function PencilIcon({ className }: { className?: string }) {
   );
 }
 
+function TrashIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M9 3h6a1 1 0 0 1 1 1v1h4v2h-1.07l-1 12.14A2 2 0 0 1 15.94 21H8.06a2 2 0 0 1-2-1.86L5.07 7H4V5h4V4a1 1 0 0 1 1-1Zm1 4v11h2V7h-2Zm4 0v11h2V7h-2Z"
+      />
+    </svg>
+  );
+}
+
 export function OkraSubmissionsPage({
   authSession,
   authReady,
@@ -116,6 +139,31 @@ export function OkraSubmissionsPage({
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState<OkraSubmission | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<OkraSubmission | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleteSubmitting) return;
+    setDeleting(null);
+    setDeleteError(null);
+  }, [deleteSubmitting]);
+
+  const submitDeletion = useCallback(async () => {
+    if (!authSession || !deleting) return;
+    setDeleteSubmitting(true);
+    setDeleteError(null);
+    try {
+      await deleteOkraSubmission(authSession, deleting.id);
+      setSubmissions((current) => current.filter((entry) => entry.id !== deleting.id));
+      setNotice('Your okra submission was deleted.');
+      setDeleting(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Unable to delete your okra submission.');
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  }, [authSession, deleting]);
 
   useEffect(() => {
     if (authReady && !authSession) {
@@ -256,6 +304,18 @@ export function OkraSubmissionsPage({
                           Edit submission
                         </Button>
                       )}
+                      <Button
+                        type="button"
+                        variant="danger"
+                        onClick={() => {
+                          setNotice(null);
+                          setDeleteError(null);
+                          setDeleting(submission);
+                        }}
+                      >
+                        <TrashIcon className="okra-submission-card__btn-icon" />
+                        Delete
+                      </Button>
                     </footer>
                   </div>
                 </article>
@@ -277,6 +337,51 @@ export function OkraSubmissionsPage({
           void refresh();
         }}
       />
+
+      {deleting ? (
+        <div
+          className="profile-cancel-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="okra-delete-dialog-title"
+          aria-describedby="okra-delete-dialog-description"
+        >
+          <div
+            className="profile-cancel-dialog__backdrop"
+            onClick={closeDeleteDialog}
+            aria-hidden="true"
+          />
+          <div className="profile-cancel-dialog__panel" role="document">
+            <h2 id="okra-delete-dialog-title" className="profile-cancel-dialog__title">
+              Delete this okra submission?
+            </h2>
+            <p id="okra-delete-dialog-description" className="profile-cancel-dialog__body">
+              This permanently removes your pin from the map and deletes the photos and story you
+              shared. This cannot be undone &mdash; you can always submit again later.
+            </p>
+            {deleteError ? <FormFeedback tone="error">{deleteError}</FormFeedback> : null}
+            <div className="profile-cancel-dialog__actions">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={closeDeleteDialog}
+                disabled={deleteSubmitting}
+              >
+                Keep submission
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={() => void submitDeletion()}
+                disabled={deleteSubmitting}
+                loading={deleteSubmitting}
+              >
+                {deleteSubmitting ? 'Deleting…' : 'Yes, delete it'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/services/okra-api/src/handlers/api.mjs
+++ b/services/okra-api/src/handlers/api.mjs
@@ -8,6 +8,7 @@ import {
 import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
 import { validate } from '@aws-lambda-powertools/validation';
 import { SchemaValidationError } from '@aws-lambda-powertools/validation/errors';
+import { S3Client, DeleteObjectsCommand } from '@aws-sdk/client-s3';
 import { createDbClient } from '../../scripts/db-client.mjs';
 import {
   createPhotoUploadIntent,
@@ -17,6 +18,7 @@ import {
 import { enqueuePhotoProcessing } from '../services/photo-processing-queue.mjs';
 import { resolveOptionalContributor } from '../services/auth.mjs';
 import {
+  deleteContributorSubmission,
   enrichSubmissionPayload,
   insertPendingSubmissionWithPhotos,
   listContributorSubmissions,
@@ -73,6 +75,56 @@ import { fuzzCoordinates } from '../services/privacy-fuzzing.mjs';
 import { createHttpRouterHandler, getCorrelationId } from '../services/http-handler.mjs';
 
 const app = new Router();
+const s3 = new S3Client({});
+
+async function deletePhotoObjectsFromS3(photos, { submissionId, correlationId }) {
+  const objectsByBucket = Object.create(null);
+  for (const photo of photos) {
+    const pairs = [
+      [photo.original_s3_bucket, photo.original_s3_key],
+      [photo.normalized_s3_bucket, photo.normalized_s3_key],
+      [photo.thumbnail_s3_bucket, photo.thumbnail_s3_key]
+    ];
+    for (const [bucket, key] of pairs) {
+      if (bucket && key) {
+        if (!objectsByBucket[bucket]) objectsByBucket[bucket] = [];
+        objectsByBucket[bucket].push({ Key: key });
+      }
+    }
+  }
+
+  for (const [bucket, objects] of Object.entries(objectsByBucket)) {
+    for (let i = 0; i < objects.length; i += 1000) {
+      const batch = objects.slice(i, i + 1000);
+      try {
+        const result = await s3.send(new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: batch, Quiet: true }
+        }));
+
+        if (result.Errors && result.Errors.length > 0) {
+          console.error(JSON.stringify({
+            level: 'warn',
+            message: 'Partial S3 cleanup failure for contributor submission delete',
+            submissionId,
+            bucket,
+            failedKeys: result.Errors.map((e) => e.Key),
+            correlationId
+          }));
+        }
+      } catch (err) {
+        console.error(JSON.stringify({
+          level: 'warn',
+          message: 'S3 cleanup failed for contributor submission delete',
+          submissionId,
+          bucket,
+          error: err instanceof Error ? err.message : String(err),
+          correlationId
+        }));
+      }
+    }
+  }
+}
 
 app.post('/photos', async ({ req, event }) => {
   const payload = await req.json();
@@ -622,6 +674,49 @@ app.patch('/me/submissions/:id', async ({ req, event, params }) => {
       message: error instanceof Error ? error.message : String(error),
       errorName: error instanceof Error ? error.name : 'UnknownError',
       endpoint: 'PATCH /me/submissions/:id',
+      submissionId: params.id,
+      correlationId
+    }));
+    return errorResponse(500, 'INTERNAL_ERROR', 'An unexpected error occurred');
+  } finally {
+    await client?.end?.();
+  }
+});
+
+app.delete('/me/submissions/:id', async ({ event, params }) => {
+  const correlationId = getCorrelationId(event);
+  const authResult = await resolveOptionalContributor(event);
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  const cognitoSub = authResult.contributor?.sub;
+  if (!cognitoSub) {
+    return errorResponse(401, 'UNAUTHORIZED', 'Sign in to delete your okra submission');
+  }
+
+  let client;
+  try {
+    client = await createDbClient();
+    await client.connect();
+    const { photos } = await deleteContributorSubmission(client, params.id, cognitoSub);
+    await client.end();
+    client = null;
+
+    if (photos.length > 0) {
+      await deletePhotoObjectsFromS3(photos, { submissionId: params.id, correlationId });
+    }
+
+    return { statusCode: 204 };
+  } catch (error) {
+    if (error?.code === 'SUBMISSION_NOT_FOUND') {
+      return errorResponse(404, 'NOT_FOUND', 'Submission not found');
+    }
+    console.error(JSON.stringify({
+      level: 'error',
+      message: error instanceof Error ? error.message : String(error),
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+      endpoint: 'DELETE /me/submissions/:id',
       submissionId: params.id,
       correlationId
     }));

--- a/services/okra-api/src/services/submissions.mjs
+++ b/services/okra-api/src/services/submissions.mjs
@@ -462,3 +462,44 @@ export async function submitContributorSubmissionEdit(client, submissionId, cogn
     throw error;
   }
 }
+
+export async function deleteContributorSubmission(client, submissionId, cognitoSub) {
+  await client.query('begin');
+
+  try {
+    const submissionResult = await client.query(
+      `
+        select id
+          from submissions
+         where id = $1 and contributor_cognito_sub = $2
+         for update
+      `,
+      [submissionId, cognitoSub]
+    );
+
+    if (submissionResult.rowCount === 0) {
+      const error = new Error('Submission not found');
+      error.code = 'SUBMISSION_NOT_FOUND';
+      throw error;
+    }
+
+    const photoResult = await client.query(
+      `
+        select original_s3_bucket, original_s3_key,
+               normalized_s3_bucket, normalized_s3_key,
+               thumbnail_s3_bucket, thumbnail_s3_key
+          from submission_photos
+         where submission_id = $1
+      `,
+      [submissionId]
+    );
+
+    await client.query('delete from submissions where id = $1', [submissionId]);
+    await client.query('commit');
+
+    return { photos: photoResult.rows };
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  }
+}

--- a/services/okra-api/template.yaml
+++ b/services/okra-api/template.yaml
@@ -196,6 +196,12 @@ Resources:
                 - SharedAssetsBucketArn: !ImportValue OGF-AssetsBucketArn
             - Effect: Allow
               Action:
+                - s3:DeleteObject
+              Resource: !Sub
+                - '${SharedAssetsBucketArn}/*'
+                - SharedAssetsBucketArn: !ImportValue OGF-AssetsBucketArn
+            - Effect: Allow
+              Action:
                 - cognito-idp:GetUser
               Resource: '*'
             - Effect: Allow


### PR DESCRIPTION
## Summary

Two unrelated fixes from one session:

- **Okra contributor delete** — signed-in contributors can now remove their own okra submissions from the *Your okra submissions* page. New `DELETE /me/submissions/:id` endpoint mirrors the ownership check used by the existing PATCH (edit) route, hard-deletes the row (FK cascade cleans up edits/photos/reviews/edit_tokens), and best-effort deletes the photo objects from S3. Adds `s3:DeleteObject` to the public `ApiFunction` policy. UI gets a red **Delete** button next to **Edit** plus a confirmation dialog reusing the existing `profile-cancel-dialog` styles. Pending edits no longer block deletion (they continue to block editing).
- **Admin URL deduplication** — in production `VITE_ADMIN_API_URL=https://api.<domain>/admin` (from the shared-API `BasePath: admin` mapping), and every call site appends `/admin/...`, producing visibly wrong `…/admin/admin/activity?limit=25` URLs. Routing still worked because API Gateway absorbed one of the prefixes. Fix strips a trailing `/admin` in `getAdminApiBaseUrl()`. No-op in dev where the raw invoke URL ends in `/api`.

## Test plan
- [ ] `apps/web` typecheck passes (verified locally)
- [ ] `services/okra-api` vitest suite passes — 197/197 tests green (verified locally)
- [ ] Manual: as a signed-in user with an okra submission, visit *Your okra submissions*, click **Delete**, confirm in the dialog, and verify the card disappears, the success notice renders, and the pin no longer appears on the public okra map
- [ ] Manual: confirm the dialog cannot be dismissed mid-request and that a 4xx/5xx renders inline in the dialog
- [ ] Manual: open the admin dashboard in prod after deploy and confirm the activity request URL is `…/admin/activity?limit=25` (single `admin`)
- [ ] Manual: confirm admin dev environment (raw invoke URL) still resolves dashboard activity correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)