### PR TITLE
Mobile menu: surface Admin link for admin users

### DIFF
--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -92,13 +92,31 @@ export function SiteHeader({
       mobileOnly: true,
       onSelect: () => onNavigate(authSession ? '/profile' : '/login'),
     },
-    ...(authSession?.user.isAdmin
-      ? [{
-          id: 'admin',
-          label: 'Admin',
-          href: buildCrossAppUrl(adminUrl, authSession),
-          mobileOnly: true,
-        }]
+    ...(authSession
+      ? [
+          {
+            id: 'okra-submissions',
+            label: 'My okra submissions',
+            href: '/okra/submissions',
+            active: pathname === '/okra/submissions',
+            mobileOnly: true,
+            onSelect: () => onNavigate('/okra/submissions'),
+          },
+          {
+            id: 'grn',
+            label: 'Good Roots Network',
+            href: buildCrossAppUrl(goodRootsNetworkUrl, authSession),
+            mobileOnly: true,
+          },
+          ...(authSession.user.isAdmin
+            ? [{
+                id: 'admin',
+                label: 'Admin',
+                href: buildCrossAppUrl(adminUrl, authSession),
+                mobileOnly: true,
+              }]
+            : []),
+        ]
       : []),
   ];
 

--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -92,6 +92,14 @@ export function SiteHeader({
       mobileOnly: true,
       onSelect: () => onNavigate(authSession ? '/profile' : '/login'),
     },
+    ...(authSession?.user.isAdmin
+      ? [{
+          id: 'admin',
+          label: 'Admin',
+          href: buildCrossAppUrl(adminUrl, authSession),
+          mobileOnly: true,
+        }]
+      : []),
   ];
 
   return (


### PR DESCRIPTION
The desktop avatar dropdown conditionally exposes the Admin app via
appLinks, but the mobile burger nav (headerNavItems) was missing it
entirely, leaving admins with no way to reach the admin app from a
phone. Add a mobileOnly Admin entry guarded by authSession.user.isAdmin.

https://claude.ai/code/session_01EsUJkmopxRNTrfJZS3mVdH