### PR TITLE
Admin: drop sticky footer on mobile to match web app

### DIFF
--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -323,8 +323,23 @@ body {
 /* ── Mobile: off-canvas drawer (matches web app's 799px breakpoint) ─ */
 
 @media (max-width: 799px) {
+  /* Drop the body-level scroll lock on phones so the page scrolls
+     normally and the footer sits at the document bottom — matching the
+     web app — instead of being pinned to the viewport. */
+  .admin-app-shell {
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
+  }
+
   .admin-shell-body {
     flex-direction: column;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .admin-shell-main {
+    overflow: visible;
   }
 
   .admin-mobile-nav-trigger {


### PR DESCRIPTION
On phones (≤799px) the admin shell switches off the body-level
scroll lock (height: 100vh; overflow: hidden) and falls back to
min-height: 100dvh, so the footer sits at the document bottom
instead of being pinned to the viewport — matching the web app's
behavior.