### PR TITLE
Track signup method (email, Google, Facebook) on new users

### DIFF
--- a/infra/foundation-web/functions/post-confirmation.mjs
+++ b/infra/foundation-web/functions/post-confirmation.mjs
@@ -33,6 +33,30 @@ function firstNonEmptyString(...values) {
   return null;
 }
 
+export function extractSignupMethod(attributes = {}) {
+  const raw = attributes.identities;
+
+  if (typeof raw !== "string" || !raw.trim()) {
+    // Cognito-native (email/password) users have no identities attribute.
+    return "email";
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "unknown";
+  }
+
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+  const provider = entry?.providerName ?? entry?.providerType;
+  const normalized = typeof provider === "string" ? provider.toLowerCase() : "";
+
+  if (normalized === "google") return "google";
+  if (normalized === "facebook") return "facebook";
+  return "unknown";
+}
+
 export function extractSignupContext(event) {
   const triggerSource = event.triggerSource;
   const correlationId = resolveCorrelationId(event);
@@ -67,6 +91,7 @@ export function extractSignupContext(event) {
     familyName,
     fullName,
     newsletterOptIn: attributes["custom:newsletter_opt_in"] === "true",
+    signupMethod: extractSignupMethod(attributes),
   };
 }
 
@@ -78,6 +103,7 @@ export function buildSignupEventDetail(context) {
     familyName: context.familyName ?? null,
     fullName: context.fullName ?? null,
     newsletterOptIn: Boolean(context.newsletterOptIn),
+    signupMethod: context.signupMethod ?? "unknown",
     correlationId: context.correlationId,
   };
 }
@@ -151,13 +177,14 @@ async function provisionShellUser(context, createClient, errorLogger) {
 
   try {
     const result = await client.query(
-      `INSERT INTO users (id, email, first_name, last_name, display_name)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO users (id, email, first_name, last_name, display_name, signup_method)
+       VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT (id) DO UPDATE
          SET email = COALESCE(users.email, EXCLUDED.email),
              first_name = COALESCE(users.first_name, EXCLUDED.first_name),
              last_name = COALESCE(users.last_name, EXCLUDED.last_name),
              display_name = COALESCE(users.display_name, EXCLUDED.display_name),
+             signup_method = COALESCE(users.signup_method, EXCLUDED.signup_method),
              updated_at = now()
        RETURNING xmax = 0 AS inserted`,
       [
@@ -166,6 +193,7 @@ async function provisionShellUser(context, createClient, errorLogger) {
         context.givenName,
         context.familyName,
         context.fullName,
+        context.signupMethod ?? "unknown",
       ],
     );
 
@@ -221,6 +249,7 @@ export function createHandler({
         triggerSource: context.triggerSource,
         userId: context.userId,
         hasEmail: context.email !== null,
+        signupMethod: context.signupMethod,
         inserted,
         linkedOrders,
       }),

--- a/infra/foundation-web/functions/tests/post-confirmation.test.mjs
+++ b/infra/foundation-web/functions/tests/post-confirmation.test.mjs
@@ -7,6 +7,7 @@ import {
   buildSignupEventDetail,
   createHandler,
   extractSignupContext,
+  extractSignupMethod,
   linkGuestOrders,
 } from "../post-confirmation.mjs";
 
@@ -41,6 +42,35 @@ describe("post-confirmation trigger sets", () => {
   });
 });
 
+describe("extractSignupMethod", () => {
+  it("returns 'email' when no identities attribute is present", () => {
+    assert.equal(extractSignupMethod({}), "email");
+    assert.equal(extractSignupMethod({ identities: "" }), "email");
+  });
+
+  it("detects Google federated signups", () => {
+    const identities = JSON.stringify([
+      { providerName: "Google", providerType: "Google", userId: "abc" },
+    ]);
+    assert.equal(extractSignupMethod({ identities }), "google");
+  });
+
+  it("detects Facebook federated signups", () => {
+    const identities = JSON.stringify([
+      { providerName: "Facebook", providerType: "Facebook", userId: "xyz" },
+    ]);
+    assert.equal(extractSignupMethod({ identities }), "facebook");
+  });
+
+  it("returns 'unknown' for unrecognized providers and bad JSON", () => {
+    assert.equal(
+      extractSignupMethod({ identities: JSON.stringify([{ providerName: "Apple" }]) }),
+      "unknown",
+    );
+    assert.equal(extractSignupMethod({ identities: "not-json" }), "unknown");
+  });
+});
+
 describe("extractSignupContext", () => {
   it("extracts user details and newsletter opt-in", () => {
     const context = extractSignupContext(buildEvent());
@@ -49,6 +79,24 @@ describe("extractSignupContext", () => {
     assert.equal(context.email, "new-user@example.com");
     assert.equal(context.fullName, "Olivia Garden");
     assert.equal(context.newsletterOptIn, true);
+    assert.equal(context.signupMethod, "email");
+  });
+
+  it("captures the federated provider as the signup method", () => {
+    const context = extractSignupContext(
+      buildEvent({
+        request: {
+          clientMetadata: { correlationId: "corr-google" },
+          userAttributes: {
+            sub: "33333333-3333-3333-3333-333333333333",
+            email: "google-user@example.com",
+            identities: JSON.stringify([{ providerName: "Google" }]),
+          },
+        },
+      }),
+    );
+
+    assert.equal(context.signupMethod, "google");
   });
 
   it("supports snake_case correlation ids", () => {
@@ -91,6 +139,7 @@ describe("buildSignupEventDetail", () => {
     assert.equal(detail.email, "new-user@example.com");
     assert.equal(detail.fullName, "Olivia Garden");
     assert.equal(detail.newsletterOptIn, true);
+    assert.equal(detail.signupMethod, "email");
     assert.equal(detail.correlationId, "corr-123");
   });
 });
@@ -153,11 +202,13 @@ describe("createHandler", () => {
       "Olivia",
       "Garden",
       "Olivia Garden",
+      "email",
     ]);
     assert.match(fake.queries[1].sql, /UPDATE store_orders/i);
     assert.equal(eventBridgeClient.sent.length, 1);
     const detail = JSON.parse(eventBridgeClient.sent[0].input.Entries[0].Detail);
     assert.equal(detail.userId, "11111111-1111-1111-1111-111111111111");
+    assert.equal(detail.signupMethod, "email");
   });
 
   it("skips publishing when the user already exists", async () => {

--- a/services/notifications/src/services/renderers.mjs
+++ b/services/notifications/src/services/renderers.mjs
@@ -183,11 +183,23 @@ function renderGardenClubCanceled(detail) {
   };
 }
 
+const SIGNUP_METHOD_LABELS = {
+  email: ':email: Email & password',
+  google: ':google: Google',
+  facebook: ':facebook: Facebook',
+  unknown: ':grey_question: Unknown'
+};
+
+function formatSignupMethod(method) {
+  return SIGNUP_METHOD_LABELS[method] ?? SIGNUP_METHOD_LABELS.unknown;
+}
+
 function renderUserSignedUp(detail) {
   const env = process.env.FOUNDATION_ENVIRONMENT ?? 'unknown';
   const lines = [
     '*:boom: New foundation signup*',
     `Environment: ${env}`,
+    `Signup method: ${formatSignupMethod(detail.signupMethod)}`,
     `Email: ${detail.email ?? 'missing'}`,
     `User ID: ${detail.userId}`,
     `Newsletter opt-in: ${detail.newsletterOptIn ? 'yes' : 'no'}`

--- a/services/notifications/test/renderers.test.mjs
+++ b/services/notifications/test/renderers.test.mjs
@@ -101,12 +101,40 @@ describe('renderEvent', () => {
       userId: 'user-1',
       email: 'new@example.com',
       fullName: 'New User',
-      newsletterOptIn: true
+      newsletterOptIn: true,
+      signupMethod: 'email'
     });
     expect(result.summary).toBe('New signup: New User');
     expect(result.slack.text).toContain('Environment: staging');
     expect(result.slack.text).toContain('Name: New User');
     expect(result.slack.text).toContain('Newsletter opt-in: yes');
+    expect(result.slack.text).toContain('Signup method: :email: Email & password');
+  });
+
+  it('labels Google signups in the slack notification', () => {
+    const result = renderEvent('ogf.signups', 'user.signed-up', {
+      userId: 'user-2',
+      email: 'g@example.com',
+      signupMethod: 'google'
+    });
+    expect(result.slack.text).toContain('Signup method: :google: Google');
+  });
+
+  it('labels Facebook signups in the slack notification', () => {
+    const result = renderEvent('ogf.signups', 'user.signed-up', {
+      userId: 'user-3',
+      email: 'f@example.com',
+      signupMethod: 'facebook'
+    });
+    expect(result.slack.text).toContain('Signup method: :facebook: Facebook');
+  });
+
+  it('falls back to an unknown signup method label when missing', () => {
+    const result = renderEvent('ogf.signups', 'user.signed-up', {
+      userId: 'user-4',
+      email: 'u@example.com'
+    });
+    expect(result.slack.text).toContain('Signup method: :grey_question: Unknown');
   });
 
   it('renders Good Roots org inquiries with org-type label and optional fields', () => {

--- a/services/web-api/db/migrations/0006_signup_method.sql
+++ b/services/web-api/db/migrations/0006_signup_method.sql
@@ -1,0 +1,7 @@
+alter table users
+  add column if not exists signup_method text
+    check (signup_method in ('email', 'google', 'facebook', 'unknown'));
+
+create index if not exists idx_users_signup_method
+  on users(signup_method)
+  where signup_method is not null;


### PR DESCRIPTION
Detect the auth provider from Cognito's identities attribute in the
post-confirmation lambda, persist it to a new users.signup_method column
for general analytics, and surface it in the Slack signup notification.

https://claude.ai/code/session_01MXC6h1boq4d5eiAVDALhUS