### PR TITLE
Make Vite okra photo-upload mock actually upload

### DIFF
--- a/apps/web/src/okra/components/PhotoUploader.tsx
+++ b/apps/web/src/okra/components/PhotoUploader.tsx
@@ -81,7 +81,7 @@ export function PhotoUploader({
         multiple
         disabled={inputDisabled}
         onChange={handleChange}
-        aria-label="Upload photos (JPEG, PNG, or WebP, max 3 MB each)"
+        aria-label="Upload photos (JPEG, PNG, or WebP, max 10 MB each)"
       />
 
       {rateLimitMsg && (
@@ -103,7 +103,7 @@ export function PhotoUploader({
             </svg>
             <span className="photo-uploader__empty-label">Add up to 5 photos</span>
             <span className="photo-uploader__browse-btn">Browse files</span>
-            <span className="photo-uploader__empty-hint">JPEG, PNG, or WebP · max 3 MB each</span>
+            <span className="photo-uploader__empty-hint">JPEG, PNG, or WebP · max 10 MB each</span>
           </div>
         ) : (
           <>

--- a/apps/web/src/okra/hooks/usePhotoUploader.ts
+++ b/apps/web/src/okra/hooks/usePhotoUploader.ts
@@ -25,7 +25,7 @@ export interface UsePhotoUploaderReturn {
 }
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const MAX_SIZE = 3 * 1024 * 1024; // 3 MB
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_PHOTOS = 5;
 const CONCURRENCY_LIMIT = 3;
 
@@ -39,7 +39,7 @@ export function validateFile(file: File): string | null {
     return 'Only JPEG, PNG, and WebP images are accepted';
   }
   if (file.size > MAX_SIZE) {
-    return 'File exceeds the 3 MB size limit';
+    return 'File exceeds the 10 MB size limit';
   }
   return null;
 }

--- a/apps/web/tests/okra-submission.spec.ts
+++ b/apps/web/tests/okra-submission.spec.ts
@@ -35,7 +35,27 @@ test.describe('okra submission flow (staging)', () => {
     await expect(dialog.getByRole('button', { name: 'Submit your garden' })).toBeDisabled();
 
     await dialog.locator('input[type="file"]').setInputFiles(selectedImages);
-    await expect(dialog.getByLabel('Upload complete')).toHaveCount(selectedImages.length, { timeout: 30000 });
+
+    // Race success against the failed-thumb appearing — without this, a real
+    // upload error just times out the success assertion with an unhelpful
+    // "expected N, got M" message instead of surfacing the actual failure.
+    const failureSignal = dialog
+      .locator('.photo-uploader__thumb--failed')
+      .first()
+      .waitFor({ state: 'visible', timeout: 30000 })
+      .then(async () => {
+        const errMsg = await dialog
+          .locator('.photo-uploader__error-msg, .photo-uploader__consolidated-error')
+          .first()
+          .textContent()
+          .catch(() => null);
+        throw new Error(`Anonymous photo upload failed: ${errMsg?.trim() ?? 'no error message captured'}`);
+      });
+    const successSignal = expect(dialog.getByLabel('Upload complete'))
+      .toHaveCount(selectedImages.length, { timeout: 30000 });
+    await Promise.race([successSignal, failureSignal]);
+
+    await expect(dialog.locator('.photo-uploader__thumb--failed')).toHaveCount(0);
 
     await dialog.getByLabel('Your name (optional)').fill(contributorName);
     await dialog.getByLabel('Your garden story (optional)').fill(storyText);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,22 @@
+import { randomUUID } from 'node:crypto';
 import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
+interface MockReq {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  on: (event: 'data' | 'end', listener: (...args: unknown[]) => void) => void;
+}
+
+interface MockRes {
+  setHeader: (name: string, value: string) => void;
+  end: (body?: string) => void;
+  statusCode?: number;
+}
+
 function mockOkraApi(): Plugin {
   const registerMocks = (middlewares: {
-    use: (path: string, handler: (_req: unknown, res: { setHeader: (name: string, value: string) => void; end: (body: string) => void; statusCode?: number }) => void) => void;
+    use: (path: string, handler: (req: MockReq, res: MockRes) => void) => void;
   }) => {
     middlewares.use('/api/okra/stats', (_req, res) => {
       res.setHeader('Content-Type', 'application/json');
@@ -68,9 +81,22 @@ function mockOkraApi(): Plugin {
       );
     });
 
-    middlewares.use('/api/photos', (_req, res) => {
+    middlewares.use('/api/mock-photo-upload', (req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        res.statusCode = 200;
+        res.end();
+      });
+    });
+
+    middlewares.use('/api/photos', (req, res) => {
+      const photoId = randomUUID();
+      const hostHeader = req.headers?.host;
+      const host = Array.isArray(hostHeader) ? hostHeader[0] : (hostHeader ?? 'localhost:4174');
+      const uploadUrl = `http://${host}/api/mock-photo-upload/${photoId}`;
+      res.statusCode = 201;
       res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ photoId: 'mock-photo-id', uploadUrl: 'https://example.com/mock-upload' }));
+      res.end(JSON.stringify({ photoId, uploadUrl, method: 'PUT', headers: {}, expiresInSeconds: 900 }));
     });
 
     middlewares.use('/api/submissions', (_req, res) => {


### PR DESCRIPTION
The dev mock for POST /api/photos returned a hardcoded uploadUrl pointing
at https://example.com/mock-upload, so the browser PUT to S3 always
failed and every photo entry transitioned to 'failed' state. That blocked
both anonymous and authenticated submission flows from being testable
locally — anonymous users hit it first because that's the default path.

Mint a real photoId per request, point uploadUrl at a new
/api/mock-photo-upload/:id middleware that drains the body and returns
200, and shape the JSON like the real intent response (statusCode 201,
photoId, uploadUrl, method, headers, expiresInSeconds).