### PR TITLE
Scope localhost return-URL allowlist to non-prod (#294)

### DIFF
--- a/services/web-api/src/services/donations.mjs
+++ b/services/web-api/src/services/donations.mjs
@@ -44,14 +44,24 @@ export const donationCheckoutSessionSchema = {
   }
 };
 
-const defaultAllowedReturnOrigins = [
-  'http://localhost:4173',
-  'http://localhost:4174',
-  'http://127.0.0.1:4173',
-  'http://127.0.0.1:4174',
+const productionAllowedReturnOrigins = [
   'https://oliviasgarden.org',
   'https://www.oliviasgarden.org'
 ];
+
+const localDevAllowedReturnOrigins = [
+  'http://localhost:4173',
+  'http://localhost:4174',
+  'http://127.0.0.1:4173',
+  'http://127.0.0.1:4174'
+];
+
+function getDefaultAllowedReturnOrigins() {
+  if (process.env.FOUNDATION_ENVIRONMENT === 'prod') {
+    return productionAllowedReturnOrigins;
+  }
+  return [...productionAllowedReturnOrigins, ...localDevAllowedReturnOrigins];
+}
 
 function requiredEnvVar(name) {
   const value = process.env[name];
@@ -97,7 +107,7 @@ function getAllowedReturnOrigins() {
     .map((origin) => origin.trim())
     .filter(Boolean);
 
-  return new Set([...defaultAllowedReturnOrigins, ...configuredOrigins]);
+  return new Set([...getDefaultAllowedReturnOrigins(), ...configuredOrigins]);
 }
 
 function parseAndValidateReturnUrl(returnUrl) {

--- a/services/web-api/src/services/workshops.mjs
+++ b/services/web-api/src/services/workshops.mjs
@@ -227,21 +227,31 @@ function pickSignupKind(workshop, registeredCount) {
 
 // --- Return URL allowlist (mirrors donations) ---
 
-const defaultAllowedReturnOrigins = [
-  'http://localhost:4173',
-  'http://localhost:4174',
-  'http://127.0.0.1:4173',
-  'http://127.0.0.1:4174',
+const productionAllowedReturnOrigins = [
   'https://oliviasgarden.org',
   'https://www.oliviasgarden.org'
 ];
+
+const localDevAllowedReturnOrigins = [
+  'http://localhost:4173',
+  'http://localhost:4174',
+  'http://127.0.0.1:4173',
+  'http://127.0.0.1:4174'
+];
+
+function getDefaultAllowedReturnOrigins() {
+  if (process.env.FOUNDATION_ENVIRONMENT === 'prod') {
+    return productionAllowedReturnOrigins;
+  }
+  return [...productionAllowedReturnOrigins, ...localDevAllowedReturnOrigins];
+}
 
 function getAllowedReturnOrigins() {
   const configuredOrigins = (process.env.ALLOWED_RETURN_URL_ORIGINS ?? '')
     .split(',')
     .map((origin) => origin.trim())
     .filter(Boolean);
-  return new Set([...defaultAllowedReturnOrigins, ...configuredOrigins]);
+  return new Set([...getDefaultAllowedReturnOrigins(), ...configuredOrigins]);
 }
 
 function parseAndValidateReturnUrl(returnUrl) {

--- a/services/web-api/test/api.test.mjs
+++ b/services/web-api/test/api.test.mjs
@@ -38,6 +38,8 @@ describe('web-api donation handler', () => {
     delete process.env.STRIPE_SECRET_KEY;
     delete process.env.OGF_USER_POOL_ID;
     delete process.env.OGF_USER_POOL_CLIENT_ID;
+    delete process.env.FOUNDATION_ENVIRONMENT;
+    delete process.env.ALLOWED_RETURN_URL_ORIGINS;
   });
 
   it('returns 422 for invalid donation amount', async () => {
@@ -133,6 +135,49 @@ describe('web-api donation handler', () => {
     expect(JSON.parse(response.body)).toEqual({
       error: 'returnUrl origin is not allowed'
     });
+  });
+
+  it('rejects localhost returnUrl origins in production', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    process.env.FOUNDATION_ENVIRONMENT = 'prod';
+
+    const response = await handler(createApiGatewayEvent({
+      method: 'POST',
+      path: '/donations/checkout-session',
+      body: {
+        mode: 'one_time',
+        amountCents: 2500,
+        returnUrl: 'http://localhost:4173/donate?session_id={CHECKOUT_SESSION_ID}'
+      }
+    }));
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'returnUrl origin is not allowed'
+    });
+  });
+
+  it('accepts localhost returnUrl origins outside production', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+    process.env.FOUNDATION_ENVIRONMENT = 'staging';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'cs_test_local', client_secret: 'cs_test_local_secret' })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handler(createApiGatewayEvent({
+      method: 'POST',
+      path: '/donations/checkout-session',
+      body: {
+        mode: 'one_time',
+        amountCents: 2500,
+        returnUrl: 'http://localhost:4173/donate?session_id={CHECKOUT_SESSION_ID}'
+      }
+    }));
+
+    expect(response.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it('returns checkout session status for embedded completion handling', async () => {


### PR DESCRIPTION
## Summary

Closes #294.

`getAllowedReturnOrigins()` in [services/web-api/src/services/donations.mjs](services/web-api/src/services/donations.mjs) and [workshops.mjs](services/web-api/src/services/workshops.mjs) merged a hardcoded list that included `http://localhost:4173/4174` and `http://127.0.0.1:4173/4174` into every deploy. In prod that means an attacker could craft a Stripe return URL pointing at a malicious local dev server and we'd accept it on the way out of Checkout.

Split the defaults:
- `productionAllowedReturnOrigins` → `https://oliviasgarden.org` + `https://www.oliviasgarden.org` (always included).
- `localDevAllowedReturnOrigins` → the four localhost/127.0.0.1 entries, only added when `FOUNDATION_ENVIRONMENT !== 'prod'`.

`FOUNDATION_ENVIRONMENT` is already populated from the SAM `EnvironmentName` parameter in [template.yaml:76](services/web-api/template.yaml#L76), so prod deploys automatically drop the localhost entries with no parameter-store changes needed.

The duplication between `donations.mjs` and `workshops.mjs` is intentional — `workshops.mjs` was added in #317 with the same hardcoded list and a `// --- mirrors donations ---` comment. Keeping the fix in place in both files matches that pattern; extracting to a shared helper is a separate refactor.

## Test plan

- [x] `npm test` in `services/web-api` — all 45 tests pass, including two new cases:
  - `rejects localhost returnUrl origins in production`
  - `accepts localhost returnUrl origins outside production`
- [x] `npm run lint` in `services/web-api` — clean
- [ ] Manual: deploy to staging, confirm `http://localhost:4173/...` returnUrl is still accepted (so local dev still works against staging backend if needed).
- [ ] Manual: confirm prod deploy with `FOUNDATION_ENVIRONMENT=prod` rejects `http://localhost:4173/...` returnUrl with `400 returnUrl origin is not allowed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)