### PR TITLE
Validate grower-crop ownership on listing writes (#201)

### DIFF
--- a/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/POST Listings - Unknown growerCropId.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Negative Paths/POST Listings - Unknown growerCropId.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+name: 'POST /listings - Unknown growerCropId'
+description: |-
+  Sends a POST /listings request with a `growerCropId` that does not exist in
+  the authenticated user's crop library. Expects a 400 status code because the
+  reference must resolve to an existing grower crop owned by the caller.
+method: POST
+url: '{{baseUrl}}/listings'
+order: 2100
+headers:
+  - key: Authorization
+    value: 'Bearer {{premiumAuthToken}}'
+  - key: Content-Type
+    value: application/json
+body:
+  type: json
+  content: |-
+    {
+      "title": "Negative Path Test Listing",
+      "growerCropId": "00000000-0000-4000-8000-000000000000",
+      "quantityTotal": 1,
+      "unit": "lb",
+      "availableStart": "2026-07-01T08:00:00Z",
+      "availableEnd": "2026-07-03T18:00:00Z",
+      "pickupLocationText": "Front porch",
+      "status": "active"
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 400", function () {
+          pm.response.to.have.status(400);
+      });
+
+      pm.test("Response surfaces the grower-crop ownership rule", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("error");
+          pm.expect(body.error).to.include("grower_crop_id");
+          pm.expect(body.error).to.include("does not reference an existing grower crop");
+      });

--- a/services/grn-api/src/api/handlers/listing.rs
+++ b/services/grn-api/src/api/handlers/listing.rs
@@ -737,10 +737,7 @@ async fn validate_listing_crop_references(
 
     if let Some(crop) = effective_crop_id {
         let crop_exists = client
-            .query_one(
-                "select exists(select 1 from crops where id = $1)",
-                &[&crop],
-            )
+            .query_one("select exists(select 1 from crops where id = $1)", &[&crop])
             .await
             .map_err(|error| db_error(&error))?
             .get::<_, bool>(0);

--- a/services/grn-api/src/api/handlers/listing.rs
+++ b/services/grn-api/src/api/handlers/listing.rs
@@ -287,20 +287,19 @@ pub async fn create_listing(
 
     let client = db::connect().await?;
 
-    // Only validate catalog links if crop_id is provided
-    if let Some(crop_id_str) = &payload.crop_id {
-        validate_catalog_links(
-            &client,
-            parse_uuid(crop_id_str, "crop_id")?,
-            parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?,
-        )
-        .await?;
-    }
-
     // Validate that we have either crop_id or grower_crop_id
     if payload.crop_id.is_none() && payload.grower_crop_id.is_none() {
         return error_response(400, "Either crop_id or grower_crop_id must be provided");
     }
+
+    validate_listing_crop_references(
+        &client,
+        user_id,
+        parse_optional_uuid(payload.crop_id.as_deref(), "crop_id")?,
+        parse_optional_uuid(payload.grower_crop_id.as_deref(), "grower_crop_id")?,
+        parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?,
+    )
+    .await?;
 
     let effective_pickup_address =
         resolve_effective_pickup_address(&client, user_id, payload.pickup_address.as_deref())
@@ -432,20 +431,19 @@ pub async fn update_listing(
 
     let client = db::connect().await?;
 
-    // Only validate catalog links if crop_id is provided
-    if let Some(crop_id_str) = &payload.crop_id {
-        validate_catalog_links(
-            &client,
-            parse_uuid(crop_id_str, "crop_id")?,
-            parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?,
-        )
-        .await?;
-    }
-
     // Validate that we have either crop_id or grower_crop_id
     if payload.crop_id.is_none() && payload.grower_crop_id.is_none() {
         return error_response(400, "Either crop_id or grower_crop_id must be provided");
     }
+
+    validate_listing_crop_references(
+        &client,
+        user_id,
+        parse_optional_uuid(payload.crop_id.as_deref(), "crop_id")?,
+        parse_optional_uuid(payload.grower_crop_id.as_deref(), "grower_crop_id")?,
+        parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?,
+    )
+    .await?;
 
     let effective_pickup_address =
         resolve_effective_pickup_address(&client, user_id, payload.pickup_address.as_deref())
@@ -674,41 +672,106 @@ fn parse_list_my_listings_query(
     })
 }
 
-async fn validate_catalog_links(
+/// Validates the crop, grower-crop, and variety references on a listing write.
+///
+/// Returns a 400-level error string when:
+/// - `grower_crop_id` is provided but does not exist or is not owned by `user_id`
+/// - both `crop_id` and `grower_crop_id` are provided and disagree on the canonical crop
+/// - `variety_id` is provided but does not belong to the effective canonical crop
+/// - `variety_id` is provided alongside a user-defined crop with no canonical link
+///
+/// Caller is responsible for enforcing that at least one of `crop_id` /
+/// `grower_crop_id` is supplied; this function is a no-op when both are `None`.
+async fn validate_listing_crop_references(
     client: &Client,
-    crop_id: Uuid,
+    user_id: Uuid,
+    crop_id: Option<Uuid>,
+    grower_crop_id: Option<Uuid>,
     variety_id: Option<Uuid>,
 ) -> Result<(), lambda_http::Error> {
-    let crop_exists = client
-        .query_one(
-            "select exists(select 1 from crops where id = $1)",
-            &[&crop_id],
-        )
-        .await
-        .map_err(|error| db_error(&error))?
-        .get::<_, bool>(0);
+    // Look up the grower crop and assert ownership. Use the same error message
+    // for "doesn't exist" and "owned by someone else" so we don't leak
+    // existence of other users' library entries.
+    let grower_crop_canonical_id = if let Some(gc_id) = grower_crop_id {
+        let row = client
+            .query_opt(
+                "select user_id, canonical_id from grower_crop_library where id = $1",
+                &[&gc_id],
+            )
+            .await
+            .map_err(|error| db_error(&error))?;
 
-    if !crop_exists {
-        return Err(lambda_http::Error::from(
-            "crop_id does not reference an existing catalog crop".to_string(),
-        ));
+        let Some(row) = row else {
+            return Err(lambda_http::Error::from(
+                "grower_crop_id does not reference an existing grower crop".to_string(),
+            ));
+        };
+
+        let owner: Uuid = row.get("user_id");
+        if owner != user_id {
+            return Err(lambda_http::Error::from(
+                "grower_crop_id does not reference an existing grower crop".to_string(),
+            ));
+        }
+
+        row.get::<_, Option<Uuid>>("canonical_id")
+    } else {
+        None
+    };
+
+    // If both ids are supplied, they must agree on the canonical crop.
+    if let (Some(supplied_crop), Some(gc_id)) = (crop_id, grower_crop_id) {
+        match grower_crop_canonical_id {
+            Some(canonical) if canonical == supplied_crop => {}
+            _ => {
+                return Err(lambda_http::Error::from(format!(
+                    "crop_id {supplied_crop} does not match the canonical crop linked to grower_crop_id {gc_id}"
+                )));
+            }
+        }
     }
 
-    if let Some(variety) = variety_id {
-        let matches = client
+    // Effective canonical crop = grower crop's canonical link if present,
+    // otherwise the supplied crop_id.
+    let effective_crop_id = grower_crop_canonical_id.or(crop_id);
+
+    if let Some(crop) = effective_crop_id {
+        let crop_exists = client
             .query_one(
-                "select exists(select 1 from crop_varieties where id = $1 and crop_id = $2)",
-                &[&variety, &crop_id],
+                "select exists(select 1 from crops where id = $1)",
+                &[&crop],
             )
             .await
             .map_err(|error| db_error(&error))?
             .get::<_, bool>(0);
 
-        if !matches {
+        if !crop_exists {
             return Err(lambda_http::Error::from(
-                "variety_id must belong to the specified crop_id".to_string(),
+                "crop_id does not reference an existing catalog crop".to_string(),
             ));
         }
+
+        if let Some(variety) = variety_id {
+            let matches = client
+                .query_one(
+                    "select exists(select 1 from crop_varieties where id = $1 and crop_id = $2)",
+                    &[&variety, &crop],
+                )
+                .await
+                .map_err(|error| db_error(&error))?
+                .get::<_, bool>(0);
+
+            if !matches {
+                return Err(lambda_http::Error::from(
+                    "variety_id must belong to the specified crop_id".to_string(),
+                ));
+            }
+        }
+    } else if variety_id.is_some() {
+        return Err(lambda_http::Error::from(
+            "variety_id requires a crop_id or a grower_crop_id linked to a catalog crop"
+                .to_string(),
+        ));
     }
 
     Ok(())

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -279,6 +279,9 @@ fn map_api_error_to_response(
         || message.contains("unit is required")
         || message.contains("crop_name is required")
         || message.contains("does not reference an existing catalog crop")
+        || message.contains("does not reference an existing grower crop")
+        || message.contains("does not match the canonical crop linked to grower_crop_id")
+        || message.contains("variety_id requires a crop_id or a grower_crop_id")
         || message.contains("must belong to the specified crop_id")
         || message.contains("must belong to the specified cropId")
         || message.contains("Request body is required")
@@ -415,6 +418,34 @@ mod tests {
     fn map_api_error_maps_organization_name_validation_to_400() {
         let error = lambda_http::Error::from(
             "organizationName is required when isOrganization is true".to_string(),
+        );
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn map_api_error_maps_unknown_grower_crop_to_400() {
+        let error = lambda_http::Error::from(
+            "grower_crop_id does not reference an existing grower crop".to_string(),
+        );
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn map_api_error_maps_grower_crop_canonical_mismatch_to_400() {
+        let error = lambda_http::Error::from(
+            "crop_id 5df666d4-f6b1-4e6f-97d6-321e531ad7ca does not match the canonical crop linked to grower_crop_id 0e7ab2f8-9d1b-46b0-9c53-b6053bc90011".to_string(),
+        );
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn map_api_error_maps_variety_without_crop_context_to_400() {
+        let error = lambda_http::Error::from(
+            "variety_id requires a crop_id or a grower_crop_id linked to a catalog crop"
+                .to_string(),
         );
         let response = map_api_error_to_response(&error).unwrap();
         assert_eq!(response.status().as_u16(), 400);


### PR DESCRIPTION
## Summary

Closes #201.

`POST /listings` and `PUT /listings/{id}` previously accepted `growerCropId` but only checked that *something* (`cropId` or `growerCropId`) was present. Anything beyond that — including cross-user references — was trusted from the client.

Replace `validate_catalog_links` in [listing.rs](services/grn-api/src/api/handlers/listing.rs) with `validate_listing_crop_references`, which:

- Looks up `grower_crop_id` and asserts it is owned by the caller. Same error message for "doesn't exist" and "owned by another user" so we don't leak existence of other users' library entries.
- When both `cropId` and `growerCropId` are supplied, requires them to agree on the canonical crop (the grower crop's `canonical_id` must equal the supplied `cropId`).
- Computes effective canonical crop = grower crop's `canonical_id` if present, else the supplied `cropId`; validates the catalog crop exists and that `varietyId` belongs to that crop.
- Rejects `varietyId` on a user-defined crop with no catalog link.

## Error mapping

Three new error-message substrings are wired into `router::map_api_error` and return `400`:

- `grower_crop_id does not reference an existing grower crop`
- `crop_id <X> does not match the canonical crop linked to grower_crop_id <Y>`
- `variety_id requires a crop_id or a grower_crop_id linked to a catalog crop`

## Test coverage

- **Rust unit tests** (`cargo test --all-features`): three new tests in `router.rs` (`map_api_error_maps_unknown_grower_crop_to_400`, `map_api_error_maps_grower_crop_canonical_mismatch_to_400`, `map_api_error_maps_variety_without_crop_context_to_400`). 268/268 tests pass.
- **Postman negative path**: new `POST /listings - Unknown growerCropId` request in [Negative Paths](postman/collections/Good%20Roots%20Network%20API%20-%20Utility%20Tests/Negative%20Paths/POST%20Listings%20-%20Unknown%20growerCropId.request.yaml) sends a random UUID as `growerCropId` and asserts 400 + `does not reference an existing grower crop`.

## Things deliberately left out

- The duplicate `validate_catalog_links` definitions in [crop.rs](services/grn-api/src/api/handlers/crop.rs) and [request.rs](services/grn-api/src/api/handlers/request.rs) are untouched. Neither endpoint accepts `growerCropId`, so the simpler check is still correct there. Consolidating those is a separate refactor.
- A Postman test for the cross-user case isn't included — that needs a second user's grower crop pre-seeded into the test environment, which is more setup than the issue's "at least one invalid path" requires. The unknown-UUID case exercises the same code path.

## Test plan

- [x] `cargo check --all-targets --all-features` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 268/268 pass
- [ ] CI Postman suite passes (new negative-path test asserts the new error)
- [ ] Manual: create a listing with another user's `growerCropId` against staging → expect `400 grower_crop_id does not reference an existing grower crop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)