### PR TITLE
GRN: redesign crop addition UX with garden beds + planting details

### DIFF
--- a/apps/grn/src/components/CropPlanner/BedSelector.tsx
+++ b/apps/grn/src/components/CropPlanner/BedSelector.tsx
@@ -110,10 +110,10 @@ export function BedSelector({ beds, isLoading, value, onChange }: BedSelectorPro
             onClick={() => onChange(null)}
             aria-pressed={value === null}
           >
-            <span className="grn-bed-card__emoji" aria-hidden="true">📍</span>
+            <span className="grn-bed-card__emoji" aria-hidden="true">🤔</span>
             <span className="grn-bed-card__body">
-              <strong>No bed yet</strong>
-              <span>Decide later — just track the crop for now</span>
+              <strong>Undecided</strong>
+              <span>I&apos;ll figure out where it&apos;s going later</span>
             </span>
           </button>
           {beds.map((bed) => (

--- a/apps/grn/src/components/CropPlanner/BedSelector.tsx
+++ b/apps/grn/src/components/CropPlanner/BedSelector.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button, Input, Select, Textarea } from '@olivias/ui';
+import type { GardenBed, SunExposure } from '../../types/listing';
+import { createMyBed, type UpsertGardenBedRequest } from '../../services/api';
+
+interface BedSelectorProps {
+  beds: GardenBed[];
+  isLoading: boolean;
+  value: string | null;
+  onChange: (bedId: string | null) => void;
+}
+
+const SUN_OPTIONS: Array<{ value: '' | SunExposure; label: string; emoji: string }> = [
+  { value: '', label: 'Not sure yet', emoji: '🌤' },
+  { value: 'full_sun', label: 'Full sun (6+ hrs)', emoji: '☀️' },
+  { value: 'partial_sun', label: 'Partial sun (4–6 hrs)', emoji: '🌤️' },
+  { value: 'partial_shade', label: 'Partial shade (2–4 hrs)', emoji: '⛅' },
+  { value: 'full_shade', label: 'Full shade (<2 hrs)', emoji: '🌥️' },
+  { value: 'mixed', label: 'Mixed throughout day', emoji: '🌗' },
+];
+
+const SUN_LABELS: Record<SunExposure, { label: string; emoji: string }> = {
+  full_sun: { label: 'Full sun', emoji: '☀️' },
+  partial_sun: { label: 'Partial sun', emoji: '🌤️' },
+  partial_shade: { label: 'Partial shade', emoji: '⛅' },
+  full_shade: { label: 'Full shade', emoji: '🌥️' },
+  mixed: { label: 'Mixed', emoji: '🌗' },
+};
+
+export function BedSelector({ beds, isLoading, value, onChange }: BedSelectorProps) {
+  const [isAdding, setIsAdding] = useState(false);
+  const [newBed, setNewBed] = useState<UpsertGardenBedRequest>({
+    name: '',
+    description: '',
+    sunExposure: null,
+    soilType: '',
+    locationNotes: '',
+    lengthInches: null,
+    widthInches: null,
+  });
+  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const createBedMutation = useMutation({
+    mutationFn: createMyBed,
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ['myBeds'] });
+      onChange(created.id);
+      setIsAdding(false);
+      setNewBed({
+        name: '',
+        description: '',
+        sunExposure: null,
+        soilType: '',
+        locationNotes: '',
+        lengthInches: null,
+        widthInches: null,
+      });
+      setError(null);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : 'Could not save the bed');
+    },
+  });
+
+  const handleSaveNewBed = () => {
+    if (!newBed.name.trim()) {
+      setError('Give your bed a name so you can find it later.');
+      return;
+    }
+    createBedMutation.mutate({
+      ...newBed,
+      name: newBed.name.trim(),
+      description: newBed.description?.trim() || null,
+      soilType: newBed.soilType?.trim() || null,
+      locationNotes: newBed.locationNotes?.trim() || null,
+      sunExposure: newBed.sunExposure || null,
+    });
+  };
+
+  return (
+    <div className="grn-bed-selector">
+      <div className="grn-bed-selector__header">
+        <div>
+          <h3 className="grn-bed-selector__title">Where will it live?</h3>
+          <p className="grn-bed-selector__hint">
+            Pick the garden bed it&apos;s going into. You can group plantings later.
+          </p>
+        </div>
+        {!isAdding ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsAdding(true)}
+            type="button"
+          >
+            + New bed
+          </Button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="grn-bed-selector__loading">Loading your beds…</div>
+      ) : (
+        <div className="grn-bed-selector__grid">
+          <button
+            type="button"
+            className={`grn-bed-card grn-bed-card--unassigned ${value === null ? 'is-selected' : ''}`.trim()}
+            onClick={() => onChange(null)}
+            aria-pressed={value === null}
+          >
+            <span className="grn-bed-card__emoji" aria-hidden="true">📍</span>
+            <span className="grn-bed-card__body">
+              <strong>No bed yet</strong>
+              <span>Decide later — just track the crop for now</span>
+            </span>
+          </button>
+          {beds.map((bed) => (
+            <button
+              key={bed.id}
+              type="button"
+              className={`grn-bed-card ${value === bed.id ? 'is-selected' : ''}`.trim()}
+              onClick={() => onChange(bed.id)}
+              aria-pressed={value === bed.id}
+            >
+              <span className="grn-bed-card__emoji" aria-hidden="true">🛏️</span>
+              <span className="grn-bed-card__body">
+                <strong>{bed.name}</strong>
+                <span className="grn-bed-card__meta">
+                  {bed.sunExposure ? (
+                    <span title={SUN_LABELS[bed.sunExposure].label}>
+                      <span aria-hidden="true">{SUN_LABELS[bed.sunExposure].emoji}</span>{' '}
+                      {SUN_LABELS[bed.sunExposure].label}
+                    </span>
+                  ) : null}
+                  {bed.lengthInches && bed.widthInches ? (
+                    <span>
+                      {Math.round(bed.lengthInches / 12)}&prime; × {Math.round(bed.widthInches / 12)}&prime;
+                    </span>
+                  ) : null}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isAdding ? (
+        <div className="grn-bed-selector__add">
+          <h4>Add a new bed</h4>
+          <div className="grn-bed-selector__add-grid">
+            <Input
+              label="Bed name"
+              required
+              placeholder="South raised bed, Front yard plot…"
+              value={newBed.name}
+              onChange={(event) => setNewBed((prev) => ({ ...prev, name: event.target.value }))}
+            />
+            <Select
+              label="Sun exposure"
+              value={newBed.sunExposure ?? ''}
+              onChange={(value) =>
+                setNewBed((prev) => ({
+                  ...prev,
+                  sunExposure: (value || null) as SunExposure | null,
+                }))
+              }
+              options={SUN_OPTIONS.map((option) => ({
+                value: option.value,
+                label: `${option.emoji}  ${option.label}`,
+              }))}
+            />
+            <Input
+              label="Length (inches)"
+              type="number"
+              placeholder="e.g. 96"
+              value={newBed.lengthInches ?? ''}
+              onChange={(event) =>
+                setNewBed((prev) => ({
+                  ...prev,
+                  lengthInches: event.target.value ? Number(event.target.value) : null,
+                }))
+              }
+            />
+            <Input
+              label="Width (inches)"
+              type="number"
+              placeholder="e.g. 48"
+              value={newBed.widthInches ?? ''}
+              onChange={(event) =>
+                setNewBed((prev) => ({
+                  ...prev,
+                  widthInches: event.target.value ? Number(event.target.value) : null,
+                }))
+              }
+            />
+            <Input
+              label="Soil"
+              placeholder="raised bed mix, native clay, etc."
+              value={newBed.soilType ?? ''}
+              onChange={(event) =>
+                setNewBed((prev) => ({ ...prev, soilType: event.target.value }))
+              }
+            />
+            <Input
+              label="Where is it?"
+              placeholder="south side near the porch"
+              value={newBed.locationNotes ?? ''}
+              onChange={(event) =>
+                setNewBed((prev) => ({ ...prev, locationNotes: event.target.value }))
+              }
+            />
+          </div>
+          <Textarea
+            label="Notes (optional)"
+            placeholder="Trellised, drip irrigation, etc."
+            rows={2}
+            value={newBed.description ?? ''}
+            onChange={(event) =>
+              setNewBed((prev) => ({ ...prev, description: event.target.value }))
+            }
+          />
+          {error ? <p className="grn-bed-selector__error">{error}</p> : null}
+          <div className="grn-bed-selector__actions">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={handleSaveNewBed}
+              disabled={createBedMutation.isPending}
+            >
+              {createBedMutation.isPending ? 'Saving…' : 'Save bed'}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setIsAdding(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/grn/src/components/CropPlanner/CropPicker.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { CatalogCrop } from '../../types/listing';
+import { CATEGORY_FILTERS, visualForCrop } from './cropVisuals';
+
+export interface CropPickerSelection {
+  catalogCropId: string | null;
+  cropName: string;
+  category: string | null;
+}
+
+interface CropPickerProps {
+  catalog: CatalogCrop[];
+  isLoading: boolean;
+  value: CropPickerSelection | null;
+  onChange: (selection: CropPickerSelection | null) => void;
+  /** When true, render a more compact variant (no category chips) */
+  compact?: boolean;
+}
+
+const MAX_VISIBLE_RESULTS = 8;
+
+function normalizeCategory(category: string | null | undefined): string {
+  return (category ?? '').trim().toLowerCase();
+}
+
+function categoryMatches(filter: string, category: string | null | undefined): boolean {
+  if (filter === 'all') return true;
+  const normalized = normalizeCategory(category);
+  if (!normalized) return false;
+  return normalized === filter || normalized.startsWith(`${filter}`) || normalized.includes(filter);
+}
+
+export function CropPicker({ catalog, isLoading, value, onChange, compact }: CropPickerProps) {
+  const [query, setQuery] = useState(value?.cropName ?? '');
+  const [activeCategory, setActiveCategory] = useState<string>('all');
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputId = useId();
+  const listboxId = `${inputId}-listbox`;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
+
+  const trimmedQuery = query.trim();
+  const lowerQuery = trimmedQuery.toLowerCase();
+
+  const matches = useMemo(() => {
+    const filtered = catalog.filter((crop) => {
+      if (!categoryMatches(activeCategory, crop.category)) return false;
+      if (!lowerQuery) return true;
+      return (
+        crop.commonName.toLowerCase().includes(lowerQuery) ||
+        (crop.scientificName?.toLowerCase().includes(lowerQuery) ?? false) ||
+        (crop.category?.toLowerCase().includes(lowerQuery) ?? false)
+      );
+    });
+    // Bring exact-prefix matches to the top.
+    if (lowerQuery) {
+      filtered.sort((a, b) => {
+        const aStarts = a.commonName.toLowerCase().startsWith(lowerQuery) ? 0 : 1;
+        const bStarts = b.commonName.toLowerCase().startsWith(lowerQuery) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.commonName.localeCompare(b.commonName);
+      });
+    }
+    return filtered.slice(0, MAX_VISIBLE_RESULTS);
+  }, [catalog, activeCategory, lowerQuery]);
+
+  const exactMatch = useMemo(() => {
+    if (!trimmedQuery) return null;
+    const lower = trimmedQuery.toLowerCase();
+    return catalog.find((crop) => crop.commonName.toLowerCase() === lower) ?? null;
+  }, [catalog, trimmedQuery]);
+
+  const showCustomOption =
+    trimmedQuery.length > 0 &&
+    !exactMatch &&
+    matches.every((crop) => crop.commonName.toLowerCase() !== trimmedQuery.toLowerCase());
+
+  const totalOptions = matches.length + (showCustomOption ? 1 : 0);
+
+  const handleSelectCatalog = (crop: CatalogCrop) => {
+    onChange({
+      catalogCropId: crop.id,
+      cropName: crop.commonName,
+      category: crop.category,
+    });
+    setQuery(crop.commonName);
+    setIsOpen(false);
+  };
+
+  const handleSelectCustom = () => {
+    if (!trimmedQuery) return;
+    onChange({
+      catalogCropId: null,
+      cropName: trimmedQuery,
+      category: null,
+    });
+    setIsOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange(null);
+    setQuery('');
+    setIsOpen(true);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setIsOpen(true);
+      setHighlightIndex((idx) => (totalOptions === 0 ? 0 : (idx + 1) % totalOptions));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setIsOpen(true);
+      setHighlightIndex((idx) =>
+        totalOptions === 0 ? 0 : (idx - 1 + totalOptions) % totalOptions
+      );
+    } else if (event.key === 'Enter') {
+      if (!isOpen || totalOptions === 0) return;
+      event.preventDefault();
+      if (highlightIndex < matches.length) {
+        handleSelectCatalog(matches[highlightIndex]);
+      } else if (showCustomOption) {
+        handleSelectCustom();
+      }
+    } else if (event.key === 'Escape') {
+      setIsOpen(false);
+    }
+  };
+
+  const selectedVisual = value
+    ? visualForCrop(value.cropName, value.category)
+    : null;
+
+  return (
+    <div className="grn-crop-picker" ref={containerRef}>
+      <label htmlFor={inputId} className="grn-crop-picker__label">
+        What are you growing?
+      </label>
+      <p className="grn-crop-picker__hint">
+        Start typing — we&apos;ll search the catalog. Don&apos;t see it? You can add a custom crop.
+      </p>
+
+      {!compact ? (
+        <div className="grn-crop-picker__chips" role="tablist" aria-label="Filter crop catalog by category">
+          {CATEGORY_FILTERS.map((chip) => (
+            <button
+              key={chip.id}
+              type="button"
+              role="tab"
+              aria-selected={activeCategory === chip.id}
+              className={`grn-crop-chip ${activeCategory === chip.id ? 'is-active' : ''}`.trim()}
+              onClick={() => {
+                setActiveCategory(chip.id);
+                setHighlightIndex(0);
+              }}
+            >
+              <span aria-hidden="true">{chip.emoji}</span>
+              <span>{chip.label}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="grn-crop-picker__field">
+        {value ? (
+          <span className="grn-crop-picker__leading" aria-hidden="true">
+            <span
+              className="grn-crop-picker__leading-emoji"
+              style={{ background: `${selectedVisual?.accent ?? '#69874b'}1f` }}
+            >
+              {selectedVisual?.emoji}
+            </span>
+          </span>
+        ) : (
+          <span className="grn-crop-picker__leading" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false">
+              <path
+                fill="currentColor"
+                d="M10 4a6 6 0 0 1 4.74 9.7l4.78 4.79-1.4 1.41-4.79-4.78A6 6 0 1 1 10 4Zm0 2a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"
+              />
+            </svg>
+          </span>
+        )}
+        <input
+          id={inputId}
+          className="grn-crop-picker__input"
+          type="search"
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            isOpen && totalOptions > 0 ? `${listboxId}-opt-${highlightIndex}` : undefined
+          }
+          placeholder={isLoading ? 'Loading catalog…' : 'Tomato, basil, raspberry…'}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setIsOpen(true);
+            setHighlightIndex(0);
+            // Typing invalidates a previous catalog selection if it diverges.
+            if (value && event.target.value.trim() !== value.cropName) {
+              onChange(null);
+            }
+          }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
+          disabled={isLoading}
+        />
+        {value ? (
+          <button
+            type="button"
+            className="grn-crop-picker__clear"
+            onClick={handleClear}
+            aria-label="Clear crop selection"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.4 5 5 6.4 10.6 12 5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4L13.4 12 19 6.4 17.6 5 12 10.6 6.4 5Z"
+              />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+
+      {value ? (
+        <div className="grn-crop-picker__selected" role="status" aria-live="polite">
+          <strong>{value.cropName}</strong>
+          {value.catalogCropId ? (
+            <span className="grn-crop-picker__pill grn-crop-picker__pill--catalog">From catalog</span>
+          ) : (
+            <span className="grn-crop-picker__pill grn-crop-picker__pill--custom">Custom crop</span>
+          )}
+        </div>
+      ) : null}
+
+      {isOpen && (matches.length > 0 || showCustomOption) ? (
+        <ul
+          className="grn-crop-picker__listbox"
+          role="listbox"
+          id={listboxId}
+        >
+          {matches.map((crop, index) => {
+            const visual = visualForCrop(crop.commonName, crop.category);
+            const isHighlighted = index === highlightIndex;
+            return (
+              <li
+                key={crop.id}
+                id={`${listboxId}-opt-${index}`}
+                role="option"
+                aria-selected={isHighlighted}
+                className={`grn-crop-picker__option ${isHighlighted ? 'is-highlighted' : ''}`.trim()}
+                onMouseEnter={() => setHighlightIndex(index)}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  handleSelectCatalog(crop);
+                }}
+              >
+                <span
+                  className="grn-crop-picker__option-emoji"
+                  aria-hidden="true"
+                  style={{ background: `${visual.accent}1f` }}
+                >
+                  {visual.emoji}
+                </span>
+                <span className="grn-crop-picker__option-text">
+                  <span className="grn-crop-picker__option-name">{crop.commonName}</span>
+                  <span className="grn-crop-picker__option-meta">
+                    {crop.category ? <span>{crop.category}</span> : null}
+                    {crop.scientificName ? <em>{crop.scientificName}</em> : null}
+                  </span>
+                </span>
+              </li>
+            );
+          })}
+          {showCustomOption ? (
+            <li
+              id={`${listboxId}-opt-${matches.length}`}
+              role="option"
+              aria-selected={highlightIndex === matches.length}
+              className={`grn-crop-picker__option grn-crop-picker__option--custom ${
+                highlightIndex === matches.length ? 'is-highlighted' : ''
+              }`.trim()}
+              onMouseEnter={() => setHighlightIndex(matches.length)}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                handleSelectCustom();
+              }}
+            >
+              <span className="grn-crop-picker__option-emoji" aria-hidden="true">
+                ➕
+              </span>
+              <span className="grn-crop-picker__option-text">
+                <span className="grn-crop-picker__option-name">
+                  Add &ldquo;{trimmedQuery}&rdquo; as a custom crop
+                </span>
+                <span className="grn-crop-picker__option-meta">
+                  Heirloom, family variety, mystery — anything goes
+                </span>
+              </span>
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/grn/src/components/CropPlanner/cropVisuals.ts
+++ b/apps/grn/src/components/CropPlanner/cropVisuals.ts
@@ -1,0 +1,96 @@
+// Maps catalog categories and common names to a friendly emoji + accent color
+// so the crop planner has visual character without needing a real image catalog.
+//
+// `categoryToVisual` is the broad fallback; `nameToVisual` overrides for crops
+// with strong visual identity that gardeners will recognize at a glance.
+
+export interface CropVisual {
+  emoji: string;
+  accent: string;
+}
+
+const DEFAULT_VISUAL: CropVisual = { emoji: '🌱', accent: '#69874b' };
+
+const categoryToVisual: Record<string, CropVisual> = {
+  vegetable: { emoji: '🥬', accent: '#5b8c4a' },
+  vegetables: { emoji: '🥬', accent: '#5b8c4a' },
+  fruit: { emoji: '🍎', accent: '#c1452f' },
+  fruits: { emoji: '🍎', accent: '#c1452f' },
+  herb: { emoji: '🌿', accent: '#446e3b' },
+  herbs: { emoji: '🌿', accent: '#446e3b' },
+  flower: { emoji: '🌸', accent: '#c97aab' },
+  flowers: { emoji: '🌸', accent: '#c97aab' },
+  grain: { emoji: '🌾', accent: '#b08a3d' },
+  grains: { emoji: '🌾', accent: '#b08a3d' },
+  legume: { emoji: '🫘', accent: '#7a533c' },
+  legumes: { emoji: '🫘', accent: '#7a533c' },
+  root: { emoji: '🥕', accent: '#d36a2c' },
+  roots: { emoji: '🥕', accent: '#d36a2c' },
+  brassica: { emoji: '🥦', accent: '#436e3b' },
+  brassicas: { emoji: '🥦', accent: '#436e3b' },
+  squash: { emoji: '🎃', accent: '#d57a1f' },
+  cucurbit: { emoji: '🥒', accent: '#5b8c4a' },
+  cucurbits: { emoji: '🥒', accent: '#5b8c4a' },
+  allium: { emoji: '🧅', accent: '#a9826b' },
+  alliums: { emoji: '🧅', accent: '#a9826b' },
+  nightshade: { emoji: '🍅', accent: '#c1452f' },
+  nightshades: { emoji: '🍅', accent: '#c1452f' },
+  berry: { emoji: '🫐', accent: '#5e4ea3' },
+  berries: { emoji: '🫐', accent: '#5e4ea3' },
+};
+
+const nameToVisual: Array<{ match: RegExp; visual: CropVisual }> = [
+  { match: /tomato/i, visual: { emoji: '🍅', accent: '#c1452f' } },
+  { match: /pepper/i, visual: { emoji: '🌶️', accent: '#c1452f' } },
+  { match: /cucumber/i, visual: { emoji: '🥒', accent: '#5b8c4a' } },
+  { match: /carrot/i, visual: { emoji: '🥕', accent: '#d36a2c' } },
+  { match: /lettuce|salad/i, visual: { emoji: '🥬', accent: '#5b8c4a' } },
+  { match: /onion/i, visual: { emoji: '🧅', accent: '#a9826b' } },
+  { match: /garlic/i, visual: { emoji: '🧄', accent: '#cdb89c' } },
+  { match: /broccoli/i, visual: { emoji: '🥦', accent: '#436e3b' } },
+  { match: /corn|maize/i, visual: { emoji: '🌽', accent: '#d6a52c' } },
+  { match: /potato/i, visual: { emoji: '🥔', accent: '#a9826b' } },
+  { match: /pumpkin|squash/i, visual: { emoji: '🎃', accent: '#d57a1f' } },
+  { match: /strawberry/i, visual: { emoji: '🍓', accent: '#c1452f' } },
+  { match: /blueberry|berry/i, visual: { emoji: '🫐', accent: '#5e4ea3' } },
+  { match: /apple/i, visual: { emoji: '🍎', accent: '#c1452f' } },
+  { match: /grape/i, visual: { emoji: '🍇', accent: '#5e4ea3' } },
+  { match: /watermelon/i, visual: { emoji: '🍉', accent: '#3f8a4f' } },
+  { match: /lemon/i, visual: { emoji: '🍋', accent: '#d6c12c' } },
+  { match: /peach/i, visual: { emoji: '🍑', accent: '#e0935b' } },
+  { match: /eggplant|aubergine/i, visual: { emoji: '🍆', accent: '#5e4ea3' } },
+  { match: /basil/i, visual: { emoji: '🌿', accent: '#446e3b' } },
+  { match: /mint/i, visual: { emoji: '🌿', accent: '#3a7e5a' } },
+  { match: /rosemary/i, visual: { emoji: '🌿', accent: '#5b7a55' } },
+  { match: /thyme/i, visual: { emoji: '🌿', accent: '#608060' } },
+  { match: /parsley/i, visual: { emoji: '🌿', accent: '#446e3b' } },
+  { match: /cilantro|coriander/i, visual: { emoji: '🌿', accent: '#5b8c4a' } },
+  { match: /sunflower/i, visual: { emoji: '🌻', accent: '#d6a52c' } },
+  { match: /rose/i, visual: { emoji: '🌹', accent: '#c1452f' } },
+  { match: /tulip/i, visual: { emoji: '🌷', accent: '#c97aab' } },
+  { match: /bean/i, visual: { emoji: '🫘', accent: '#7a533c' } },
+  { match: /pea/i, visual: { emoji: '🌱', accent: '#5b8c4a' } },
+  { match: /kale|chard|spinach|collard/i, visual: { emoji: '🥬', accent: '#446e3b' } },
+];
+
+export function visualForCrop(name?: string | null, category?: string | null): CropVisual {
+  if (name) {
+    for (const entry of nameToVisual) {
+      if (entry.match.test(name)) return entry.visual;
+    }
+  }
+  if (category) {
+    const key = category.trim().toLowerCase();
+    if (categoryToVisual[key]) return categoryToVisual[key];
+  }
+  return DEFAULT_VISUAL;
+}
+
+export const CATEGORY_FILTERS: ReadonlyArray<{ id: string; label: string; emoji: string }> = [
+  { id: 'all', label: 'All', emoji: '🌍' },
+  { id: 'vegetable', label: 'Vegetables', emoji: '🥬' },
+  { id: 'fruit', label: 'Fruits', emoji: '🍎' },
+  { id: 'herb', label: 'Herbs', emoji: '🌿' },
+  { id: 'flower', label: 'Flowers', emoji: '🌸' },
+  { id: 'grain', label: 'Grains', emoji: '🌾' },
+];

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -1,17 +1,11 @@
-import { useState } from 'react';
-import type { ChangeEvent, FormEvent } from 'react';
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  listMyCrops,
-  createMyCrop,
-  updateMyCrop,
-  deleteMyCrop,
-  listCatalogCrops,
-} from '../../services/api';
-import type { UpsertGrowerCropRequest } from '../../services/api';
+import { listMyCrops, deleteMyCrop, listMyBeds } from '../../services/api';
 import type { GrowerCropItem } from '../../types/listing';
-import { Button, Card, Input, Select } from '@olivias/ui';
+import { Button, Card } from '@olivias/ui';
 import { createLogger } from '../../utils/logging';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
 
 const logger = createLogger('crop-library');
 
@@ -19,58 +13,58 @@ interface CropLibraryPanelProps {
   viewerUserId?: string;
 }
 
-export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
-  const [isAddingCrop, setIsAddingCrop] = useState(false);
-  const [editingCrop, setEditingCrop] = useState<GrowerCropItem | null>(null);
-  const [formData, setFormData] = useState({
-    cropName: '',
-    canonicalId: '',
-    status: 'interested',
-    visibility: 'local',
-    surplusEnabled: false,
-    nickname: '',
-    defaultUnit: '',
-    notes: '',
-  });
-  void viewerUserId;
+const STATUS_LABELS: Record<string, { label: string; emoji: string; tone: string }> = {
+  interested: { label: 'Interested', emoji: '💭', tone: 'neutral' },
+  planning: { label: 'Planning', emoji: '📋', tone: 'info' },
+  growing: { label: 'Growing', emoji: '🌱', tone: 'success' },
+  paused: { label: 'Paused', emoji: '⏸️', tone: 'muted' },
+};
 
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const parsed = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function daysUntil(iso: string | null): number | null {
+  if (!iso) return null;
+  const target = new Date(`${iso}T00:00:00Z`).getTime();
+  if (Number.isNaN(target)) return null;
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  return Math.round((target - today.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function harvestProgress(plantingDate: string | null, harvestDate: string | null): number | null {
+  if (!plantingDate || !harvestDate) return null;
+  const start = new Date(`${plantingDate}T00:00:00Z`).getTime();
+  const end = new Date(`${harvestDate}T00:00:00Z`).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return null;
+  const now = Date.now();
+  if (now <= start) return 0;
+  if (now >= end) return 100;
+  return Math.round(((now - start) / (end - start)) * 100);
+}
+
+export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
+  void viewerUserId;
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<'all' | 'growing' | 'planning' | 'interested'>('all');
 
   const { data: myCrops, isLoading: isLoadingCrops } = useQuery({
     queryKey: ['myCrops'],
     queryFn: listMyCrops,
   });
 
-  const { data: catalogCrops, isLoading: isLoadingCatalog } = useQuery({
-    queryKey: ['catalogCrops'],
-    queryFn: listCatalogCrops,
-  });
-
-  const createMutation = useMutation({
-    mutationFn: createMyCrop,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myCrops'] });
-      resetForm();
-      setIsAddingCrop(false);
-      logger.info('Crop added to library');
-    },
-    onError: (error) => {
-      logger.error('Failed to add crop', error instanceof Error ? error : undefined);
-    },
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UpsertGrowerCropRequest }) =>
-      updateMyCrop(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myCrops'] });
-      resetForm();
-      setEditingCrop(null);
-      logger.info('Crop updated');
-    },
-    onError: (error) => {
-      logger.error('Failed to update crop', error instanceof Error ? error : undefined);
-    },
+  const { data: beds = [] } = useQuery({
+    queryKey: ['myBeds'],
+    queryFn: listMyBeds,
   });
 
   const deleteMutation = useMutation({
@@ -84,265 +78,215 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
     },
   });
 
-  const resetForm = () => {
-    setFormData({
-      cropName: '',
-      canonicalId: '',
-      status: 'interested',
-      visibility: 'local',
-      surplusEnabled: false,
-      nickname: '',
-      defaultUnit: '',
-      notes: '',
-    });
-  };
+  const filteredCrops = useMemo(() => {
+    if (!myCrops) return [];
+    if (filter === 'all') return myCrops;
+    return myCrops.filter((crop) => crop.status === filter);
+  }, [myCrops, filter]);
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-
-    const data: UpsertGrowerCropRequest = {
-      cropName: formData.cropName,
-      canonicalId: formData.canonicalId || undefined,
-      status: formData.status,
-      visibility: formData.visibility,
-      surplusEnabled: formData.surplusEnabled,
-      nickname: formData.nickname || undefined,
-      defaultUnit: formData.defaultUnit || undefined,
-      notes: formData.notes || undefined,
-    };
-
-    if (editingCrop) {
-      updateMutation.mutate({ id: editingCrop.id, data });
-    } else {
-      createMutation.mutate(data);
+  const handleDelete = (crop: GrowerCropItem) => {
+    if (
+      confirm(
+        `Remove "${crop.nickname || crop.cropName}" from your garden? This won't delete any listings already created.`
+      )
+    ) {
+      deleteMutation.mutate(crop.id);
     }
   };
-
-  const handleEdit = (crop: GrowerCropItem) => {
-    setEditingCrop(crop);
-    setFormData({
-      cropName: crop.cropName,
-      canonicalId: crop.canonicalId || '',
-      status: crop.status,
-      visibility: crop.visibility,
-      surplusEnabled: crop.surplusEnabled,
-      nickname: crop.nickname || '',
-      defaultUnit: crop.defaultUnit || '',
-      notes: crop.notes || '',
-    });
-  };
-
-  const handleDelete = (cropId: string) => {
-    if (confirm('Are you sure you want to remove this crop from your library?')) {
-      deleteMutation.mutate(cropId);
-    }
-  };
-
-  const handleCancel = () => {
-    resetForm();
-    setIsAddingCrop(false);
-    setEditingCrop(null);
-  };
-
-  const catalogOptions = catalogCrops?.map(crop => ({
-    value: crop.id,
-    label: crop.commonName,
-  })) || [];
-
-  const getInputValue = (event: ChangeEvent<HTMLInputElement>) => event.target.value;
-
-  const statusOptions = [
-    { value: 'interested', label: 'Interested' },
-    { value: 'planning', label: 'Planning' },
-    { value: 'growing', label: 'Growing' },
-    { value: 'paused', label: 'Paused' },
-  ];
-
-  const visibilityOptions = [
-    { value: 'private', label: 'Private' },
-    { value: 'local', label: 'Local' },
-    { value: 'public', label: 'Public' },
-  ];
 
   if (isLoadingCrops) {
     return (
       <Card>
-        <div className="p-4 text-center">
-          <p className="text-gray-600">Loading your crop library...</p>
+        <div className="grn-page-status">
+          <p>Loading your garden…</p>
+        </div>
+      </Card>
+    );
+  }
+
+  const counts = {
+    all: myCrops?.length ?? 0,
+    growing: myCrops?.filter((c) => c.status === 'growing').length ?? 0,
+    planning: myCrops?.filter((c) => c.status === 'planning').length ?? 0,
+    interested: myCrops?.filter((c) => c.status === 'interested').length ?? 0,
+  };
+
+  if (!myCrops || myCrops.length === 0) {
+    return (
+      <Card padding="6">
+        <div className="grn-crop-empty">
+          <span className="grn-crop-empty__emoji" aria-hidden="true">🌱</span>
+          <h3>Your garden is a blank slate</h3>
+          <p>
+            Add your first crop and start mapping out beds, planting dates, and what you&apos;d like to grow.
+          </p>
+          <Button variant="primary" size="md" onClick={() => navigate('/crops/new')}>
+            Add a crop
+          </Button>
+          {beds.length === 0 ? (
+            <p className="grn-crop-empty__hint">
+              You can also set up garden beds while adding your first crop.
+            </p>
+          ) : null}
         </div>
       </Card>
     );
   }
 
   return (
-    <Card>
-      <div className="p-4">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-gray-900">My Crop Library</h3>
-          <Button
-            onClick={() => setIsAddingCrop(true)}
-            variant="primary"
-            size="sm"
-            disabled={isAddingCrop || !!editingCrop}
-          >
-            Add Crop
+    <div className="grn-crop-library">
+      <Card padding="6">
+        <div className="grn-crop-library__head">
+          <div>
+            <h3 className="grn-crop-library__title">My garden</h3>
+            <p className="grn-crop-library__subtitle">
+              {counts.all} crop{counts.all === 1 ? '' : 's'} tracked
+              {beds.length ? ` · ${beds.length} bed${beds.length === 1 ? '' : 's'}` : ''}
+            </p>
+          </div>
+          <Button variant="primary" size="sm" onClick={() => navigate('/crops/new')}>
+            + Add crop
           </Button>
         </div>
 
-        {(isAddingCrop || editingCrop) && (
-          <form onSubmit={handleSubmit} className="mb-6 p-4 bg-gray-50 rounded-lg">
-            <h4 className="text-md font-medium mb-3">
-              {editingCrop ? 'Edit Crop' : 'Add New Crop'}
-            </h4>
+        <div className="grn-crop-library__filters" role="tablist" aria-label="Filter crops by status">
+          {([
+            { id: 'all', label: 'All', count: counts.all },
+            { id: 'growing', label: 'Growing', count: counts.growing },
+            { id: 'planning', label: 'Planning', count: counts.planning },
+            { id: 'interested', label: 'Interested', count: counts.interested },
+          ] as const).map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={filter === tab.id}
+              className={`grn-crop-library__tab ${filter === tab.id ? 'is-active' : ''}`.trim()}
+              onClick={() => setFilter(tab.id)}
+            >
+              <span>{tab.label}</span>
+              <span className="grn-crop-library__tab-count">{tab.count}</span>
+            </button>
+          ))}
+        </div>
 
-            <div className="space-y-4">
-              <Input
-                label="Crop Name"
-                value={formData.cropName}
-                onChange={(event) => setFormData(prev => ({ ...prev, cropName: getInputValue(event) }))}
-                placeholder="e.g., Heirloom Tomatoes, Mystery Squash"
-                required
-              />
+        <div className="grn-crop-grid">
+          {filteredCrops.map((crop) => {
+            const visual = visualForCrop(crop.cropName, null);
+            const status = STATUS_LABELS[crop.status] ?? STATUS_LABELS.interested;
+            const planted = formatDate(crop.plantingDate);
+            const harvest = formatDate(crop.expectedHarvestDate);
+            const harvestIn = daysUntil(crop.expectedHarvestDate);
+            const progress = harvestProgress(crop.plantingDate, crop.expectedHarvestDate);
 
-              <Select
-                label="Link to Catalog Crop (Optional)"
-                value={formData.canonicalId}
-                onChange={(value) => setFormData(prev => ({ ...prev, canonicalId: value }))}
-                options={[
-                  { value: '', label: 'No catalog link (custom crop)' },
-                  ...catalogOptions,
-                ]}
-                disabled={isLoadingCatalog}
-              />
+            return (
+              <article key={crop.id} className="grn-crop-card">
+                <header
+                  className="grn-crop-card__header"
+                  style={{
+                    background: `linear-gradient(135deg, ${visual.accent}33, ${visual.accent}10)`,
+                  }}
+                >
+                  <span className="grn-crop-card__emoji" aria-hidden="true">
+                    {visual.emoji}
+                  </span>
+                  <span className={`grn-crop-card__status grn-crop-card__status--${status.tone}`}>
+                    <span aria-hidden="true">{status.emoji}</span>
+                    {status.label}
+                  </span>
+                </header>
 
-              <Select
-                label="Status"
-                value={formData.status}
-                onChange={(value) => setFormData(prev => ({ ...prev, status: value }))}
-                options={statusOptions}
-                required
-              />
+                <div className="grn-crop-card__body">
+                  <h4 className="grn-crop-card__name">
+                    {crop.nickname || crop.cropName}
+                  </h4>
+                  {crop.nickname ? (
+                    <p className="grn-crop-card__subname">{crop.cropName}</p>
+                  ) : null}
 
-              <Select
-                label="Visibility"
-                value={formData.visibility}
-                onChange={(value) => setFormData(prev => ({ ...prev, visibility: value }))}
-                options={visibilityOptions}
-                required
-              />
+                  <ul className="grn-crop-card__facts">
+                    {crop.bedName ? (
+                      <li>
+                        <span aria-hidden="true">🛏️</span>
+                        <span>{crop.bedName}</span>
+                      </li>
+                    ) : null}
+                    {planted ? (
+                      <li>
+                        <span aria-hidden="true">🌱</span>
+                        <span>Planted {planted}</span>
+                      </li>
+                    ) : null}
+                    {harvest ? (
+                      <li>
+                        <span aria-hidden="true">🌾</span>
+                        <span>
+                          Harvest {harvest}
+                          {harvestIn !== null && harvestIn >= 0
+                            ? ` · in ${harvestIn} day${harvestIn === 1 ? '' : 's'}`
+                            : ''}
+                        </span>
+                      </li>
+                    ) : null}
+                    {crop.plantCount ? (
+                      <li>
+                        <span aria-hidden="true">🔢</span>
+                        <span>
+                          {crop.plantCount} plant{crop.plantCount === 1 ? '' : 's'}
+                          {crop.spacingInches ? ` · ${crop.spacingInches}" apart` : ''}
+                        </span>
+                      </li>
+                    ) : null}
+                    {crop.surplusEnabled ? (
+                      <li>
+                        <span aria-hidden="true">🤝</span>
+                        <span>Surplus sharing on</span>
+                      </li>
+                    ) : null}
+                  </ul>
 
-              <div className="flex items-center">
-                <input
-                  type="checkbox"
-                  id="surplusEnabled"
-                  checked={formData.surplusEnabled}
-                  onChange={(e) => setFormData(prev => ({ ...prev, surplusEnabled: e.target.checked }))}
-                  className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
-                />
-                <label htmlFor="surplusEnabled" className="ml-2 text-sm text-gray-700">
-                  Enable surplus sharing
-                </label>
-              </div>
-
-              <Input
-                label="Nickname (Optional)"
-                value={formData.nickname}
-                onChange={(event) => setFormData(prev => ({ ...prev, nickname: getInputValue(event) }))}
-                placeholder="e.g., Big Boy, Sweet 100s"
-              />
-
-              <Input
-                label="Default Unit (Optional)"
-                value={formData.defaultUnit}
-                onChange={(event) => setFormData(prev => ({ ...prev, defaultUnit: getInputValue(event) }))}
-                placeholder="e.g., lb, bunch, each"
-              />
-
-              <Input
-                label="Notes (Optional)"
-                value={formData.notes}
-                onChange={(event) => setFormData(prev => ({ ...prev, notes: getInputValue(event) }))}
-                placeholder="Any additional notes about this crop"
-              />
-            </div>
-
-            <div className="flex gap-2 mt-4">
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                disabled={createMutation.isPending || updateMutation.isPending}
-              >
-                {createMutation.isPending || updateMutation.isPending ? 'Saving...' : 'Save'}
-              </Button>
-              <Button
-                type="button"
-                onClick={handleCancel}
-                variant="secondary"
-                size="sm"
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        )}
-
-        <div className="space-y-2">
-          {myCrops?.length === 0 ? (
-            <p className="text-gray-500 text-center py-8">
-              No crops in your library yet. Add your first crop above!
-            </p>
-          ) : (
-            myCrops?.map((crop) => (
-              <div
-                key={crop.id}
-                className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
-              >
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-gray-900">
-                      {crop.nickname || crop.cropName}
-                    </span>
-                    {crop.canonicalId && (
-                      <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
-                        Catalog
-                      </span>
-                    )}
-                    {!crop.canonicalId && (
-                      <span className="text-xs bg-green-100 text-green-800 px-2 py-1 rounded">
-                        Custom
-                      </span>
-                    )}
-                  </div>
-                  <div className="text-sm text-gray-600">
-                    Status: {crop.status} • Visibility: {crop.visibility}
-                    {crop.surplusEnabled && ' • Surplus enabled'}
-                  </div>
+                  {progress !== null ? (
+                    <div
+                      className="grn-crop-card__progress"
+                      role="progressbar"
+                      aria-valuenow={progress}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-label="Days planted vs days to harvest"
+                    >
+                      <span
+                        className="grn-crop-card__progress-bar"
+                        style={{ width: `${progress}%`, background: visual.accent }}
+                      />
+                    </div>
+                  ) : null}
                 </div>
-                <div className="flex gap-2">
+
+                <footer className="grn-crop-card__footer">
                   <Button
-                    onClick={() => handleEdit(crop)}
-                    variant="secondary"
+                    variant="ghost"
                     size="sm"
-                    disabled={isAddingCrop || !!editingCrop}
+                    onClick={() => navigate(`/crops/new?edit=${crop.id}`)}
+                    disabled
+                    title="Editing comes next — for now, remove and re-add"
                   >
                     Edit
                   </Button>
                   <Button
-                    onClick={() => handleDelete(crop.id)}
                     variant="outline"
                     size="sm"
+                    onClick={() => handleDelete(crop)}
                     disabled={deleteMutation.isPending}
-                    className="!border-red-300 !text-red-600 hover:!bg-red-50"
+                    className="grn-crop-card__remove"
                   >
                     Remove
                   </Button>
-                </div>
-              </div>
-            ))
-          )}
+                </footer>
+              </article>
+            );
+          })}
         </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }

--- a/apps/grn/src/pages/CropsPage.tsx
+++ b/apps/grn/src/pages/CropsPage.tsx
@@ -16,7 +16,7 @@ export function CropsPage() {
   if (isLoading) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Grower tools" title="Crop library" />
+        <SectionHeading eyebrow="Grower tools" title="My garden" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading…</p>
@@ -33,8 +33,8 @@ export function CropsPage() {
     <section className="grn-section">
       <SectionHeading
         eyebrow="Grower tools"
-        title="Crop library"
-        body="Track what you grow and prep listings from your library."
+        title="My garden"
+        body="Track what you grow, when it goes in the ground, and where it lives."
       />
       <CropLibraryPanel viewerUserId={profile.id} />
     </section>

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -1,0 +1,469 @@
+import { useMemo, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button, Card, Input, Panel, SectionHeading, Textarea } from '@olivias/ui';
+import {
+  createMyCrop,
+  getMe,
+  listCatalogCrops,
+  listMyBeds,
+  type UpsertGrowerCropRequest,
+} from '../services/api';
+import { CropPicker, type CropPickerSelection } from '../components/CropPlanner/CropPicker';
+import { BedSelector } from '../components/CropPlanner/BedSelector';
+import { visualForCrop } from '../components/CropPlanner/cropVisuals';
+import { PlantLoader } from '../components/branding/PlantLoader';
+import { createLogger } from '../utils/logging';
+
+const logger = createLogger('new-crop-page');
+
+interface PlantingDetails {
+  bedId: string | null;
+  plantingDate: string;
+  expectedHarvestDate: string;
+  plantCount: string;
+  spacingInches: string;
+  status: 'interested' | 'planning' | 'growing' | 'paused';
+}
+
+interface AdvancedDetails {
+  nickname: string;
+  defaultUnit: string;
+  notes: string;
+  visibility: 'private' | 'local' | 'public';
+  surplusEnabled: boolean;
+}
+
+const STATUS_OPTIONS: Array<{
+  id: PlantingDetails['status'];
+  label: string;
+  description: string;
+  emoji: string;
+}> = [
+  { id: 'interested', label: 'Interested', description: 'Just noting it down', emoji: '💭' },
+  { id: 'planning', label: 'Planning', description: 'I plan to plant this season', emoji: '📋' },
+  { id: 'growing', label: 'Growing', description: "It's in the ground right now", emoji: '🌱' },
+  { id: 'paused', label: 'Paused', description: 'Taking a break', emoji: '⏸️' },
+];
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDaysIso(base: string, days: number): string {
+  const d = new Date(`${base}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(a: string, b: string): number | null {
+  if (!a || !b) return null;
+  const start = new Date(`${a}T00:00:00Z`).getTime();
+  const end = new Date(`${b}T00:00:00Z`).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.round((end - start) / (1000 * 60 * 60 * 24));
+}
+
+export function NewCropPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: profile, isLoading: isLoadingProfile } = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getMe,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: catalog = [], isLoading: isLoadingCatalog } = useQuery({
+    queryKey: ['catalogCrops'],
+    queryFn: listCatalogCrops,
+  });
+
+  const { data: beds = [], isLoading: isLoadingBeds } = useQuery({
+    queryKey: ['myBeds'],
+    queryFn: listMyBeds,
+    enabled: profile?.userType === 'grower',
+  });
+
+  const [selection, setSelection] = useState<CropPickerSelection | null>(null);
+  const [planting, setPlanting] = useState<PlantingDetails>({
+    bedId: null,
+    plantingDate: '',
+    expectedHarvestDate: '',
+    plantCount: '',
+    spacingInches: '',
+    status: 'planning',
+  });
+  const [advanced, setAdvanced] = useState<AdvancedDetails>({
+    nickname: '',
+    defaultUnit: '',
+    notes: '',
+    visibility: 'local',
+    surplusEnabled: false,
+  });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const visual = useMemo(
+    () => visualForCrop(selection?.cropName, selection?.category),
+    [selection]
+  );
+
+  const daysToHarvest = useMemo(
+    () => daysBetween(planting.plantingDate, planting.expectedHarvestDate),
+    [planting.plantingDate, planting.expectedHarvestDate]
+  );
+
+  const createMutation = useMutation({
+    mutationFn: createMyCrop,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myCrops'] });
+      logger.info('Created crop from new-crop page');
+      navigate('/crops', { replace: true });
+    },
+    onError: (err) => {
+      logger.error('Failed to create crop', err instanceof Error ? err : undefined);
+      setSubmitError(err instanceof Error ? err.message : 'Could not save your crop');
+    },
+  });
+
+  if (isLoadingProfile) {
+    return (
+      <section className="grn-section">
+        <Panel className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Loading your garden…</p>
+        </Panel>
+      </section>
+    );
+  }
+
+  if (!profile || profile.userType !== 'grower') {
+    return <Navigate to="/" replace />;
+  }
+
+  const canSubmit =
+    selection !== null &&
+    selection.cropName.trim().length > 0 &&
+    !createMutation.isPending;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmitError(null);
+    if (!selection) {
+      setSubmitError('Pick a crop first.');
+      return;
+    }
+    const trimmedName = selection.cropName.trim();
+    if (!trimmedName) {
+      setSubmitError('Crop needs a name.');
+      return;
+    }
+
+    const payload: UpsertGrowerCropRequest = {
+      cropName: trimmedName,
+      canonicalId: selection.catalogCropId ?? undefined,
+      status: planting.status,
+      visibility: advanced.visibility,
+      surplusEnabled: advanced.surplusEnabled,
+      nickname: advanced.nickname.trim() || undefined,
+      defaultUnit: advanced.defaultUnit.trim() || undefined,
+      notes: advanced.notes.trim() || undefined,
+      bedId: planting.bedId,
+      plantingDate: planting.plantingDate || null,
+      expectedHarvestDate: planting.expectedHarvestDate || null,
+      plantCount: planting.plantCount ? Number(planting.plantCount) : null,
+      spacingInches: planting.spacingInches ? Number(planting.spacingInches) : null,
+    };
+
+    createMutation.mutate(payload);
+  };
+
+  return (
+    <section className="grn-section grn-new-crop">
+      <SectionHeading
+        eyebrow="Plan your garden"
+        title="Add a crop"
+        body="Tell us what's going in the ground — we'll tuck it into your garden plan."
+      />
+
+      <form onSubmit={handleSubmit} className="grn-new-crop__form">
+        <Card className="grn-new-crop__hero" padding="6">
+          <div
+            className="grn-new-crop__hero-visual"
+            style={{ background: `linear-gradient(135deg, ${visual.accent}33, ${visual.accent}10)` }}
+            aria-hidden="true"
+          >
+            <span className="grn-new-crop__hero-emoji">{visual.emoji}</span>
+          </div>
+          <div className="grn-new-crop__hero-body">
+            <CropPicker
+              catalog={catalog}
+              isLoading={isLoadingCatalog}
+              value={selection}
+              onChange={setSelection}
+            />
+          </div>
+        </Card>
+
+        <Card padding="6">
+          <div className="grn-new-crop__section-head">
+            <span className="grn-new-crop__step">2</span>
+            <div>
+              <h2 className="grn-new-crop__section-title">Planting plan</h2>
+              <p className="grn-new-crop__section-sub">
+                Where it&apos;s going, when, and how many. Skip anything you don&apos;t know yet.
+              </p>
+            </div>
+          </div>
+
+          <fieldset className="grn-status-picker" aria-label="Planting status">
+            {STATUS_OPTIONS.map((option) => {
+              const isActive = planting.status === option.id;
+              return (
+                <label
+                  key={option.id}
+                  className={`grn-status-option ${isActive ? 'is-active' : ''}`.trim()}
+                >
+                  <input
+                    type="radio"
+                    name="planting-status"
+                    value={option.id}
+                    checked={isActive}
+                    onChange={() =>
+                      setPlanting((prev) => ({
+                        ...prev,
+                        status: option.id,
+                        // When the gardener says "it's growing now", default planting
+                        // date to today so the harvest progress bar starts ticking.
+                        plantingDate:
+                          option.id === 'growing' && !prev.plantingDate
+                            ? todayIso()
+                            : prev.plantingDate,
+                      }))
+                    }
+                  />
+                  <span className="grn-status-option__emoji" aria-hidden="true">
+                    {option.emoji}
+                  </span>
+                  <span className="grn-status-option__text">
+                    <strong>{option.label}</strong>
+                    <span>{option.description}</span>
+                  </span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          <BedSelector
+            beds={beds}
+            isLoading={isLoadingBeds}
+            value={planting.bedId}
+            onChange={(bedId) => setPlanting((prev) => ({ ...prev, bedId }))}
+          />
+
+          <div className="grn-new-crop__row">
+            <Input
+              label="Planting date"
+              type="text"
+              placeholder="YYYY-MM-DD"
+              value={planting.plantingDate}
+              onChange={(event) =>
+                setPlanting((prev) => ({ ...prev, plantingDate: event.target.value }))
+              }
+            />
+            <Input
+              label="Expected first harvest"
+              type="text"
+              placeholder="YYYY-MM-DD"
+              value={planting.expectedHarvestDate}
+              onChange={(event) =>
+                setPlanting((prev) => ({ ...prev, expectedHarvestDate: event.target.value }))
+              }
+            />
+          </div>
+
+          <div className="grn-quick-pick" role="group" aria-label="Quick harvest estimates">
+            <span className="grn-quick-pick__label">Typical harvest window:</span>
+            {[60, 75, 90, 120].map((days) => (
+              <button
+                key={days}
+                type="button"
+                className="grn-quick-pick__chip"
+                onClick={() => {
+                  const start = planting.plantingDate || todayIso();
+                  setPlanting((prev) => ({
+                    ...prev,
+                    plantingDate: prev.plantingDate || start,
+                    expectedHarvestDate: addDaysIso(start, days),
+                  }));
+                }}
+                disabled={!!daysToHarvest && daysToHarvest === days}
+              >
+                {days} days
+              </button>
+            ))}
+          </div>
+
+          {daysToHarvest !== null ? (
+            <p className="grn-new-crop__harvest-hint">
+              {daysToHarvest >= 0
+                ? `🌾 About ${daysToHarvest} day${daysToHarvest === 1 ? '' : 's'} until first harvest`
+                : `⚠️ Harvest date is before planting date — double-check the dates above.`}
+            </p>
+          ) : null}
+
+          <div className="grn-new-crop__row">
+            <Input
+              label="Number of plants"
+              type="number"
+              min={1}
+              placeholder="e.g. 6"
+              value={planting.plantCount}
+              onChange={(event) =>
+                setPlanting((prev) => ({ ...prev, plantCount: event.target.value }))
+              }
+            />
+            <Input
+              label="Spacing (inches)"
+              type="number"
+              min={0}
+              placeholder="e.g. 18"
+              value={planting.spacingInches}
+              onChange={(event) =>
+                setPlanting((prev) => ({ ...prev, spacingInches: event.target.value }))
+              }
+            />
+          </div>
+        </Card>
+
+        <Card padding="6">
+          <button
+            type="button"
+            className="grn-disclosure"
+            aria-expanded={showAdvanced}
+            onClick={() => setShowAdvanced((prev) => !prev)}
+          >
+            <span className="grn-disclosure__chevron" aria-hidden="true">
+              {showAdvanced ? '▾' : '▸'}
+            </span>
+            <span>
+              <strong>Notes &amp; sharing</strong>
+              <span className="grn-disclosure__hint">
+                {' '}
+                — nickname, units, and whether to share surplus with the community.
+              </span>
+            </span>
+          </button>
+
+          {showAdvanced ? (
+            <div className="grn-new-crop__advanced">
+              <div className="grn-new-crop__row">
+                <Input
+                  label="Nickname"
+                  placeholder="e.g. Big Boy, Sweet 100s"
+                  value={advanced.nickname}
+                  onChange={(event) =>
+                    setAdvanced((prev) => ({ ...prev, nickname: event.target.value }))
+                  }
+                />
+                <Input
+                  label="Default harvest unit"
+                  placeholder="lb, bunch, each"
+                  value={advanced.defaultUnit}
+                  onChange={(event) =>
+                    setAdvanced((prev) => ({ ...prev, defaultUnit: event.target.value }))
+                  }
+                />
+              </div>
+              <Textarea
+                label="Notes"
+                placeholder="Anything you want to remember — varieties tried, soil amendments, etc."
+                rows={3}
+                value={advanced.notes}
+                onChange={(event) =>
+                  setAdvanced((prev) => ({ ...prev, notes: event.target.value }))
+                }
+              />
+
+              <div className="grn-share-toggle">
+                <label className="grn-share-toggle__row">
+                  <input
+                    type="checkbox"
+                    checked={advanced.surplusEnabled}
+                    onChange={(event) =>
+                      setAdvanced((prev) => ({
+                        ...prev,
+                        surplusEnabled: event.target.checked,
+                      }))
+                    }
+                  />
+                  <span>
+                    <strong>Share surplus with neighbors</strong>
+                    <span>
+                      When you have extra, you can list it for nearby gatherers without retyping crop info.
+                    </span>
+                  </span>
+                </label>
+
+                {advanced.surplusEnabled ? (
+                  <fieldset className="grn-share-toggle__visibility">
+                    <legend>Who can see this crop in your garden?</legend>
+                    {(
+                      [
+                        { id: 'private', label: 'Just me', emoji: '🔒' },
+                        { id: 'local', label: 'Nearby community', emoji: '🤝' },
+                        { id: 'public', label: 'Anyone on GRN', emoji: '🌍' },
+                      ] as const
+                    ).map((option) => (
+                      <label
+                        key={option.id}
+                        className={`grn-share-toggle__option ${
+                          advanced.visibility === option.id ? 'is-active' : ''
+                        }`.trim()}
+                      >
+                        <input
+                          type="radio"
+                          name="visibility"
+                          value={option.id}
+                          checked={advanced.visibility === option.id}
+                          onChange={() =>
+                            setAdvanced((prev) => ({ ...prev, visibility: option.id }))
+                          }
+                        />
+                        <span aria-hidden="true">{option.emoji}</span>
+                        <span>{option.label}</span>
+                      </label>
+                    ))}
+                  </fieldset>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </Card>
+
+        {submitError ? (
+          <p className="grn-new-crop__submit-error" role="alert">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="grn-new-crop__actions">
+          <Button
+            type="button"
+            variant="ghost"
+            size="md"
+            onClick={() => navigate('/crops')}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="md" disabled={!canSubmit}>
+            {createMutation.isPending ? 'Planting…' : 'Add to my garden'}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+export default NewCropPage;

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -6,9 +6,11 @@ import type {
   CatalogCrop,
   CatalogVariety,
   DiscoverListingsResponse,
+  GardenBed,
   GrowerCropItem,
   Listing,
   ListMyListingsResponse,
+  SunExposure,
   UpsertListingRequest,
 } from '../types/listing';
 import type { RequestItem, UpsertRequestPayload } from '../types/request';
@@ -230,6 +232,27 @@ interface RawGrowerCropItem {
   nickname: string | null;
   default_unit: string | null;
   notes: string | null;
+  bed_id: string | null;
+  bed_name: string | null;
+  planting_date: string | null;
+  expected_harvest_date: string | null;
+  plant_count: number | null;
+  spacing_inches: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RawGardenBed {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  sun_exposure: SunExposure | null;
+  soil_type: string | null;
+  length_inches: number | null;
+  width_inches: number | null;
+  location_notes: string | null;
+  sort_order: number;
   created_at: string;
   updated_at: string;
 }
@@ -406,6 +429,29 @@ function mapGrowerCropItem(raw: RawGrowerCropItem): GrowerCropItem {
     nickname: raw.nickname,
     defaultUnit: raw.default_unit,
     notes: raw.notes,
+    bedId: raw.bed_id ?? null,
+    bedName: raw.bed_name ?? null,
+    plantingDate: raw.planting_date ?? null,
+    expectedHarvestDate: raw.expected_harvest_date ?? null,
+    plantCount: raw.plant_count ?? null,
+    spacingInches: raw.spacing_inches ?? null,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function mapGardenBed(raw: RawGardenBed): GardenBed {
+  return {
+    id: raw.id,
+    userId: raw.user_id,
+    name: raw.name,
+    description: raw.description,
+    sunExposure: raw.sun_exposure,
+    soilType: raw.soil_type,
+    lengthInches: raw.length_inches,
+    widthInches: raw.width_inches,
+    locationNotes: raw.location_notes,
+    sortOrder: raw.sort_order,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
   };
@@ -647,6 +693,11 @@ export interface UpsertGrowerCropRequest {
   nickname?: string;
   defaultUnit?: string;
   notes?: string;
+  bedId?: string | null;
+  plantingDate?: string | null;
+  expectedHarvestDate?: string | null;
+  plantCount?: number | null;
+  spacingInches?: number | null;
 }
 
 export async function createMyCrop(data: UpsertGrowerCropRequest): Promise<GrowerCropItem> {
@@ -667,6 +718,44 @@ export async function updateMyCrop(cropId: string, data: UpsertGrowerCropRequest
 
 export async function deleteMyCrop(cropId: string): Promise<void> {
   await apiFetch(`/crops/${cropId}`, {
+    method: 'DELETE',
+  });
+}
+
+export interface UpsertGardenBedRequest {
+  name: string;
+  description?: string | null;
+  sunExposure?: SunExposure | null;
+  soilType?: string | null;
+  lengthInches?: number | null;
+  widthInches?: number | null;
+  locationNotes?: string | null;
+  sortOrder?: number;
+}
+
+export async function listMyBeds(): Promise<GardenBed[]> {
+  const response = await apiFetch<RawGardenBed[]>('/beds');
+  return response.map(mapGardenBed);
+}
+
+export async function createMyBed(data: UpsertGardenBedRequest): Promise<GardenBed> {
+  const response = await apiFetch<RawGardenBed>('/beds', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return mapGardenBed(response);
+}
+
+export async function updateMyBed(bedId: string, data: UpsertGardenBedRequest): Promise<GardenBed> {
+  const response = await apiFetch<RawGardenBed>(`/beds/${bedId}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+  return mapGardenBed(response);
+}
+
+export async function deleteMyBed(bedId: string): Promise<void> {
+  await apiFetch(`/beds/${bedId}`, {
     method: 'DELETE',
   });
 }

--- a/apps/grn/src/shell/AppShell.tsx
+++ b/apps/grn/src/shell/AppShell.tsx
@@ -43,7 +43,7 @@ const growerNavItems: NavItem[] = [
   {
     id: 'crops',
     path: '/crops',
-    label: 'Crop library',
+    label: 'My garden',
     icon: (
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -11,6 +11,9 @@ const DashboardPage = lazy(() =>
 const CropsPage = lazy(() =>
   import('../pages/CropsPage').then((m) => ({ default: m.CropsPage }))
 );
+const NewCropPage = lazy(() =>
+  import('../pages/NewCropPage').then((m) => ({ default: m.NewCropPage }))
+);
 const ListingsPage = lazy(() =>
   import('../pages/ListingsPage').then((m) => ({ default: m.ListingsPage }))
 );
@@ -50,6 +53,7 @@ export function AuthenticatedRoot() {
             <Routes>
               <Route path="/" element={<DashboardPage />} />
               <Route path="/crops" element={<CropsPage />} />
+              <Route path="/crops/new" element={<NewCropPage />} />
               <Route path="/listings" element={<ListingsPage />} />
               <Route path="/requests" element={<RequestsPage />} />
               <Route path="/reminders" element={<RemindersPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -552,3 +552,924 @@ body {
     width: 100%;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────
+ * Crop planner: /crops/new flow + crop library cards + beds.
+ * Uses --og-* tokens from @olivias/ui so styling matches the rest
+ * of the app (creamy paper backgrounds, moss/soil ink, soft shadows).
+ * ────────────────────────────────────────────────────────────────── */
+
+.grn-new-crop {
+  max-width: 880px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.grn-new-crop__form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.grn-new-crop__hero {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) 1fr;
+  gap: clamp(1rem, 3vw, 1.75rem);
+  align-items: stretch;
+}
+
+.grn-new-crop__hero-visual {
+  border-radius: var(--og-radius-md);
+  display: grid;
+  place-items: center;
+  min-height: 9rem;
+}
+
+.grn-new-crop__hero-emoji {
+  font-size: clamp(3rem, 8vw, 4.5rem);
+  line-height: 1;
+  filter: drop-shadow(0 6px 14px rgba(38, 23, 15, 0.15));
+}
+
+.grn-new-crop__hero-body {
+  display: grid;
+  align-content: center;
+}
+
+.grn-new-crop__section-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  margin-bottom: 1.25rem;
+}
+
+.grn-new-crop__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.grn-new-crop__section-title {
+  margin: 0 0 0.25rem;
+  font-family: var(--og-font-display);
+  color: var(--og-color-soil);
+  font-size: 1.25rem;
+}
+
+.grn-new-crop__section-sub {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.95rem;
+}
+
+.grn-new-crop__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.grn-new-crop__harvest-hint {
+  margin: 0.5rem 0 0;
+  color: var(--og-color-moss);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.grn-new-crop__advanced {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.grn-new-crop__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.grn-new-crop__submit-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--og-radius-md);
+  background: rgba(173, 32, 27, 0.08);
+  color: #93221d;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 600px) {
+  .grn-new-crop__hero {
+    grid-template-columns: 1fr;
+  }
+  .grn-new-crop__hero-visual {
+    min-height: 7rem;
+  }
+}
+
+/* ── Crop picker (search + autocomplete) ─────────────────────────── */
+
+.grn-crop-picker {
+  position: relative;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.grn-crop-picker__label {
+  font-family: var(--og-font-display);
+  font-size: 1.1rem;
+  color: var(--og-color-soil);
+  margin: 0;
+}
+
+.grn-crop-picker__hint {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.88rem;
+}
+
+.grn-crop-picker__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.grn-crop-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  background: rgba(255, 252, 246, 0.92);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.grn-crop-chip:hover {
+  background: rgba(232, 222, 203, 0.8);
+}
+
+.grn-crop-chip.is-active {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  border-color: var(--og-color-moss);
+}
+
+.grn-crop-picker__field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid rgba(79, 56, 37, 0.18);
+  background: var(--og-color-paper);
+  border-radius: var(--og-radius-md);
+  padding: 0.6rem 0.85rem;
+  box-shadow: 0 2px 8px rgba(38, 23, 15, 0.06);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.grn-crop-picker__field:focus-within {
+  border-color: var(--og-color-moss);
+  box-shadow: 0 0 0 3px rgba(66, 107, 63, 0.18);
+}
+
+.grn-crop-picker__leading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  color: var(--og-color-moss);
+  flex-shrink: 0;
+}
+
+.grn-crop-picker__leading svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.grn-crop-picker__leading-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--og-radius-sm);
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.grn-crop-picker__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: 1rem;
+  color: var(--og-color-ink);
+  padding: 0.25rem 0;
+  outline: none;
+}
+
+.grn-crop-picker__input:disabled {
+  color: rgba(79, 56, 37, 0.5);
+}
+
+.grn-crop-picker__clear {
+  border: none;
+  background: transparent;
+  color: rgba(79, 56, 37, 0.55);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem;
+  border-radius: 999px;
+}
+
+.grn-crop-picker__clear:hover {
+  color: var(--og-color-soil);
+  background: rgba(79, 56, 37, 0.08);
+}
+
+.grn-crop-picker__clear svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.grn-crop-picker__selected {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.92rem;
+  color: var(--og-color-soil);
+}
+
+.grn-crop-picker__pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.grn-crop-picker__pill--catalog {
+  background: rgba(66, 107, 63, 0.16);
+  color: var(--og-color-moss);
+}
+
+.grn-crop-picker__pill--custom {
+  background: rgba(216, 167, 65, 0.18);
+  color: #8a5c1d;
+}
+
+.grn-crop-picker__listbox {
+  list-style: none;
+  margin: 0.35rem 0 0;
+  padding: 0.3rem;
+  background: var(--og-color-paper);
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: var(--og-radius-md);
+  box-shadow: 0 18px 32px rgba(38, 23, 15, 0.16);
+  position: absolute;
+  inset-inline: 0;
+  top: 100%;
+  z-index: 20;
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.grn-crop-picker__option {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: var(--og-radius-sm);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.grn-crop-picker__option.is-highlighted,
+.grn-crop-picker__option:hover {
+  background: rgba(232, 222, 203, 0.6);
+}
+
+.grn-crop-picker__option--custom {
+  border-top: 1px dashed rgba(79, 56, 37, 0.15);
+  margin-top: 0.25rem;
+  padding-top: 0.65rem;
+}
+
+.grn-crop-picker__option-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: var(--og-radius-sm);
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.grn-crop-picker__option-text {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.grn-crop-picker__option-name {
+  color: var(--og-color-soil);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.grn-crop-picker__option-meta {
+  color: rgba(79, 56, 37, 0.65);
+  font-size: 0.8rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.grn-crop-picker__option-meta em {
+  font-style: italic;
+}
+
+/* ── Status picker pills ─────────────────────────────────────────── */
+
+.grn-status-picker {
+  border: none;
+  padding: 0;
+  margin: 0 0 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.65rem;
+}
+
+.grn-status-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.grn-status-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.grn-status-option:hover {
+  border-color: rgba(66, 107, 63, 0.4);
+}
+
+.grn-status-option.is-active {
+  border-color: var(--og-color-moss);
+  background: rgba(66, 107, 63, 0.08);
+  box-shadow: 0 0 0 2px rgba(66, 107, 63, 0.18);
+}
+
+.grn-status-option__emoji {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.grn-status-option__text {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.grn-status-option__text strong {
+  color: var(--og-color-soil);
+  font-size: 0.95rem;
+}
+
+.grn-status-option__text span {
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.82rem;
+}
+
+/* ── Bed selector grid ───────────────────────────────────────────── */
+
+.grn-bed-selector {
+  margin: 1.25rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.grn-bed-selector__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.grn-bed-selector__title {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+  color: var(--og-color-soil);
+}
+
+.grn-bed-selector__hint {
+  margin: 0.15rem 0 0;
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.85rem;
+}
+
+.grn-bed-selector__loading {
+  padding: 1rem;
+  background: rgba(232, 222, 203, 0.4);
+  border-radius: var(--og-radius-sm);
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.grn-bed-selector__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.65rem;
+}
+
+.grn-bed-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.grn-bed-card:hover {
+  border-color: rgba(66, 107, 63, 0.4);
+}
+
+.grn-bed-card.is-selected {
+  border-color: var(--og-color-moss);
+  background: rgba(66, 107, 63, 0.08);
+  box-shadow: 0 0 0 2px rgba(66, 107, 63, 0.18);
+}
+
+.grn-bed-card--unassigned {
+  background: rgba(232, 222, 203, 0.4);
+  border-style: dashed;
+}
+
+.grn-bed-card__emoji {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.grn-bed-card__body {
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.88rem;
+  color: var(--og-color-soil);
+  min-width: 0;
+}
+
+.grn-bed-card__body strong {
+  font-size: 0.95rem;
+}
+
+.grn-bed-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.8rem;
+}
+
+.grn-bed-selector__add {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: var(--og-radius-md);
+  background: rgba(232, 222, 203, 0.4);
+  border: 1px dashed rgba(79, 56, 37, 0.2);
+}
+
+.grn-bed-selector__add h4 {
+  margin: 0;
+  font-family: var(--og-font-display);
+  color: var(--og-color-soil);
+  font-size: 1rem;
+}
+
+.grn-bed-selector__add-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.grn-bed-selector__error {
+  margin: 0;
+  color: #93221d;
+  font-size: 0.85rem;
+}
+
+.grn-bed-selector__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ── Quick-pick chips (harvest windows) ──────────────────────────── */
+
+.grn-quick-pick {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.grn-quick-pick__label {
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.85rem;
+}
+
+.grn-quick-pick__chip {
+  border: 1px solid rgba(79, 56, 37, 0.18);
+  background: var(--og-color-paper);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--og-color-soil);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.grn-quick-pick__chip:hover:not(:disabled) {
+  background: rgba(232, 222, 203, 0.6);
+  border-color: rgba(66, 107, 63, 0.4);
+}
+
+.grn-quick-pick__chip:disabled {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  border-color: var(--og-color-moss);
+  cursor: default;
+}
+
+/* ── Disclosure (Notes & sharing) ────────────────────────────────── */
+
+.grn-disclosure {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  width: 100%;
+  border: none;
+  background: none;
+  font: inherit;
+  color: var(--og-color-soil);
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+}
+
+.grn-disclosure__chevron {
+  font-size: 0.9rem;
+  margin-top: 0.1rem;
+  color: var(--og-color-moss);
+}
+
+.grn-disclosure__hint {
+  font-weight: 400;
+  color: rgba(79, 56, 37, 0.65);
+  font-size: 0.9rem;
+}
+
+/* ── Surplus share toggle ────────────────────────────────────────── */
+
+.grn-share-toggle {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: var(--og-radius-md);
+  background: rgba(232, 222, 203, 0.4);
+}
+
+.grn-share-toggle__row {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.grn-share-toggle__row input[type='checkbox'] {
+  margin-top: 0.25rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--og-color-moss);
+}
+
+.grn-share-toggle__row span {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.grn-share-toggle__row strong {
+  color: var(--og-color-soil);
+}
+
+.grn-share-toggle__row span span {
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.85rem;
+}
+
+.grn-share-toggle__visibility {
+  border: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.grn-share-toggle__visibility legend {
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.7);
+  margin-bottom: 0.35rem;
+}
+
+.grn-share-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.18);
+  background: var(--og-color-paper);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-share-toggle__option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.grn-share-toggle__option.is-active {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  border-color: var(--og-color-moss);
+}
+
+/* ── Crop library (the /crops page) ──────────────────────────────── */
+
+.grn-crop-library {
+  display: grid;
+  gap: 1rem;
+}
+
+.grn-crop-library__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.grn-crop-library__title {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.4rem;
+  color: var(--og-color-soil);
+}
+
+.grn-crop-library__subtitle {
+  margin: 0.15rem 0 0;
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.88rem;
+}
+
+.grn-crop-library__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.grn-crop-library__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.16);
+  background: rgba(255, 252, 246, 0.92);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.grn-crop-library__tab.is-active {
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  border-color: var(--og-color-moss);
+}
+
+.grn-crop-library__tab-count {
+  font-weight: 600;
+  font-size: 0.78rem;
+  background: rgba(255, 255, 255, 0.25);
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+}
+
+.grn-crop-library__tab:not(.is-active) .grn-crop-library__tab-count {
+  background: rgba(79, 56, 37, 0.1);
+}
+
+.grn-crop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.grn-crop-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(79, 56, 37, 0.14);
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(38, 23, 15, 0.06);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.grn-crop-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(38, 23, 15, 0.12);
+}
+
+.grn-crop-card__header {
+  position: relative;
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grn-crop-card__emoji {
+  font-size: 2.4rem;
+  line-height: 1;
+  filter: drop-shadow(0 4px 10px rgba(38, 23, 15, 0.15));
+}
+
+.grn-crop-card__status {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: rgba(255, 252, 246, 0.92);
+  color: var(--og-color-soil);
+  box-shadow: 0 1px 3px rgba(38, 23, 15, 0.12);
+}
+
+.grn-crop-card__status--success {
+  background: rgba(66, 107, 63, 0.18);
+  color: var(--og-color-moss);
+}
+
+.grn-crop-card__status--info {
+  background: rgba(38, 70, 83, 0.14);
+  color: #1d3641;
+}
+
+.grn-crop-card__status--muted {
+  background: rgba(79, 56, 37, 0.1);
+  color: rgba(79, 56, 37, 0.75);
+}
+
+.grn-crop-card__body {
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.grn-crop-card__name {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+  color: var(--og-color-soil);
+}
+
+.grn-crop-card__subname {
+  margin: -0.4rem 0 0;
+  color: rgba(79, 56, 37, 0.65);
+  font-size: 0.82rem;
+}
+
+.grn-crop-card__facts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-crop-card__facts li {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.grn-crop-card__progress {
+  height: 0.4rem;
+  border-radius: 999px;
+  background: rgba(79, 56, 37, 0.1);
+  overflow: hidden;
+}
+
+.grn-crop-card__progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.grn-crop-card__footer {
+  margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0 1rem 0.85rem;
+}
+
+.grn-crop-card__remove {
+  border-color: rgba(173, 32, 27, 0.32) !important;
+  color: #93221d !important;
+}
+
+.grn-crop-card__remove:hover {
+  background: rgba(173, 32, 27, 0.06) !important;
+}
+
+/* ── Empty state ─────────────────────────────────────────────────── */
+
+.grn-crop-empty {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 0.65rem;
+  padding: 1.5rem 1rem 1.75rem;
+}
+
+.grn-crop-empty__emoji {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.grn-crop-empty h3 {
+  margin: 0;
+  font-family: var(--og-font-display);
+  color: var(--og-color-soil);
+  font-size: 1.25rem;
+}
+
+.grn-crop-empty p {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.78);
+  max-width: 32rem;
+}
+
+.grn-crop-empty__hint {
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.6);
+}

--- a/apps/grn/src/types/listing.ts
+++ b/apps/grn/src/types/listing.ts
@@ -27,6 +27,34 @@ export interface GrowerCropItem {
   nickname: string | null;
   defaultUnit: string | null;
   notes: string | null;
+  bedId: string | null;
+  bedName: string | null;
+  plantingDate: string | null;
+  expectedHarvestDate: string | null;
+  plantCount: number | null;
+  spacingInches: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SunExposure =
+  | 'full_sun'
+  | 'partial_sun'
+  | 'partial_shade'
+  | 'full_shade'
+  | 'mixed';
+
+export interface GardenBed {
+  id: string;
+  userId: string;
+  name: string;
+  description: string | null;
+  sunExposure: SunExposure | null;
+  soilType: string | null;
+  lengthInches: number | null;
+  widthInches: number | null;
+  locationNotes: string | null;
+  sortOrder: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -397,6 +397,33 @@ create unique index if not exists idx_crop_zone_suitability_crop_system_null_var
   where variety_id is null;
 
 -- ============================
+-- GARDEN BEDS
+-- ============================
+create table if not exists garden_beds (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  name text not null,
+  description text,
+  sun_exposure text,
+  soil_type text,
+  length_inches integer,
+  width_inches integer,
+  location_notes text,
+  sort_order integer not null default 0,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_beds_name_not_empty check (length(trim(name)) > 0),
+  constraint garden_beds_length_nonnegative check (length_inches is null or length_inches >= 0),
+  constraint garden_beds_width_nonnegative check (width_inches is null or width_inches >= 0)
+);
+
+create index if not exists idx_garden_beds_user
+  on garden_beds(user_id)
+  where archived_at is null;
+
+-- ============================
 -- GROWER CROP LIBRARY
 -- ============================
 create table if not exists grower_crop_library (
@@ -415,6 +442,13 @@ create table if not exists grower_crop_library (
   default_unit text, -- e.g. "lb", "bunch", "bag", "each"
   notes text,
 
+  -- Planting details (all optional)
+  bed_id uuid references garden_beds(id) on delete set null,
+  planting_date date,
+  expected_harvest_date date,
+  plant_count integer,
+  spacing_inches integer,
+
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
@@ -422,11 +456,22 @@ create table if not exists grower_crop_library (
   constraint grower_crop_library_crop_link_check check (
     (canonical_id is null and crop_name is not null) or  -- user-defined crop
     (canonical_id is not null)                           -- catalog crop (crop_name will be populated from catalog)
-  )
+  ),
+  constraint grower_crop_library_plant_count_positive
+    check (plant_count is null or plant_count > 0),
+  constraint grower_crop_library_spacing_nonnegative
+    check (spacing_inches is null or spacing_inches >= 0),
+  constraint grower_crop_library_harvest_after_planting
+    check (
+      planting_date is null
+      or expected_harvest_date is null
+      or expected_harvest_date >= planting_date
+    )
 );
 
 create index if not exists idx_grower_crop_library_user on grower_crop_library(user_id);
 create index if not exists idx_grower_crop_library_canonical on grower_crop_library(canonical_id) where canonical_id is not null;
+create index if not exists idx_grower_crop_library_bed on grower_crop_library(bed_id) where bed_id is not null;
 
 -- ============================
 -- SURPLUS LISTINGS

--- a/services/grn-api/db/migrations/0028_garden_beds_and_planting_details.sql
+++ b/services/grn-api/db/migrations/0028_garden_beds_and_planting_details.sql
@@ -1,0 +1,88 @@
+-- Migration: Add garden beds and per-crop planting details
+-- Adds a garden_beds table so growers can describe the physical
+-- locations where they grow, plus optional planting columns on
+-- grower_crop_library that turn the library into a real garden plan.
+
+create table if not exists garden_beds (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  name text not null,
+  description text,
+  sun_exposure text,            -- e.g. 'full_sun', 'partial_sun', 'partial_shade', 'full_shade'
+  soil_type text,               -- free-form: 'sandy_loam', 'raised_bed_mix', etc.
+  length_inches integer,        -- optional dimensions for future visual layouts
+  width_inches integer,
+  location_notes text,          -- e.g. 'south side, near rosemary'
+  sort_order integer not null default 0,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_beds_name_not_empty check (length(trim(name)) > 0),
+  constraint garden_beds_length_nonnegative check (length_inches is null or length_inches >= 0),
+  constraint garden_beds_width_nonnegative check (width_inches is null or width_inches >= 0)
+);
+
+create index if not exists idx_garden_beds_user
+  on garden_beds(user_id)
+  where archived_at is null;
+
+-- Per-crop planting metadata: where it lives, when it went in, when to expect harvest, how many plants.
+alter table grower_crop_library
+  add column if not exists bed_id uuid references garden_beds(id) on delete set null;
+
+alter table grower_crop_library
+  add column if not exists planting_date date;
+
+alter table grower_crop_library
+  add column if not exists expected_harvest_date date;
+
+alter table grower_crop_library
+  add column if not exists plant_count integer;
+
+alter table grower_crop_library
+  add column if not exists spacing_inches integer;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'grower_crop_library'::regclass
+      and conname = 'grower_crop_library_plant_count_positive'
+  ) then
+    alter table grower_crop_library
+      add constraint grower_crop_library_plant_count_positive
+      check (plant_count is null or plant_count > 0);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'grower_crop_library'::regclass
+      and conname = 'grower_crop_library_spacing_nonnegative'
+  ) then
+    alter table grower_crop_library
+      add constraint grower_crop_library_spacing_nonnegative
+      check (spacing_inches is null or spacing_inches >= 0);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'grower_crop_library'::regclass
+      and conname = 'grower_crop_library_harvest_after_planting'
+  ) then
+    alter table grower_crop_library
+      add constraint grower_crop_library_harvest_after_planting
+      check (
+        planting_date is null
+        or expected_harvest_date is null
+        or expected_harvest_date >= planting_date
+      );
+  end if;
+end $$;
+
+create index if not exists idx_grower_crop_library_bed
+  on grower_crop_library(bed_id)
+  where bed_id is not null;

--- a/services/grn-api/src/api/handlers/bed.rs
+++ b/services/grn-api/src/api/handlers/bed.rs
@@ -1,0 +1,347 @@
+use crate::auth::{extract_auth_context_with_fallback, require_grower};
+use crate::db;
+use crate::handlers::crop::error_response;
+use crate::models::bed::{GardenBed, UpsertGardenBedRequest};
+use crate::models::crop::ErrorResponse;
+use lambda_http::{Body, Request, Response};
+use serde::Serialize;
+use tokio_postgres::Row;
+use tracing::info;
+use uuid::Uuid;
+
+const ALLOWED_SUN_EXPOSURE: [&str; 5] = [
+    "full_sun",
+    "partial_sun",
+    "partial_shade",
+    "full_shade",
+    "mixed",
+];
+
+pub async fn list_my_beds(
+    request: &Request,
+    _correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let client = db::connect().await?;
+
+    let rows = client
+        .query(
+            "
+            select id, user_id, name, description, sun_exposure, soil_type,
+                   length_inches, width_inches, location_notes, sort_order,
+                   created_at, updated_at
+            from garden_beds
+            where user_id = $1 and archived_at is null
+            order by sort_order asc, created_at asc
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let beds = rows.into_iter().map(|row| row_to_bed(&row)).collect::<Vec<_>>();
+    json_response(200, &beds)
+}
+
+pub async fn create_my_bed(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let payload: UpsertGardenBedRequest = parse_json_body(request)?;
+    let trimmed_name = validate_bed_payload(&payload)?;
+
+    let client = db::connect().await?;
+    let row = client
+        .query_one(
+            "
+            insert into garden_beds
+                (user_id, name, description, sun_exposure, soil_type,
+                 length_inches, width_inches, location_notes, sort_order)
+            values ($1, $2, $3, $4, $5, $6, $7, $8, coalesce($9, 0))
+            returning id, user_id, name, description, sun_exposure, soil_type,
+                      length_inches, width_inches, location_notes, sort_order,
+                      created_at, updated_at
+            ",
+            &[
+                &user_id,
+                &trimmed_name,
+                &payload.description.as_ref().map(|s| s.trim().to_string()),
+                &payload.sun_exposure,
+                &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
+                &payload.length_inches,
+                &payload.width_inches,
+                &payload.location_notes.as_ref().map(|s| s.trim().to_string()),
+                &payload.sort_order,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        bed_id = %row.get::<_, Uuid>("id"),
+        "Created garden bed"
+    );
+
+    json_response(201, &row_to_bed(&row))
+}
+
+pub async fn update_my_bed(
+    request: &Request,
+    correlation_id: &str,
+    bed_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let payload: UpsertGardenBedRequest = parse_json_body(request)?;
+    let trimmed_name = validate_bed_payload(&payload)?;
+    let id = parse_uuid(bed_id, "bed id")?;
+
+    let client = db::connect().await?;
+    let maybe_row = client
+        .query_opt(
+            "
+            update garden_beds
+            set name = $1,
+                description = $2,
+                sun_exposure = $3,
+                soil_type = $4,
+                length_inches = $5,
+                width_inches = $6,
+                location_notes = $7,
+                sort_order = coalesce($8, sort_order),
+                updated_at = now()
+            where id = $9 and user_id = $10 and archived_at is null
+            returning id, user_id, name, description, sun_exposure, soil_type,
+                      length_inches, width_inches, location_notes, sort_order,
+                      created_at, updated_at
+            ",
+            &[
+                &trimmed_name,
+                &payload.description.as_ref().map(|s| s.trim().to_string()),
+                &payload.sun_exposure,
+                &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
+                &payload.length_inches,
+                &payload.width_inches,
+                &payload.location_notes.as_ref().map(|s| s.trim().to_string()),
+                &payload.sort_order,
+                &id,
+                &user_id,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+    if let Some(row) = maybe_row {
+        info!(
+            correlation_id = correlation_id,
+            user_id = %user_id,
+            bed_id = %id,
+            "Updated garden bed"
+        );
+        return json_response(200, &row_to_bed(&row));
+    }
+
+    not_found_response()
+}
+
+pub async fn delete_my_bed(
+    request: &Request,
+    correlation_id: &str,
+    bed_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let id = parse_uuid(bed_id, "bed id")?;
+
+    let client = db::connect().await?;
+    // Soft delete: keeps any historical references intact via SET NULL on FK.
+    let archived = client
+        .execute(
+            "
+            update garden_beds
+            set archived_at = now(), updated_at = now()
+            where id = $1 and user_id = $2 and archived_at is null
+            ",
+            &[&id, &user_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    if archived == 0 {
+        return not_found_response();
+    }
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        bed_id = %id,
+        "Archived garden bed"
+    );
+
+    Response::builder()
+        .status(204)
+        .body(Body::Empty)
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+pub fn validate_bed_payload(
+    payload: &UpsertGardenBedRequest,
+) -> Result<String, lambda_http::Error> {
+    let trimmed = payload.name.trim();
+    if trimmed.is_empty() {
+        return Err(lambda_http::Error::from(
+            "bed name is required".to_string(),
+        ));
+    }
+    if trimmed.len() > 80 {
+        return Err(lambda_http::Error::from(
+            "bed name must be 80 characters or fewer".to_string(),
+        ));
+    }
+    if let Some(sun) = payload.sun_exposure.as_deref() {
+        if !sun.is_empty() && !ALLOWED_SUN_EXPOSURE.contains(&sun) {
+            return Err(lambda_http::Error::from(format!(
+                "Invalid sunExposure '{sun}'. Allowed values: {}",
+                ALLOWED_SUN_EXPOSURE.join(", ")
+            )));
+        }
+    }
+    if payload.length_inches.is_some_and(|v| v < 0) || payload.width_inches.is_some_and(|v| v < 0) {
+        return Err(lambda_http::Error::from(
+            "bed dimensions must be non-negative".to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_user_id(value: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(value).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn parse_uuid(value: &str, field_name: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(value.trim())
+        .map_err(|_| lambda_http::Error::from(format!("{field_name} must be a valid UUID")))
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn row_to_bed(row: &Row) -> GardenBed {
+    GardenBed {
+        id: row.get::<_, Uuid>("id").to_string(),
+        user_id: row.get::<_, Uuid>("user_id").to_string(),
+        name: row.get("name"),
+        description: row.get("description"),
+        sun_exposure: row.get("sun_exposure"),
+        soil_type: row.get("soil_type"),
+        length_inches: row.get("length_inches"),
+        width_inches: row.get("width_inches"),
+        location_notes: row.get("location_notes"),
+        sort_order: row.get("sort_order"),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+        updated_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("updated_at")
+            .to_rfc3339(),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn not_found_response() -> Result<Response<Body>, lambda_http::Error> {
+    error_response(404, "Garden bed not found").or_else(|_| {
+        let body = serde_json::to_string(&ErrorResponse {
+            error: "Garden bed not found".to_string(),
+        })
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+        Response::builder()
+            .status(404)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .map_err(|e| lambda_http::Error::from(e.to_string()))
+    })
+}
+
+fn db_error(error: tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_bed_payload, UpsertGardenBedRequest};
+
+    fn payload() -> UpsertGardenBedRequest {
+        UpsertGardenBedRequest {
+            name: "Front raised bed".to_string(),
+            description: None,
+            sun_exposure: Some("full_sun".to_string()),
+            soil_type: None,
+            length_inches: Some(48),
+            width_inches: Some(48),
+            location_notes: None,
+            sort_order: Some(0),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_payload() {
+        assert_eq!(validate_bed_payload(&payload()).unwrap(), "Front raised bed");
+    }
+
+    #[test]
+    fn rejects_blank_name() {
+        let mut p = payload();
+        p.name = "   ".to_string();
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_sun_exposure() {
+        let mut p = payload();
+        p.sun_exposure = Some("rainforest".to_string());
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_negative_dimensions() {
+        let mut p = payload();
+        p.length_inches = Some(-1);
+        assert!(validate_bed_payload(&p).is_err());
+    }
+}

--- a/services/grn-api/src/api/handlers/bed.rs
+++ b/services/grn-api/src/api/handlers/bed.rs
@@ -40,9 +40,12 @@ pub async fn list_my_beds(
             &[&user_id],
         )
         .await
-        .map_err(db_error)?;
+        .map_err(|e| db_error(&e))?;
 
-    let beds = rows.into_iter().map(|row| row_to_bed(&row)).collect::<Vec<_>>();
+    let beds = rows
+        .into_iter()
+        .map(|row| row_to_bed(&row))
+        .collect::<Vec<_>>();
     json_response(200, &beds)
 }
 
@@ -77,12 +80,15 @@ pub async fn create_my_bed(
                 &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
                 &payload.length_inches,
                 &payload.width_inches,
-                &payload.location_notes.as_ref().map(|s| s.trim().to_string()),
+                &payload
+                    .location_notes
+                    .as_ref()
+                    .map(|s| s.trim().to_string()),
                 &payload.sort_order,
             ],
         )
         .await
-        .map_err(db_error)?;
+        .map_err(|e| db_error(&e))?;
 
     info!(
         correlation_id = correlation_id,
@@ -133,14 +139,17 @@ pub async fn update_my_bed(
                 &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
                 &payload.length_inches,
                 &payload.width_inches,
-                &payload.location_notes.as_ref().map(|s| s.trim().to_string()),
+                &payload
+                    .location_notes
+                    .as_ref()
+                    .map(|s| s.trim().to_string()),
                 &payload.sort_order,
                 &id,
                 &user_id,
             ],
         )
         .await
-        .map_err(db_error)?;
+        .map_err(|e| db_error(&e))?;
 
     if let Some(row) = maybe_row {
         info!(
@@ -178,7 +187,7 @@ pub async fn delete_my_bed(
             &[&id, &user_id],
         )
         .await
-        .map_err(db_error)?;
+        .map_err(|e| db_error(&e))?;
 
     if archived == 0 {
         return not_found_response();
@@ -202,9 +211,7 @@ pub fn validate_bed_payload(
 ) -> Result<String, lambda_http::Error> {
     let trimmed = payload.name.trim();
     if trimmed.is_empty() {
-        return Err(lambda_http::Error::from(
-            "bed name is required".to_string(),
-        ));
+        return Err(lambda_http::Error::from("bed name is required".to_string()));
     }
     if trimmed.len() > 80 {
         return Err(lambda_http::Error::from(
@@ -298,11 +305,12 @@ fn not_found_response() -> Result<Response<Body>, lambda_http::Error> {
     })
 }
 
-fn db_error(error: tokio_postgres::Error) -> lambda_http::Error {
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
     lambda_http::Error::from(format!("Database query error: {error}"))
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::{validate_bed_payload, UpsertGardenBedRequest};
 
@@ -321,7 +329,10 @@ mod tests {
 
     #[test]
     fn accepts_valid_payload() {
-        assert_eq!(validate_bed_payload(&payload()).unwrap(), "Front raised bed");
+        assert_eq!(
+            validate_bed_payload(&payload()).unwrap(),
+            "Front raised bed"
+        );
     }
 
     #[test]

--- a/services/grn-api/src/api/handlers/crop.rs
+++ b/services/grn-api/src/api/handlers/crop.rs
@@ -97,8 +97,10 @@ pub async fn create_my_crop(
     let variety_id = parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?;
     let bed_id = parse_optional_uuid(payload.bed_id.as_deref(), "bed_id")?;
     let planting_date = parse_optional_date(payload.planting_date.as_deref(), "plantingDate")?;
-    let expected_harvest_date =
-        parse_optional_date(payload.expected_harvest_date.as_deref(), "expectedHarvestDate")?;
+    let expected_harvest_date = parse_optional_date(
+        payload.expected_harvest_date.as_deref(),
+        "expectedHarvestDate",
+    )?;
 
     let client = db::connect().await?;
 
@@ -181,8 +183,10 @@ pub async fn update_my_crop(
     let variety_id = parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?;
     let bed_id = parse_optional_uuid(payload.bed_id.as_deref(), "bed_id")?;
     let planting_date = parse_optional_date(payload.planting_date.as_deref(), "plantingDate")?;
-    let expected_harvest_date =
-        parse_optional_date(payload.expected_harvest_date.as_deref(), "expectedHarvestDate")?;
+    let expected_harvest_date = parse_optional_date(
+        payload.expected_harvest_date.as_deref(),
+        "expectedHarvestDate",
+    )?;
 
     let client = db::connect().await?;
 
@@ -475,22 +479,24 @@ fn parse_optional_uuid(
     value: Option<&str>,
     field_name: &str,
 ) -> Result<Option<Uuid>, lambda_http::Error> {
-    match value.map(str::trim).filter(|v| !v.is_empty()) {
-        None => Ok(None),
-        Some(v) => parse_uuid(v, field_name).map(Some),
-    }
+    value
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map_or(Ok(None), |v| parse_uuid(v, field_name).map(Some))
 }
 
 fn parse_optional_date(
     value: Option<&str>,
     field_name: &str,
 ) -> Result<Option<NaiveDate>, lambda_http::Error> {
-    match value.map(str::trim).filter(|v| !v.is_empty()) {
-        None => Ok(None),
-        Some(v) => NaiveDate::parse_from_str(v, "%Y-%m-%d")
-            .map(Some)
-            .map_err(|_| lambda_http::Error::from(format!("{field_name} must be YYYY-MM-DD"))),
-    }
+    value
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map_or(Ok(None), |v| {
+            NaiveDate::parse_from_str(v, "%Y-%m-%d")
+                .map(Some)
+                .map_err(|_| lambda_http::Error::from(format!("{field_name} must be YYYY-MM-DD")))
+        })
 }
 
 fn parse_json_body<T: serde::de::DeserializeOwned>(

--- a/services/grn-api/src/api/handlers/crop.rs
+++ b/services/grn-api/src/api/handlers/crop.rs
@@ -1,6 +1,7 @@
 use crate::auth::{extract_auth_context_with_fallback, require_grower};
 use crate::db;
 use crate::models::crop::{ErrorResponse, GrowerCropItem, UpsertGrowerCropRequest};
+use chrono::NaiveDate;
 use lambda_http::{Body, Request, Response};
 use serde::Serialize;
 use tokio_postgres::{Client, Row};
@@ -9,6 +10,18 @@ use uuid::Uuid;
 
 const ALLOWED_STATUS: [&str; 4] = ["interested", "planning", "growing", "paused"];
 const ALLOWED_VISIBILITY: [&str; 3] = ["private", "local", "public"];
+
+const GROWER_CROP_SELECT: &str = "
+    select g.id, g.user_id, g.canonical_id, g.crop_name, g.variety_id,
+           g.status::text as status, g.visibility::text as visibility,
+           g.surplus_enabled, g.nickname, g.default_unit, g.notes,
+           g.bed_id, b.name as bed_name,
+           g.planting_date, g.expected_harvest_date,
+           g.plant_count, g.spacing_inches,
+           g.created_at, g.updated_at
+    from grower_crop_library g
+    left join garden_beds b on b.id = g.bed_id and b.archived_at is null
+";
 
 pub async fn list_my_crops(
     request: &Request,
@@ -22,17 +35,9 @@ pub async fn list_my_crops(
         .map_err(|_| lambda_http::Error::from("Invalid user ID format"))?;
     let client = db::connect().await?;
 
+    let query = format!("{GROWER_CROP_SELECT} where g.user_id = $1 order by g.created_at desc");
     let rows = client
-        .query(
-            "
-            select id, user_id, canonical_id, crop_name, variety_id, status::text, visibility::text,
-                   surplus_enabled, nickname, default_unit, notes, created_at, updated_at
-            from grower_crop_library
-            where user_id = $1
-            order by created_at desc
-            ",
-            &[&user_id],
-        )
+        .query(&query, &[&user_id])
         .await
         .map_err(|error| db_error(&error))?;
 
@@ -57,16 +62,9 @@ pub async fn get_my_crop(
     let id = parse_uuid(crop_library_id, "crop library id")?;
     let client = db::connect().await?;
 
+    let query = format!("{GROWER_CROP_SELECT} where g.id = $1 and g.user_id = $2");
     let maybe_row = client
-        .query_opt(
-            "
-            select id, user_id, canonical_id, crop_name, variety_id, status::text, visibility::text,
-                   surplus_enabled, nickname, default_unit, notes, created_at, updated_at
-            from grower_crop_library
-            where id = $1 and user_id = $2
-            ",
-            &[&id, &user_id],
-        )
+        .query_opt(&query, &[&id, &user_id])
         .await
         .map_err(|error| db_error(&error))?;
 
@@ -97,14 +95,18 @@ pub async fn create_my_crop(
 
     let canonical_id = parse_optional_uuid(payload.canonical_id.as_deref(), "canonical_id")?;
     let variety_id = parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?;
-    let canonical_id_text = canonical_id.map(|v| v.to_string());
-    let variety_id_text = variety_id.map(|v| v.to_string());
+    let bed_id = parse_optional_uuid(payload.bed_id.as_deref(), "bed_id")?;
+    let planting_date = parse_optional_date(payload.planting_date.as_deref(), "plantingDate")?;
+    let expected_harvest_date =
+        parse_optional_date(payload.expected_harvest_date.as_deref(), "expectedHarvestDate")?;
 
     let client = db::connect().await?;
 
-    // Only validate catalog links if canonical_id is provided
     if let Some(crop_id) = canonical_id {
         validate_catalog_links(&client, crop_id, variety_id).await?;
+    }
+    if let Some(bed) = bed_id {
+        validate_bed_ownership(&client, bed, user_id).await?;
     }
     let crop_name = resolve_crop_name(&client, &payload, canonical_id).await?;
 
@@ -112,36 +114,52 @@ pub async fn create_my_crop(
         .query_one(
             "
             insert into grower_crop_library
-                (user_id, canonical_id, crop_name, variety_id, status, visibility, surplus_enabled, nickname, default_unit, notes)
+                (user_id, canonical_id, crop_name, variety_id, status, visibility,
+                 surplus_enabled, nickname, default_unit, notes,
+                 bed_id, planting_date, expected_harvest_date, plant_count, spacing_inches)
             values
-                ($1, $2::text::uuid, $3, $4::text::uuid, $5::text::grower_crop_status, $6::text::visibility_scope, $7, $8, $9, $10)
-            returning id, user_id, canonical_id, crop_name, variety_id, status::text, visibility::text,
-                      surplus_enabled, nickname, default_unit, notes, created_at, updated_at
+                ($1, $2, $3, $4, $5::text::grower_crop_status, $6::text::visibility_scope,
+                 $7, $8, $9, $10,
+                 $11, $12, $13, $14, $15)
+            returning id
             ",
             &[
                 &user_id,
-                &canonical_id_text,
+                &canonical_id,
                 &crop_name,
-                &variety_id_text,
+                &variety_id,
                 &payload.status,
                 &payload.visibility,
                 &payload.surplus_enabled,
                 &payload.nickname,
                 &payload.default_unit,
                 &payload.notes,
+                &bed_id,
+                &planting_date,
+                &expected_harvest_date,
+                &payload.plant_count,
+                &payload.spacing_inches,
             ],
         )
+        .await
+        .map_err(|error| db_error(&error))?;
+
+    let new_id: Uuid = row.get("id");
+
+    let select = format!("{GROWER_CROP_SELECT} where g.id = $1 and g.user_id = $2");
+    let full_row = client
+        .query_one(&select, &[&new_id, &user_id])
         .await
         .map_err(|error| db_error(&error))?;
 
     info!(
         correlation_id = correlation_id,
         user_id = %user_id,
-        crop_library_id = %row.get::<_, Uuid>("id"),
+        crop_library_id = %new_id,
         "Created grower crop library item"
     );
 
-    json_response(201, &row_to_item(&row))
+    json_response(201, &row_to_item(&full_row))
 }
 
 pub async fn update_my_crop(
@@ -161,45 +179,57 @@ pub async fn update_my_crop(
     let id = parse_uuid(crop_library_id, "crop library id")?;
     let canonical_id = parse_optional_uuid(payload.canonical_id.as_deref(), "canonical_id")?;
     let variety_id = parse_optional_uuid(payload.variety_id.as_deref(), "variety_id")?;
-    let canonical_id_text = canonical_id.map(|v| v.to_string());
-    let variety_id_text = variety_id.map(|v| v.to_string());
+    let bed_id = parse_optional_uuid(payload.bed_id.as_deref(), "bed_id")?;
+    let planting_date = parse_optional_date(payload.planting_date.as_deref(), "plantingDate")?;
+    let expected_harvest_date =
+        parse_optional_date(payload.expected_harvest_date.as_deref(), "expectedHarvestDate")?;
 
     let client = db::connect().await?;
 
-    // Only validate catalog links if canonical_id is provided
     if let Some(crop_id) = canonical_id {
         validate_catalog_links(&client, crop_id, variety_id).await?;
     }
+    if let Some(bed) = bed_id {
+        validate_bed_ownership(&client, bed, user_id).await?;
+    }
     let crop_name = resolve_crop_name(&client, &payload, canonical_id).await?;
 
-    let maybe_row = client
-        .query_opt(
+    let updated = client
+        .execute(
             "
             update grower_crop_library
-            set canonical_id = $1::text::uuid,
+            set canonical_id = $1,
                 crop_name = $2,
-                variety_id = $3::text::uuid,
+                variety_id = $3,
                 status = $4::text::grower_crop_status,
                 visibility = $5::text::visibility_scope,
                 surplus_enabled = $6,
                 nickname = $7,
                 default_unit = $8,
                 notes = $9,
+                bed_id = $10,
+                planting_date = $11,
+                expected_harvest_date = $12,
+                plant_count = $13,
+                spacing_inches = $14,
                 updated_at = now()
-            where id = $10 and user_id = $11
-            returning id, user_id, canonical_id, crop_name, variety_id, status::text, visibility::text,
-                      surplus_enabled, nickname, default_unit, notes, created_at, updated_at
+            where id = $15 and user_id = $16
             ",
             &[
-                &canonical_id_text,
+                &canonical_id,
                 &crop_name,
-                &variety_id_text,
+                &variety_id,
                 &payload.status,
                 &payload.visibility,
                 &payload.surplus_enabled,
                 &payload.nickname,
                 &payload.default_unit,
                 &payload.notes,
+                &bed_id,
+                &planting_date,
+                &expected_harvest_date,
+                &payload.plant_count,
+                &payload.spacing_inches,
                 &id,
                 &user_id,
             ],
@@ -207,22 +237,28 @@ pub async fn update_my_crop(
         .await
         .map_err(|error| db_error(&error))?;
 
-    if let Some(row) = maybe_row {
-        info!(
-            correlation_id = correlation_id,
-            user_id = %user_id,
-            crop_library_id = %id,
-            "Updated grower crop library item"
+    if updated == 0 {
+        return json_response(
+            404,
+            &ErrorResponse {
+                error: "Grower crop record not found".to_string(),
+            },
         );
-        return json_response(200, &row_to_item(&row));
     }
 
-    json_response(
-        404,
-        &ErrorResponse {
-            error: "Grower crop record not found".to_string(),
-        },
-    )
+    let select = format!("{GROWER_CROP_SELECT} where g.id = $1 and g.user_id = $2");
+    let full_row = client
+        .query_one(&select, &[&id, &user_id])
+        .await
+        .map_err(|error| db_error(&error))?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        crop_library_id = %id,
+        "Updated grower crop library item"
+    );
+    json_response(200, &row_to_item(&full_row))
 }
 
 pub async fn delete_my_crop(
@@ -301,6 +337,37 @@ fn validate_upsert_payload(payload: &UpsertGrowerCropRequest) -> Result<(), lamb
         ));
     }
 
+    if let Some(count) = payload.plant_count {
+        if count <= 0 {
+            return Err(lambda_http::Error::from(
+                "plantCount must be a positive integer".to_string(),
+            ));
+        }
+    }
+    if let Some(spacing) = payload.spacing_inches {
+        if spacing < 0 {
+            return Err(lambda_http::Error::from(
+                "spacingInches must be non-negative".to_string(),
+            ));
+        }
+    }
+
+    if let (Some(planting), Some(harvest)) = (
+        payload.planting_date.as_deref(),
+        payload.expected_harvest_date.as_deref(),
+    ) {
+        let p = NaiveDate::parse_from_str(planting.trim(), "%Y-%m-%d")
+            .map_err(|_| lambda_http::Error::from("plantingDate must be YYYY-MM-DD".to_string()))?;
+        let h = NaiveDate::parse_from_str(harvest.trim(), "%Y-%m-%d").map_err(|_| {
+            lambda_http::Error::from("expectedHarvestDate must be YYYY-MM-DD".to_string())
+        })?;
+        if h < p {
+            return Err(lambda_http::Error::from(
+                "expectedHarvestDate must be on or after plantingDate".to_string(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -371,6 +438,33 @@ async fn validate_catalog_links(
     Ok(())
 }
 
+async fn validate_bed_ownership(
+    client: &Client,
+    bed_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), lambda_http::Error> {
+    let exists = client
+        .query_one(
+            "
+            select exists(
+                select 1 from garden_beds
+                where id = $1 and user_id = $2 and archived_at is null
+            )
+            ",
+            &[&bed_id, &user_id],
+        )
+        .await
+        .map_err(|error| db_error(&error))?
+        .get::<_, bool>(0);
+
+    if !exists {
+        return Err(lambda_http::Error::from(
+            "bed_id does not reference one of your garden beds".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn parse_uuid(value: &str, field_name: &str) -> Result<Uuid, lambda_http::Error> {
     let normalized = value.trim();
     Uuid::parse_str(normalized)
@@ -381,7 +475,22 @@ fn parse_optional_uuid(
     value: Option<&str>,
     field_name: &str,
 ) -> Result<Option<Uuid>, lambda_http::Error> {
-    value.map_or(Ok(None), |v| parse_uuid(v, field_name).map(Some))
+    match value.map(str::trim).filter(|v| !v.is_empty()) {
+        None => Ok(None),
+        Some(v) => parse_uuid(v, field_name).map(Some),
+    }
+}
+
+fn parse_optional_date(
+    value: Option<&str>,
+    field_name: &str,
+) -> Result<Option<NaiveDate>, lambda_http::Error> {
+    match value.map(str::trim).filter(|v| !v.is_empty()) {
+        None => Ok(None),
+        Some(v) => NaiveDate::parse_from_str(v, "%Y-%m-%d")
+            .map(Some)
+            .map_err(|_| lambda_http::Error::from(format!("{field_name} must be YYYY-MM-DD"))),
+    }
 }
 
 fn parse_json_body<T: serde::de::DeserializeOwned>(
@@ -418,6 +527,16 @@ fn row_to_item(row: &Row) -> GrowerCropItem {
         nickname: row.get("nickname"),
         default_unit: row.get("default_unit"),
         notes: row.get("notes"),
+        bed_id: row.get::<_, Option<Uuid>>("bed_id").map(|v| v.to_string()),
+        bed_name: row.get("bed_name"),
+        planting_date: row
+            .get::<_, Option<NaiveDate>>("planting_date")
+            .map(|d| d.format("%Y-%m-%d").to_string()),
+        expected_harvest_date: row
+            .get::<_, Option<NaiveDate>>("expected_harvest_date")
+            .map(|d| d.format("%Y-%m-%d").to_string()),
+        plant_count: row.get("plant_count"),
+        spacing_inches: row.get("spacing_inches"),
         created_at: row
             .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
             .to_rfc3339(),
@@ -469,6 +588,11 @@ mod tests {
             nickname: None,
             default_unit: None,
             notes: None,
+            bed_id: None,
+            planting_date: None,
+            expected_harvest_date: None,
+            plant_count: None,
+            spacing_inches: None,
         }
     }
 
@@ -497,6 +621,37 @@ mod tests {
         let mut payload = valid_payload();
         payload.crop_name = None;
         payload.canonical_id = None;
+        assert!(validate_upsert_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn payload_validation_rejects_zero_plant_count() {
+        let mut payload = valid_payload();
+        payload.plant_count = Some(0);
+        assert!(validate_upsert_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn payload_validation_rejects_harvest_before_planting() {
+        let mut payload = valid_payload();
+        payload.planting_date = Some("2026-05-01".to_string());
+        payload.expected_harvest_date = Some("2026-04-15".to_string());
+        assert!(validate_upsert_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn payload_validation_accepts_harvest_after_planting() {
+        let mut payload = valid_payload();
+        payload.planting_date = Some("2026-05-01".to_string());
+        payload.expected_harvest_date = Some("2026-08-01".to_string());
+        assert!(validate_upsert_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn payload_validation_rejects_malformed_planting_date() {
+        let mut payload = valid_payload();
+        payload.planting_date = Some("yesterday".to_string());
+        payload.expected_harvest_date = Some("2026-08-01".to_string());
         assert!(validate_upsert_payload(&payload).is_err());
     }
 }

--- a/services/grn-api/src/api/handlers/mod.rs
+++ b/services/grn-api/src/api/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_task;
 pub mod ai_copilot;
 pub mod analytics;
+pub mod bed;
 pub mod billing;
 pub mod catalog;
 pub mod claim;

--- a/services/grn-api/src/api/models/bed.rs
+++ b/services/grn-api/src/api/models/bed.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GardenBed {
+    pub id: String,
+    pub user_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub sun_exposure: Option<String>,
+    pub soil_type: Option<String>,
+    pub length_inches: Option<i32>,
+    pub width_inches: Option<i32>,
+    pub location_notes: Option<String>,
+    pub sort_order: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpsertGardenBedRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default, alias = "sunExposure")]
+    pub sun_exposure: Option<String>,
+    #[serde(default, alias = "soilType")]
+    pub soil_type: Option<String>,
+    #[serde(default, alias = "lengthInches")]
+    pub length_inches: Option<i32>,
+    #[serde(default, alias = "widthInches")]
+    pub width_inches: Option<i32>,
+    #[serde(default, alias = "locationNotes")]
+    pub location_notes: Option<String>,
+    #[serde(default, alias = "sortOrder")]
+    pub sort_order: Option<i32>,
+}

--- a/services/grn-api/src/api/models/crop.rs
+++ b/services/grn-api/src/api/models/crop.rs
@@ -14,6 +14,12 @@ pub struct GrowerCropItem {
     pub nickname: Option<String>,
     pub default_unit: Option<String>,
     pub notes: Option<String>,
+    pub bed_id: Option<String>,
+    pub bed_name: Option<String>,
+    pub planting_date: Option<String>,
+    pub expected_harvest_date: Option<String>,
+    pub plant_count: Option<i32>,
+    pub spacing_inches: Option<i32>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -34,6 +40,16 @@ pub struct UpsertGrowerCropRequest {
     #[serde(default, alias = "defaultUnit")]
     pub default_unit: Option<String>,
     pub notes: Option<String>,
+    #[serde(default, alias = "bedId")]
+    pub bed_id: Option<String>,
+    #[serde(default, alias = "plantingDate")]
+    pub planting_date: Option<String>,
+    #[serde(default, alias = "expectedHarvestDate")]
+    pub expected_harvest_date: Option<String>,
+    #[serde(default, alias = "plantCount")]
+    pub plant_count: Option<i32>,
+    #[serde(default, alias = "spacingInches")]
+    pub spacing_inches: Option<i32>,
 }
 
 #[derive(Debug, Serialize)]

--- a/services/grn-api/src/api/models/mod.rs
+++ b/services/grn-api/src/api/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod bed;
 pub mod catalog;
 pub mod crop;
 pub mod entitlements;

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -1,6 +1,6 @@
 use crate::handlers::{
-    agent_task, ai_copilot, analytics, billing, catalog, claim, claim_read, crop, feed, listing,
-    listing_discovery, reminder, request, user,
+    agent_task, ai_copilot, analytics, bed, billing, catalog, claim, claim_read, crop, feed,
+    listing, listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -101,6 +101,9 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
         ("GET", "/crops") => handle(crop::list_my_crops(event, &correlation_id).await)?,
         ("POST", "/crops") => handle(crop::create_my_crop(event, &correlation_id).await)?,
 
+        ("GET", "/beds") => handle(bed::list_my_beds(event, &correlation_id).await)?,
+        ("POST", "/beds") => handle(bed::create_my_bed(event, &correlation_id).await)?,
+
         ("GET", "/my/listings") => handle(listing::list_my_listings(event, &correlation_id).await)?,
         ("GET", "/listings/discover") => {
             handle(listing_discovery::discover_listings(event, &correlation_id).await)?
@@ -155,6 +158,15 @@ async fn route_dynamic_routes(
             "GET" => crop::get_my_crop(event, correlation_id, crop_library_id).await,
             "PUT" => crop::update_my_crop(event, correlation_id, crop_library_id).await,
             "DELETE" => crop::delete_my_crop(event, correlation_id, crop_library_id).await,
+            _ => method_not_allowed(),
+        };
+        return handle(result);
+    }
+
+    if let Some(bed_id) = request_path.strip_prefix("/beds/") {
+        let result = match event.method().as_str() {
+            "PUT" => bed::update_my_bed(event, correlation_id, bed_id).await,
+            "DELETE" => bed::delete_my_bed(event, correlation_id, bed_id).await,
             _ => method_not_allowed(),
         };
         return handle(result);
@@ -278,6 +290,15 @@ fn map_api_error_to_response(
         || message.contains("title is required")
         || message.contains("unit is required")
         || message.contains("crop_name is required")
+        || message.contains("bed name is required")
+        || message.contains("bed name must be")
+        || message.contains("Invalid sunExposure")
+        || message.contains("bed dimensions must be non-negative")
+        || message.contains("bed_id does not reference one of your garden beds")
+        || message.contains("plantingDate must be")
+        || message.contains("expectedHarvestDate must be")
+        || message.contains("plantCount must be")
+        || message.contains("spacingInches must be")
         || message.contains("does not reference an existing catalog crop")
         || message.contains("does not reference an existing grower crop")
         || message.contains("does not match the canonical crop linked to grower_crop_id")

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -101,9 +101,6 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
         ("GET", "/crops") => handle(crop::list_my_crops(event, &correlation_id).await)?,
         ("POST", "/crops") => handle(crop::create_my_crop(event, &correlation_id).await)?,
 
-        ("GET", "/beds") => handle(bed::list_my_beds(event, &correlation_id).await)?,
-        ("POST", "/beds") => handle(bed::create_my_bed(event, &correlation_id).await)?,
-
         ("GET", "/my/listings") => handle(listing::list_my_listings(event, &correlation_id).await)?,
         ("GET", "/listings/discover") => {
             handle(listing_discovery::discover_listings(event, &correlation_id).await)?
@@ -158,6 +155,15 @@ async fn route_dynamic_routes(
             "GET" => crop::get_my_crop(event, correlation_id, crop_library_id).await,
             "PUT" => crop::update_my_crop(event, correlation_id, crop_library_id).await,
             "DELETE" => crop::delete_my_crop(event, correlation_id, crop_library_id).await,
+            _ => method_not_allowed(),
+        };
+        return handle(result);
+    }
+
+    if request_path == "/beds" {
+        let result = match event.method().as_str() {
+            "GET" => bed::list_my_beds(event, correlation_id).await,
+            "POST" => bed::create_my_bed(event, correlation_id).await,
             _ => method_not_allowed(),
         };
         return handle(result);


### PR DESCRIPTION
Replaces the old inline 8-field crop form with a dedicated full-page
flow at /crops/new that feels like a real garden planner.

Backend
- New garden_beds table (name, sun exposure, soil, dimensions, location
  notes) plus REST routes at /beds and /beds/{id}.
- Adds bed_id, planting_date, expected_harvest_date, plant_count, and
  spacing_inches to grower_crop_library with validation
  (positive plant count, harvest >= planting, owned bed).
- Crop responses now join garden_beds for bed_name so the UI doesn't
  need a second lookup.

Frontend
- /crops/new page: visual hero, searchable autocomplete crop picker
  with category chips, status pills, bed selector with inline
  "+ New bed" creation, planting/harvest date fields with quick-pick
  harvest-window chips, plant count + spacing, and a collapsed
  "Notes & sharing" disclosure that hides surplus/visibility behind
  sensible defaults so basic gardeners don't see the jargon.
- Crop library page reworked into a card grid with status filter tabs,
  emoji visuals per crop, harvest progress bars, and a friendly empty
  state. "Add Crop" now navigates to /crops/new.
- Styling uses the existing --og-* tokens (cream/moss/soil/paper) and
  the grn-* class namespace so it sits naturally with the rest of GRN.