### PR TITLE
GRN: backend foundation for garden designer (PR 1)

### DIFF
--- a/services/grn-api/Cargo.toml
+++ b/services/grn-api/Cargo.toml
@@ -30,6 +30,7 @@ if_same_then_else = "allow"
 aws-config = { workspace = true }
 aws-sdk-cognitoidentityprovider = { workspace = true }
 aws-sdk-eventbridge = { workspace = true }
+aws-sdk-s3 = { workspace = true }
 aws_lambda_events = { workspace = true }
 jsonwebtoken = { workspace = true }
 lambda_http = { workspace = true }

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -414,14 +414,49 @@ create table if not exists garden_beds (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
 
+  -- Garden designer geometry (added in 0029_garden_layout.sql)
+  bed_type text not null default 'raised',
+  shape text not null default 'rect',
+  position_x integer,
+  position_y integer,
+  rotation_deg integer not null default 0,
+  points jsonb,
+  color text,
+
   constraint garden_beds_name_not_empty check (length(trim(name)) > 0),
   constraint garden_beds_length_nonnegative check (length_inches is null or length_inches >= 0),
-  constraint garden_beds_width_nonnegative check (width_inches is null or width_inches >= 0)
+  constraint garden_beds_width_nonnegative check (width_inches is null or width_inches >= 0),
+  constraint garden_beds_bed_type_allowed check (bed_type in ('in_ground', 'raised', 'mound')),
+  constraint garden_beds_shape_allowed check (shape in ('rect', 'circle', 'polygon')),
+  constraint garden_beds_rotation_range check (rotation_deg >= -360 and rotation_deg <= 360),
+  constraint garden_beds_polygon_requires_points check (
+    shape <> 'polygon' or (points is not null and jsonb_typeof(points) = 'array')
+  )
 );
 
 create index if not exists idx_garden_beds_user
   on garden_beds(user_id)
   where archived_at is null;
+
+-- ============================
+-- GARDEN CANVAS (single per user in v1; UNIQUE drops when multi-garden ships)
+-- ============================
+create table if not exists garden_canvases (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references users(id) on delete cascade,
+  width_inches integer not null default 360,
+  height_inches integer not null default 240,
+  background_image_key text,
+  background_opacity smallint not null default 60,
+  north_offset_deg smallint not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_canvases_width_positive check (width_inches > 0),
+  constraint garden_canvases_height_positive check (height_inches > 0),
+  constraint garden_canvases_opacity_range check (background_opacity between 0 and 100),
+  constraint garden_canvases_north_range check (north_offset_deg between -360 and 360)
+);
 
 -- ============================
 -- GROWER CROP LIBRARY

--- a/services/grn-api/db/migrations/0029_garden_layout.sql
+++ b/services/grn-api/db/migrations/0029_garden_layout.sql
@@ -1,0 +1,90 @@
+-- Migration: Garden designer layout columns + per-user garden canvas
+-- Adds the geometry/positioning/typing columns garden_beds needs to be
+-- rendered on a 2D designer canvas, and introduces a garden_canvases
+-- table that owns canvas-level metadata (dimensions, optional background
+-- image). v1 ships single-canvas-per-user; the UNIQUE on user_id can be
+-- dropped later when multi-garden becomes a paid-tier feature.
+
+alter table garden_beds
+  add column if not exists bed_type text not null default 'raised';
+
+alter table garden_beds
+  add column if not exists shape text not null default 'rect';
+
+alter table garden_beds
+  add column if not exists position_x integer;
+
+alter table garden_beds
+  add column if not exists position_y integer;
+
+alter table garden_beds
+  add column if not exists rotation_deg integer not null default 0;
+
+alter table garden_beds
+  add column if not exists points jsonb;
+
+alter table garden_beds
+  add column if not exists color text;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'garden_beds'::regclass
+      and conname = 'garden_beds_bed_type_allowed'
+  ) then
+    alter table garden_beds
+      add constraint garden_beds_bed_type_allowed
+      check (bed_type in ('in_ground', 'raised', 'mound'));
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'garden_beds'::regclass
+      and conname = 'garden_beds_shape_allowed'
+  ) then
+    alter table garden_beds
+      add constraint garden_beds_shape_allowed
+      check (shape in ('rect', 'circle', 'polygon'));
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'garden_beds'::regclass
+      and conname = 'garden_beds_rotation_range'
+  ) then
+    alter table garden_beds
+      add constraint garden_beds_rotation_range
+      check (rotation_deg >= -360 and rotation_deg <= 360);
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'garden_beds'::regclass
+      and conname = 'garden_beds_polygon_requires_points'
+  ) then
+    alter table garden_beds
+      add constraint garden_beds_polygon_requires_points
+      check (
+        shape <> 'polygon'
+        or (points is not null and jsonb_typeof(points) = 'array')
+      );
+  end if;
+end $$;
+
+create table if not exists garden_canvases (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references users(id) on delete cascade,
+  width_inches integer not null default 360,
+  height_inches integer not null default 240,
+  background_image_key text,
+  background_opacity smallint not null default 60,
+  north_offset_deg smallint not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_canvases_width_positive check (width_inches > 0),
+  constraint garden_canvases_height_positive check (height_inches > 0),
+  constraint garden_canvases_opacity_range check (background_opacity between 0 and 100),
+  constraint garden_canvases_north_range check (north_offset_deg between -360 and 360)
+);

--- a/services/grn-api/openapi.yaml
+++ b/services/grn-api/openapi.yaml
@@ -62,6 +62,14 @@ paths:
     $ref: 'openapi/paths/crop-library.yaml#/~1crops'
   /crops/{cropLibraryId}:
     $ref: 'openapi/paths/crop-library.yaml#/~1crops~1{cropLibraryId}'
+  /beds:
+    $ref: 'openapi/paths/garden.yaml#/~1beds'
+  /beds/{bedId}:
+    $ref: 'openapi/paths/garden.yaml#/~1beds~1{bedId}'
+  /garden:
+    $ref: 'openapi/paths/garden.yaml#/~1garden'
+  /garden/background-upload-url:
+    $ref: 'openapi/paths/garden.yaml#/~1garden~1background-upload-url'
   /catalog/crops:
     $ref: 'openapi/paths/catalog.yaml#/~1catalog~1crops'
   /catalog/crops/{cropId}/varieties:

--- a/services/grn-api/openapi/paths/garden.yaml
+++ b/services/grn-api/openapi/paths/garden.yaml
@@ -1,0 +1,175 @@
+/beds:
+  get:
+    tags: [Crop Library, Grower Only, Idempotent]
+    summary: List the current grower's garden beds
+    operationId: listMyBeds
+    responses:
+      '200':
+        description: Garden beds owned by the caller
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '../schemas/garden.yaml#/GardenBed'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  post:
+    tags: [Crop Library, Grower Only]
+    summary: Create a garden bed
+    operationId: createMyBed
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/UpsertGardenBedRequest'
+    responses:
+      '201':
+        description: Created garden bed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenBed'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+/beds/{bedId}:
+  parameters:
+    - in: path
+      name: bedId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  put:
+    tags: [Crop Library, Grower Only]
+    summary: Update a garden bed
+    operationId: updateMyBed
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/UpsertGardenBedRequest'
+    responses:
+      '200':
+        description: Updated garden bed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenBed'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  delete:
+    tags: [Crop Library, Grower Only]
+    summary: Archive (soft-delete) a garden bed
+    operationId: deleteMyBed
+    responses:
+      '204':
+        description: Archived
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+/garden:
+  get:
+    tags: [Crop Library, Grower Only, Idempotent]
+    summary: Get the current grower's garden canvas
+    description: |
+      Auto-creates a default canvas (360 in × 240 in, opacity 60) on first
+      access so the designer UI can render immediately without a separate
+      provisioning call.
+    operationId: getMyGardenCanvas
+    responses:
+      '200':
+        description: Canvas
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenCanvas'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  put:
+    tags: [Crop Library, Grower Only]
+    summary: Update the current grower's garden canvas
+    operationId: updateMyGardenCanvas
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/UpsertGardenCanvasRequest'
+    responses:
+      '200':
+        description: Updated canvas
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenCanvas'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+/garden/background-upload-url:
+  post:
+    tags: [Crop Library, Grower Only]
+    summary: Issue a presigned PUT URL for a garden background image
+    description: |
+      Returns a 15-minute presigned URL the browser can PUT the image to.
+      The caller persists the returned `s3_key` on the canvas via
+      `PUT /garden` once the upload completes.
+    operationId: createGardenBackgroundUploadUrl
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/BackgroundUploadIntentRequest'
+    responses:
+      '201':
+        description: Presigned upload intent
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/BackgroundUploadIntentResponse'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '503':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'

--- a/services/grn-api/openapi/schemas/garden.yaml
+++ b/services/grn-api/openapi/schemas/garden.yaml
@@ -1,0 +1,273 @@
+GardenBed:
+  type: object
+  description: |
+    A user-owned garden bed. Includes the descriptive metadata used in the
+    crop-library flow plus geometry/positioning fields used by the garden
+    designer canvas.
+  required:
+    - id
+    - user_id
+    - name
+    - sort_order
+    - bed_type
+    - shape
+    - rotation_deg
+    - created_at
+    - updated_at
+  properties:
+    id:
+      type: string
+      format: uuid
+    user_id:
+      type: string
+      format: uuid
+    name:
+      type: string
+    description:
+      type: string
+      nullable: true
+    sun_exposure:
+      type: string
+      nullable: true
+      enum: [full_sun, partial_sun, partial_shade, full_shade, mixed, null]
+    soil_type:
+      type: string
+      nullable: true
+    length_inches:
+      type: integer
+      nullable: true
+    width_inches:
+      type: integer
+      nullable: true
+    location_notes:
+      type: string
+      nullable: true
+    sort_order:
+      type: integer
+    bed_type:
+      type: string
+      enum: [in_ground, raised, mound]
+    shape:
+      type: string
+      enum: [rect, circle, polygon]
+    position_x:
+      type: integer
+      nullable: true
+      description: "Top-left X position on the garden canvas, in inches"
+    position_y:
+      type: integer
+      nullable: true
+      description: "Top-left Y position on the garden canvas, in inches"
+    rotation_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+    points:
+      nullable: true
+      description: |
+        Polygon vertices, required when `shape == "polygon"`. Up to 64
+        entries, each `{ "x": <int>, "y": <int> }` in canvas inches.
+      type: array
+      items:
+        type: object
+        required: [x, y]
+        properties:
+          x:
+            type: integer
+          y:
+            type: integer
+    color:
+      type: string
+      nullable: true
+      pattern: '^#[0-9a-fA-F]{6}$'
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+UpsertGardenBedRequest:
+  type: object
+  description: |
+    Create or update a garden bed. Accepts both snake_case and camelCase
+    aliases for compatibility with existing clients (sunExposure, soilType,
+    lengthInches, widthInches, locationNotes, sortOrder, bedType,
+    positionX, positionY, rotationDeg).
+  required: [name]
+  properties:
+    name:
+      type: string
+      maxLength: 80
+    description:
+      type: string
+      nullable: true
+    sun_exposure:
+      type: string
+      nullable: true
+      enum: [full_sun, partial_sun, partial_shade, full_shade, mixed, null]
+    soil_type:
+      type: string
+      nullable: true
+    length_inches:
+      type: integer
+      minimum: 0
+      nullable: true
+    width_inches:
+      type: integer
+      minimum: 0
+      nullable: true
+    location_notes:
+      type: string
+      nullable: true
+    sort_order:
+      type: integer
+      nullable: true
+    bed_type:
+      type: string
+      enum: [in_ground, raised, mound]
+      nullable: true
+    shape:
+      type: string
+      enum: [rect, circle, polygon]
+      nullable: true
+    position_x:
+      type: integer
+      nullable: true
+    position_y:
+      type: integer
+      nullable: true
+    rotation_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+      nullable: true
+    points:
+      nullable: true
+      type: array
+      maxItems: 64
+      items:
+        type: object
+        required: [x, y]
+        properties:
+          x:
+            type: integer
+          y:
+            type: integer
+    color:
+      type: string
+      nullable: true
+      pattern: '^#[0-9a-fA-F]{6}$'
+
+GardenCanvas:
+  type: object
+  description: "Per-user designer canvas (single canvas per user in v1)."
+  required:
+    - id
+    - user_id
+    - width_inches
+    - height_inches
+    - background_opacity
+    - north_offset_deg
+    - created_at
+    - updated_at
+  properties:
+    id:
+      type: string
+      format: uuid
+    user_id:
+      type: string
+      format: uuid
+    width_inches:
+      type: integer
+      minimum: 12
+      maximum: 12000
+    height_inches:
+      type: integer
+      minimum: 12
+      maximum: 12000
+    background_image_key:
+      type: string
+      nullable: true
+      description: "S3 object key under garden-backgrounds/, or null."
+    background_opacity:
+      type: integer
+      minimum: 0
+      maximum: 100
+    north_offset_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+UpsertGardenCanvasRequest:
+  type: object
+  description: |
+    Update the user's canvas. Any field omitted is left unchanged, except
+    `background_image_key` which is treated as a write-through value:
+    sending null clears the background, sending a valid key sets it.
+  properties:
+    width_inches:
+      type: integer
+      minimum: 12
+      maximum: 12000
+      nullable: true
+    height_inches:
+      type: integer
+      minimum: 12
+      maximum: 12000
+      nullable: true
+    background_image_key:
+      type: string
+      nullable: true
+      description: "S3 object key under garden-backgrounds/, or null to clear."
+    background_opacity:
+      type: integer
+      minimum: 0
+      maximum: 100
+      nullable: true
+    north_offset_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+      nullable: true
+
+BackgroundUploadIntentRequest:
+  type: object
+  required: [contentType, contentLength]
+  properties:
+    contentType:
+      type: string
+      enum: [image/jpeg, image/png, image/webp]
+    contentLength:
+      type: integer
+      minimum: 1
+      maximum: 8388608
+      description: "Size of the file in bytes (max 8 MB)."
+
+BackgroundUploadIntentResponse:
+  type: object
+  required: [upload_url, method, headers, s3_key, expires_in_seconds]
+  properties:
+    upload_url:
+      type: string
+      format: uri
+    method:
+      type: string
+      enum: [PUT]
+    headers:
+      type: object
+      required: [Content-Type]
+      properties:
+        Content-Type:
+          type: string
+    s3_key:
+      type: string
+      description: "Persist this on the canvas via PUT /garden once the upload completes."
+    expires_in_seconds:
+      type: integer

--- a/services/grn-api/package.json
+++ b/services/grn-api/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "lint": "eslint functions/",
-    "test": "node --test functions/tests/*.test.mjs"
+    "test": "node --test functions/tests/*.test.mjs",
+    "test:integration": "node ./scripts/integration-test.mjs"
   },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1012.0",

--- a/services/grn-api/scripts/integration-test.mjs
+++ b/services/grn-api/scripts/integration-test.mjs
@@ -1,0 +1,465 @@
+import crypto from 'node:crypto';
+import { createHttpClient } from './integration/http-client.mjs';
+import { createReporter } from './integration/reporter.mjs';
+
+// --- Environment variable validation ---
+
+const REQUIRED_ENV_VARS = ['GRN_API_BASE_URL', 'GROWER_TOKEN'];
+
+function validateEnv() {
+  const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    console.error(`Missing required environment variable(s): ${missing.join(', ')}`);
+    console.error('All of the following must be set:');
+    for (const name of REQUIRED_ENV_VARS) {
+      console.error(`  ${name}=${process.env[name] ? '✓ set' : '✗ MISSING'}`);
+    }
+    console.error('\nOptional:');
+    console.error(`  GATHERER_TOKEN=${process.env.GATHERER_TOKEN ? '✓ set (used to verify grower-only enforcement)' : 'unset (grower-only 403 check is skipped)'}`);
+    console.error('\nProvision tokens with the ci-auth-seed Lambda (services/grn-api/functions/ci-auth-seed.mjs).');
+    process.exit(1);
+  }
+}
+
+// --- Helpers ---
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const GARDEN_BED_FIELDS = [
+  'id',
+  'user_id',
+  'name',
+  'description',
+  'sun_exposure',
+  'soil_type',
+  'length_inches',
+  'width_inches',
+  'location_notes',
+  'sort_order',
+  'bed_type',
+  'shape',
+  'position_x',
+  'position_y',
+  'rotation_deg',
+  'points',
+  'color',
+  'created_at',
+  'updated_at'
+];
+
+const GARDEN_CANVAS_FIELDS = [
+  'id',
+  'user_id',
+  'width_inches',
+  'height_inches',
+  'background_image_key',
+  'background_opacity',
+  'north_offset_deg',
+  'created_at',
+  'updated_at'
+];
+
+function missingFields(item, fields) {
+  return fields.filter((f) => !(f in item));
+}
+
+// --- Main runner ---
+
+async function run() {
+  validateEnv();
+
+  const runPrefix = `ci-${crypto.randomUUID().slice(0, 8)}`;
+  console.log(`\nRun_Prefix: ${runPrefix}\n`);
+
+  const apiBase = process.env.GRN_API_BASE_URL;
+  const growerToken = process.env.GROWER_TOKEN;
+  const gathererToken = process.env.GATHERER_TOKEN;
+
+  const noAuthApi = createHttpClient(apiBase);
+  const badTokenApi = createHttpClient(apiBase, {
+    Authorization: 'Bearer invalid-token-value'
+  });
+  const growerApi = createHttpClient(apiBase, {
+    Authorization: `Bearer ${growerToken}`
+  });
+  const gathererApi = gathererToken
+    ? createHttpClient(apiBase, { Authorization: `Bearer ${gathererToken}` })
+    : null;
+
+  const reporter = createReporter(runPrefix);
+  const createdBedIds = [];
+
+  // --- Auth Boundary ---
+  console.log('\n=== Auth Boundary ===');
+  {
+    const dummyId = '00000000-0000-4000-8000-000000000000';
+    {
+      const res = await noAuthApi.request('/beds');
+      reporter.assert('auth-boundary', res.status === 401, `GET /beds without auth returns 401 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await noAuthApi.request('/beds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'should fail' })
+      });
+      reporter.assert('auth-boundary', res.status === 401, `POST /beds without auth returns 401 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await noAuthApi.request(`/beds/${dummyId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'should fail' })
+      });
+      reporter.assert('auth-boundary', res.status === 401, `PUT /beds/:id without auth returns 401 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await noAuthApi.request('/garden');
+      reporter.assert('auth-boundary', res.status === 401, `GET /garden without auth returns 401 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await badTokenApi.request('/beds');
+      reporter.assert('auth-boundary',
+        res.status === 401 || res.status === 403,
+        `GET /beds with invalid token returns 401/403 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await badTokenApi.request('/garden');
+      reporter.assert('auth-boundary',
+        res.status === 401 || res.status === 403,
+        `GET /garden with invalid token returns 401/403 (got ${res.status})`, res.json);
+    }
+  }
+
+  // --- Grower-only enforcement (optional) ---
+  console.log('\n=== Grower-only enforcement ===');
+  if (!gathererApi) {
+    reporter.skip('grower-only', 'GATHERER_TOKEN not set; skipping role enforcement check');
+  } else {
+    const res = await gathererApi.request('/beds');
+    reporter.assert('grower-only', res.status === 403,
+      `GET /beds with gatherer token returns 403 (got ${res.status})`, res.json);
+  }
+
+  // --- Bed validation ---
+  console.log('\n=== Bed validation ===');
+  {
+    const cases = [
+      {
+        label: 'blank name',
+        body: { name: '   ', shape: 'rect', bedType: 'raised' }
+      },
+      {
+        label: 'unknown bedType',
+        body: { name: 'bad bedType', bedType: 'hydroponic' }
+      },
+      {
+        label: 'unknown shape',
+        body: { name: 'bad shape', shape: 'octagon' }
+      },
+      {
+        label: 'polygon without points',
+        body: { name: 'no points', shape: 'polygon' }
+      },
+      {
+        label: 'polygon with too few points',
+        body: {
+          name: 'two points',
+          shape: 'polygon',
+          points: [{ x: 0, y: 0 }, { x: 10, y: 0 }]
+        }
+      },
+      {
+        label: 'point missing y',
+        body: {
+          name: 'bad point',
+          shape: 'polygon',
+          points: [{ x: 0, y: 0 }, { x: 10 }, { x: 5, y: 10 }]
+        }
+      },
+      {
+        label: 'rotation out of range',
+        body: { name: 'spin', rotationDeg: 720 }
+      },
+      {
+        label: 'invalid color',
+        body: { name: 'colorful', color: 'green' }
+      },
+      {
+        label: 'negative length',
+        body: { name: 'tiny', lengthInches: -1 }
+      },
+      {
+        label: 'unknown sunExposure',
+        body: { name: 'rainforest bed', sunExposure: 'rainforest' }
+      }
+    ];
+
+    for (const { label, body } of cases) {
+      const res = await growerApi.request('/beds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      reporter.assert('bed-validation', res.status === 400,
+        `POST /beds (${label}) returns 400 (got ${res.status})`, res.json);
+    }
+
+    // Empty body / not-a-uuid path param.
+    {
+      const res = await growerApi.request('/beds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: ''
+      });
+      reporter.assert('bed-validation', res.status === 400,
+        `POST /beds with empty body returns 400 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await growerApi.request('/beds/not-a-uuid', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'whatever' })
+      });
+      reporter.assert('bed-validation', res.status === 400,
+        `PUT /beds/not-a-uuid returns 400 (got ${res.status})`, res.json);
+    }
+  }
+
+  // --- Bed CRUD ---
+  console.log('\n=== Bed CRUD ===');
+  try {
+    // Create a polygon bed with the full set of new fields.
+    const polygonName = `${runPrefix}-polygon-bed`;
+    const polygonPayload = {
+      name: polygonName,
+      bedType: 'in_ground',
+      shape: 'polygon',
+      points: [
+        { x: 0, y: 0 },
+        { x: 96, y: 0 },
+        { x: 96, y: 48 },
+        { x: 0, y: 48 }
+      ],
+      positionX: 12,
+      positionY: 24,
+      rotationDeg: 15,
+      color: '#4f8a3b',
+      lengthInches: 96,
+      widthInches: 48,
+      sunExposure: 'partial_sun',
+      soilType: 'sandy_loam',
+      locationNotes: 'south fence line',
+      sortOrder: 1
+    };
+    const createRes = await growerApi.request('/beds', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(polygonPayload)
+    });
+    reporter.assert('bed-crud', createRes.status === 201, `POST /beds returns 201 (got ${createRes.status})`, createRes.json);
+    const created = createRes.json;
+    if (created?.id) createdBedIds.push(created.id);
+
+    const fieldGap = missingFields(created ?? {}, GARDEN_BED_FIELDS);
+    reporter.assert('bed-crud', fieldGap.length === 0,
+      fieldGap.length === 0
+        ? 'created bed has all expected fields'
+        : `created bed missing fields: ${fieldGap.join(', ')}`,
+      created);
+    reporter.assert('bed-crud', UUID_PATTERN.test(created?.id ?? ''), `created bed id is a UUID (got ${created?.id})`, created);
+    reporter.assert('bed-crud', created?.bed_type === 'in_ground', `bed_type roundtrips as in_ground (got ${created?.bed_type})`, created);
+    reporter.assert('bed-crud', created?.shape === 'polygon', `shape roundtrips as polygon (got ${created?.shape})`, created);
+    reporter.assert('bed-crud', Array.isArray(created?.points) && created.points.length === 4,
+      `points roundtrip as 4-entry array (got ${created?.points?.length})`, created);
+    reporter.assert('bed-crud', created?.position_x === 12 && created?.position_y === 24,
+      `position roundtrips (got ${created?.position_x}, ${created?.position_y})`, created);
+    reporter.assert('bed-crud', created?.rotation_deg === 15, `rotation_deg roundtrips (got ${created?.rotation_deg})`, created);
+    reporter.assert('bed-crud', created?.color === '#4f8a3b', `color roundtrips (got ${created?.color})`, created);
+
+    // Update: flip to a rect, drop the polygon points, change position.
+    if (created?.id) {
+      const updatePayload = {
+        ...polygonPayload,
+        name: `${polygonName}-renamed`,
+        shape: 'rect',
+        points: null,
+        positionX: 60,
+        positionY: 60,
+        rotationDeg: 0
+      };
+      const updateRes = await growerApi.request(`/beds/${created.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updatePayload)
+      });
+      reporter.assert('bed-crud', updateRes.status === 200, `PUT /beds/:id returns 200 (got ${updateRes.status})`, updateRes.json);
+      reporter.assert('bed-crud', updateRes.json?.shape === 'rect', `shape updates to rect (got ${updateRes.json?.shape})`, updateRes.json);
+      reporter.assert('bed-crud', updateRes.json?.points === null, `points cleared on shape change (got ${updateRes.json?.points})`, updateRes.json);
+      reporter.assert('bed-crud', updateRes.json?.position_x === 60 && updateRes.json?.position_y === 60,
+        `position updates (got ${updateRes.json?.position_x}, ${updateRes.json?.position_y})`, updateRes.json);
+    }
+
+    // List shows the bed.
+    {
+      const listRes = await growerApi.request('/beds');
+      reporter.assert('bed-crud', listRes.status === 200, `GET /beds returns 200 (got ${listRes.status})`, listRes.json);
+      const found = Array.isArray(listRes.json) && listRes.json.some((b) => b.id === created?.id);
+      reporter.assert('bed-crud', found, 'created bed appears in list', listRes.json);
+    }
+
+    // Delete (soft) → not in list.
+    if (created?.id) {
+      const deleteRes = await growerApi.request(`/beds/${created.id}`, { method: 'DELETE' });
+      reporter.assert('bed-crud', deleteRes.status === 204, `DELETE /beds/:id returns 204 (got ${deleteRes.status})`, deleteRes.json);
+      const listAfter = await growerApi.request('/beds');
+      const stillThere = Array.isArray(listAfter.json) && listAfter.json.some((b) => b.id === created.id);
+      reporter.assert('bed-crud', !stillThere, 'archived bed is filtered from list', listAfter.json);
+      // Tracked-id list mirrors the soft-delete; clear it so cleanup doesn't double-delete.
+      const idx = createdBedIds.indexOf(created.id);
+      if (idx >= 0) createdBedIds.splice(idx, 1);
+    }
+
+    // Delete on unknown id → 404.
+    {
+      const dummyId = '00000000-0000-4000-8000-000000000000';
+      const res = await growerApi.request(`/beds/${dummyId}`, { method: 'DELETE' });
+      reporter.assert('bed-crud', res.status === 404, `DELETE /beds/:unknown returns 404 (got ${res.status})`, res.json);
+    }
+  } catch (err) {
+    reporter.fail('bed-crud', `Bed CRUD error: ${err.message}`);
+  }
+
+  // --- Garden canvas ---
+  console.log('\n=== Garden canvas ===');
+  try {
+    // GET auto-creates with defaults.
+    const getRes = await growerApi.request('/garden');
+    reporter.assert('garden-canvas', getRes.status === 200, `GET /garden returns 200 (got ${getRes.status})`, getRes.json);
+    const canvas = getRes.json;
+    const fieldGap = missingFields(canvas ?? {}, GARDEN_CANVAS_FIELDS);
+    reporter.assert('garden-canvas', fieldGap.length === 0,
+      fieldGap.length === 0
+        ? 'canvas has all expected fields'
+        : `canvas missing fields: ${fieldGap.join(', ')}`,
+      canvas);
+    reporter.assert('garden-canvas', UUID_PATTERN.test(canvas?.id ?? ''), `canvas id is a UUID (got ${canvas?.id})`, canvas);
+    reporter.assert('garden-canvas', typeof canvas?.width_inches === 'number' && canvas.width_inches > 0,
+      `width_inches is positive (got ${canvas?.width_inches})`, canvas);
+    reporter.assert('garden-canvas', typeof canvas?.height_inches === 'number' && canvas.height_inches > 0,
+      `height_inches is positive (got ${canvas?.height_inches})`, canvas);
+
+    // PUT updates dimensions and opacity.
+    {
+      const updateRes = await growerApi.request('/garden', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          widthInches: 480,
+          heightInches: 300,
+          backgroundOpacity: 40,
+          backgroundImageKey: null,
+          northOffsetDeg: 12
+        })
+      });
+      reporter.assert('garden-canvas', updateRes.status === 200, `PUT /garden returns 200 (got ${updateRes.status})`, updateRes.json);
+      reporter.assert('garden-canvas', updateRes.json?.width_inches === 480, `width updates (got ${updateRes.json?.width_inches})`, updateRes.json);
+      reporter.assert('garden-canvas', updateRes.json?.height_inches === 300, `height updates (got ${updateRes.json?.height_inches})`, updateRes.json);
+      reporter.assert('garden-canvas', updateRes.json?.background_opacity === 40, `opacity updates (got ${updateRes.json?.background_opacity})`, updateRes.json);
+      reporter.assert('garden-canvas', updateRes.json?.north_offset_deg === 12, `north offset updates (got ${updateRes.json?.north_offset_deg})`, updateRes.json);
+      reporter.assert('garden-canvas', updateRes.json?.background_image_key === null, 'background_image_key persists as null', updateRes.json);
+    }
+
+    // Validation failures.
+    const badCases = [
+      { label: 'opacity > 100', body: { backgroundOpacity: 250 } },
+      { label: 'opacity < 0', body: { backgroundOpacity: -5 } },
+      { label: 'width too small', body: { widthInches: 1 } },
+      { label: 'width too large', body: { widthInches: 999_999 } },
+      { label: 'north offset out of range', body: { northOffsetDeg: 9_999 } },
+      { label: 'background key outside prefix', body: { backgroundImageKey: 'other-prefix/foo.jpg' } },
+      { label: 'background key with traversal', body: { backgroundImageKey: 'garden-backgrounds/../etc' } }
+    ];
+    for (const { label, body } of badCases) {
+      const res = await growerApi.request('/garden', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      reporter.assert('garden-canvas', res.status === 400,
+        `PUT /garden (${label}) returns 400 (got ${res.status})`, res.json);
+    }
+  } catch (err) {
+    reporter.fail('garden-canvas', `Garden canvas error: ${err.message}`);
+  }
+
+  // --- Background upload URL ---
+  console.log('\n=== Background upload URL ===');
+  try {
+    {
+      const res = await growerApi.request('/garden/background-upload-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contentType: 'image/jpeg', contentLength: 1024 })
+      });
+      // 503 is acceptable in environments where MEDIA_BUCKET_NAME isn't wired
+      // (the env passes the validation step before failing on missing config),
+      // so accept either 201 (success) or 503 (config gap).
+      const acceptable = res.status === 201 || res.status === 503;
+      reporter.assert('background-upload-url', acceptable,
+        `POST /garden/background-upload-url returns 201 or 503 (got ${res.status})`, res.json);
+      if (res.status === 201) {
+        reporter.assert('background-upload-url', typeof res.json?.upload_url === 'string' && res.json.upload_url.startsWith('https://'),
+          'response includes https upload_url', res.json);
+        reporter.assert('background-upload-url', typeof res.json?.s3_key === 'string' && res.json.s3_key.startsWith('garden-backgrounds/'),
+          'response s3_key sits under garden-backgrounds/', res.json);
+        reporter.assert('background-upload-url', res.json?.method === 'PUT', `method is PUT (got ${res.json?.method})`, res.json);
+        reporter.assert('background-upload-url', res.json?.headers?.['Content-Type'] === 'image/jpeg',
+          'response headers include Content-Type: image/jpeg', res.json);
+        reporter.assert('background-upload-url', typeof res.json?.expires_in_seconds === 'number' && res.json.expires_in_seconds > 0,
+          `expires_in_seconds is positive (got ${res.json?.expires_in_seconds})`, res.json);
+      } else {
+        reporter.skip('background-upload-url', 'MEDIA_BUCKET_NAME not configured in this environment; presigning skipped');
+      }
+    }
+
+    // Bad content-type → 400.
+    {
+      const res = await growerApi.request('/garden/background-upload-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contentType: 'text/plain', contentLength: 1024 })
+      });
+      reporter.assert('background-upload-url', res.status === 400, `POST with bad content type returns 400 (got ${res.status})`, res.json);
+    }
+
+    // Oversize content-length → 400.
+    {
+      const res = await growerApi.request('/garden/background-upload-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contentType: 'image/png', contentLength: 50 * 1024 * 1024 })
+      });
+      reporter.assert('background-upload-url', res.status === 400, `POST with oversize length returns 400 (got ${res.status})`, res.json);
+    }
+  } catch (err) {
+    reporter.fail('background-upload-url', `Background upload URL error: ${err.message}`);
+  }
+
+  // --- Cleanup any beds that survived the CRUD scenario ---
+  for (const bedId of createdBedIds) {
+    try {
+      await growerApi.request(`/beds/${bedId}`, { method: 'DELETE' });
+    } catch (err) {
+      console.error(`Cleanup failed for bed ${bedId}: ${err.message}`);
+    }
+  }
+
+  const exitCode = reporter.summary();
+  process.exit(exitCode);
+}
+
+run().catch((err) => {
+  console.error('Fatal error in grn-api integration test runner:', err.message);
+  process.exit(1);
+});

--- a/services/grn-api/scripts/integration/http-client.mjs
+++ b/services/grn-api/scripts/integration/http-client.mjs
@@ -1,0 +1,48 @@
+const color = {
+  reset: '\x1b[0m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m'
+};
+
+const symbol = {
+  step: `${color.cyan}→${color.reset}`
+};
+
+function normalizeBase(url) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+/**
+ * Creates an HTTP client bound to a base URL with optional default headers.
+ * Every request logs: method, path, response status.
+ *
+ * @param {string} baseUrl
+ * @param {object} [defaultHeaders]
+ * @returns {{ request: (path: string, options?: RequestInit) => Promise<{ status: number, headers: Headers, json: any, text: string }> }}
+ */
+export function createHttpClient(baseUrl, defaultHeaders = {}) {
+  const base = normalizeBase(baseUrl);
+
+  async function request(path, options = {}) {
+    const method = options.method ?? 'GET';
+    console.log(`${symbol.step} ${color.cyan}${method} ${path}${color.reset}`);
+
+    const res = await fetch(`${base}${path}`, {
+      ...options,
+      headers: { ...defaultHeaders, ...options.headers }
+    });
+
+    const text = await res.text();
+    let json;
+    try {
+      json = text ? JSON.parse(text) : undefined;
+    } catch {
+      json = undefined;
+    }
+
+    console.log(`${color.dim}  status: ${res.status}${color.reset}`);
+    return { status: res.status, headers: res.headers, json, text };
+  }
+
+  return { request };
+}

--- a/services/grn-api/scripts/integration/reporter.mjs
+++ b/services/grn-api/scripts/integration/reporter.mjs
@@ -1,0 +1,88 @@
+const color = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m'
+};
+
+const symbol = {
+  pass: `${color.green}✓${color.reset}`,
+  fail: `${color.red}✗${color.reset}`
+};
+
+/**
+ * Tracks assertions and produces a summary.
+ *
+ * @param {string} runPrefix - The ci-<uuid> prefix for this run
+ * @returns {{ pass, fail, assert, skip, summary }}
+ */
+export function createReporter(runPrefix) {
+  /** @type {Record<string, { passed: number, failed: number, skipped: number }>} */
+  const scenarios = {};
+
+  function ensure(scenario) {
+    if (!scenarios[scenario]) {
+      scenarios[scenario] = { passed: 0, failed: 0, skipped: 0 };
+    }
+  }
+
+  function pass(scenario, message) {
+    ensure(scenario);
+    scenarios[scenario].passed++;
+    console.log(`  ${symbol.pass} ${message}`);
+  }
+
+  function fail(scenario, message, responseBody) {
+    ensure(scenario);
+    scenarios[scenario].failed++;
+    console.log(`  ${symbol.fail} ${message}`);
+    if (responseBody !== undefined) {
+      const body = typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody, null, 2);
+      console.log(`${color.red}  Response body: ${body}${color.reset}`);
+    }
+    console.log(`${color.dim}  Run_Prefix: ${runPrefix}${color.reset}`);
+  }
+
+  function assert(scenario, condition, message, responseBody) {
+    if (condition) {
+      pass(scenario, message);
+    } else {
+      fail(scenario, message, responseBody);
+    }
+  }
+
+  function skip(scenario, message) {
+    ensure(scenario);
+    scenarios[scenario].skipped++;
+    console.log(`  ${color.yellow}○ skipped: ${message}${color.reset}`);
+  }
+
+  function summary() {
+    console.log(`\n${color.yellow}=== Test Summary (${runPrefix}) ===${color.reset}`);
+
+    let totalPassed = 0;
+    let totalFailed = 0;
+    let totalSkipped = 0;
+
+    for (const [name, counts] of Object.entries(scenarios)) {
+      totalPassed += counts.passed;
+      totalFailed += counts.failed;
+      totalSkipped += counts.skipped;
+      const status = counts.failed === 0 ? symbol.pass : symbol.fail;
+      const skipNote = counts.skipped > 0 ? `, ${counts.skipped} skipped` : '';
+      console.log(`  ${status} ${name}: ${counts.passed} passed, ${counts.failed} failed${skipNote}`);
+    }
+
+    console.log(`\n${color.yellow}Total: ${totalPassed} passed, ${totalFailed} failed${totalSkipped > 0 ? `, ${totalSkipped} skipped` : ''}${color.reset}`);
+
+    if (totalFailed === 0) {
+      console.log(`${color.green}All tests passed.${color.reset}`);
+      return 0;
+    }
+    console.log(`${color.red}Some tests failed.${color.reset}`);
+    return 1;
+  }
+
+  return { pass, fail, assert, skip, summary };
+}

--- a/services/grn-api/src/api/handlers/bed.rs
+++ b/services/grn-api/src/api/handlers/bed.rs
@@ -17,6 +17,11 @@ const ALLOWED_SUN_EXPOSURE: [&str; 5] = [
     "mixed",
 ];
 
+const ALLOWED_BED_TYPES: [&str; 3] = ["in_ground", "raised", "mound"];
+const ALLOWED_SHAPES: [&str; 3] = ["rect", "circle", "polygon"];
+const COLOR_HEX_LEN: usize = 7; // "#rrggbb"
+const MAX_POLYGON_POINTS: usize = 64;
+
 pub async fn list_my_beds(
     request: &Request,
     _correlation_id: &str,
@@ -32,7 +37,8 @@ pub async fn list_my_beds(
             "
             select id, user_id, name, description, sun_exposure, soil_type,
                    length_inches, width_inches, location_notes, sort_order,
-                   created_at, updated_at
+                   bed_type, shape, position_x, position_y, rotation_deg,
+                   points, color, created_at, updated_at
             from garden_beds
             where user_id = $1 and archived_at is null
             order by sort_order asc, created_at asc
@@ -58,7 +64,7 @@ pub async fn create_my_bed(
 
     let user_id = parse_user_id(&auth_context.user_id)?;
     let payload: UpsertGardenBedRequest = parse_json_body(request)?;
-    let trimmed_name = validate_bed_payload(&payload)?;
+    let validated = validate_bed_payload(&payload)?;
 
     let client = db::connect().await?;
     let row = client
@@ -66,15 +72,20 @@ pub async fn create_my_bed(
             "
             insert into garden_beds
                 (user_id, name, description, sun_exposure, soil_type,
-                 length_inches, width_inches, location_notes, sort_order)
-            values ($1, $2, $3, $4, $5, $6, $7, $8, coalesce($9, 0))
+                 length_inches, width_inches, location_notes, sort_order,
+                 bed_type, shape, position_x, position_y, rotation_deg,
+                 points, color)
+            values ($1, $2, $3, $4, $5, $6, $7, $8, coalesce($9, 0),
+                    coalesce($10, 'raised'), coalesce($11, 'rect'),
+                    $12, $13, coalesce($14, 0), $15, $16)
             returning id, user_id, name, description, sun_exposure, soil_type,
                       length_inches, width_inches, location_notes, sort_order,
-                      created_at, updated_at
+                      bed_type, shape, position_x, position_y, rotation_deg,
+                      points, color, created_at, updated_at
             ",
             &[
                 &user_id,
-                &trimmed_name,
+                &validated.name,
                 &payload.description.as_ref().map(|s| s.trim().to_string()),
                 &payload.sun_exposure,
                 &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
@@ -85,6 +96,13 @@ pub async fn create_my_bed(
                     .as_ref()
                     .map(|s| s.trim().to_string()),
                 &payload.sort_order,
+                &validated.bed_type,
+                &validated.shape,
+                &payload.position_x,
+                &payload.position_y,
+                &payload.rotation_deg,
+                &validated.points,
+                &validated.color,
             ],
         )
         .await
@@ -110,7 +128,7 @@ pub async fn update_my_bed(
 
     let user_id = parse_user_id(&auth_context.user_id)?;
     let payload: UpsertGardenBedRequest = parse_json_body(request)?;
-    let trimmed_name = validate_bed_payload(&payload)?;
+    let validated = validate_bed_payload(&payload)?;
     let id = parse_uuid(bed_id, "bed id")?;
 
     let client = db::connect().await?;
@@ -126,14 +144,22 @@ pub async fn update_my_bed(
                 width_inches = $6,
                 location_notes = $7,
                 sort_order = coalesce($8, sort_order),
+                bed_type = coalesce($9, bed_type),
+                shape = coalesce($10, shape),
+                position_x = $11,
+                position_y = $12,
+                rotation_deg = coalesce($13, rotation_deg),
+                points = $14,
+                color = $15,
                 updated_at = now()
-            where id = $9 and user_id = $10 and archived_at is null
+            where id = $16 and user_id = $17 and archived_at is null
             returning id, user_id, name, description, sun_exposure, soil_type,
                       length_inches, width_inches, location_notes, sort_order,
-                      created_at, updated_at
+                      bed_type, shape, position_x, position_y, rotation_deg,
+                      points, color, created_at, updated_at
             ",
             &[
-                &trimmed_name,
+                &validated.name,
                 &payload.description.as_ref().map(|s| s.trim().to_string()),
                 &payload.sun_exposure,
                 &payload.soil_type.as_ref().map(|s| s.trim().to_string()),
@@ -144,6 +170,13 @@ pub async fn update_my_bed(
                     .as_ref()
                     .map(|s| s.trim().to_string()),
                 &payload.sort_order,
+                &validated.bed_type,
+                &validated.shape,
+                &payload.position_x,
+                &payload.position_y,
+                &payload.rotation_deg,
+                &validated.points,
+                &validated.color,
                 &id,
                 &user_id,
             ],
@@ -206,9 +239,17 @@ pub async fn delete_my_bed(
         .map_err(|e| lambda_http::Error::from(e.to_string()))
 }
 
+pub struct ValidatedBed {
+    pub name: String,
+    pub bed_type: Option<String>,
+    pub shape: Option<String>,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
+}
+
 pub fn validate_bed_payload(
     payload: &UpsertGardenBedRequest,
-) -> Result<String, lambda_http::Error> {
+) -> Result<ValidatedBed, lambda_http::Error> {
     let trimmed = payload.name.trim();
     if trimmed.is_empty() {
         return Err(lambda_http::Error::from("bed name is required".to_string()));
@@ -231,7 +272,118 @@ pub fn validate_bed_payload(
             "bed dimensions must be non-negative".to_string(),
         ));
     }
-    Ok(trimmed.to_string())
+
+    let bed_type = match payload.bed_type.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if ALLOWED_BED_TYPES.contains(&value) => Some(value.to_string()),
+        Some(value) => {
+            return Err(lambda_http::Error::from(format!(
+                "Invalid bedType '{value}'. Allowed values: {}",
+                ALLOWED_BED_TYPES.join(", ")
+            )));
+        }
+    };
+
+    let shape = match payload.shape.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if ALLOWED_SHAPES.contains(&value) => Some(value.to_string()),
+        Some(value) => {
+            return Err(lambda_http::Error::from(format!(
+                "Invalid bed shape '{value}'. Allowed values: {}",
+                ALLOWED_SHAPES.join(", ")
+            )));
+        }
+    };
+
+    if let Some(deg) = payload.rotation_deg {
+        if !(-360..=360).contains(&deg) {
+            return Err(lambda_http::Error::from(
+                "rotationDeg must be between -360 and 360".to_string(),
+            ));
+        }
+    }
+
+    let points = validate_polygon_points(payload.points.as_ref(), shape.as_deref())?;
+
+    let color = match payload.color.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if is_valid_hex_color(value) => Some(value.to_lowercase()),
+        Some(_) => {
+            return Err(lambda_http::Error::from(
+                "color must be a 7-character hex string like #4f8a3b".to_string(),
+            ));
+        }
+    };
+
+    Ok(ValidatedBed {
+        name: trimmed.to_string(),
+        bed_type,
+        shape,
+        points,
+        color,
+    })
+}
+
+fn validate_polygon_points(
+    raw: Option<&serde_json::Value>,
+    shape: Option<&str>,
+) -> Result<Option<serde_json::Value>, lambda_http::Error> {
+    let Some(value) = raw else {
+        if shape == Some("polygon") {
+            return Err(lambda_http::Error::from(
+                "points is required when shape is polygon".to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+
+    let array = value
+        .as_array()
+        .ok_or_else(|| lambda_http::Error::from("points must be an array".to_string()))?;
+
+    if shape == Some("polygon") && array.len() < 3 {
+        return Err(lambda_http::Error::from(
+            "points must contain at least 3 entries for a polygon".to_string(),
+        ));
+    }
+    if array.len() > MAX_POLYGON_POINTS {
+        return Err(lambda_http::Error::from(format!(
+            "points must contain {MAX_POLYGON_POINTS} or fewer entries"
+        )));
+    }
+
+    for entry in array {
+        let object = entry
+            .as_object()
+            .ok_or_else(|| lambda_http::Error::from("each point must be an object".to_string()))?;
+        let x = object
+            .get("x")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| {
+                lambda_http::Error::from("each point must have integer x".to_string())
+            })?;
+        let y = object
+            .get("y")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| {
+                lambda_http::Error::from("each point must have integer y".to_string())
+            })?;
+        if !(i64::from(i32::MIN)..=i64::from(i32::MAX)).contains(&x)
+            || !(i64::from(i32::MIN)..=i64::from(i32::MAX)).contains(&y)
+        {
+            return Err(lambda_http::Error::from(
+                "point coordinates must fit in a 32-bit integer".to_string(),
+            ));
+        }
+    }
+
+    Ok(Some(value.clone()))
+}
+
+fn is_valid_hex_color(value: &str) -> bool {
+    value.len() == COLOR_HEX_LEN
+        && value.starts_with('#')
+        && value[1..].chars().all(|c| c.is_ascii_hexdigit())
 }
 
 fn parse_user_id(value: &str) -> Result<Uuid, lambda_http::Error> {
@@ -269,6 +421,13 @@ fn row_to_bed(row: &Row) -> GardenBed {
         width_inches: row.get("width_inches"),
         location_notes: row.get("location_notes"),
         sort_order: row.get("sort_order"),
+        bed_type: row.get("bed_type"),
+        shape: row.get("shape"),
+        position_x: row.get("position_x"),
+        position_y: row.get("position_y"),
+        rotation_deg: row.get("rotation_deg"),
+        points: row.get("points"),
+        color: row.get("color"),
         created_at: row
             .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
             .to_rfc3339(),
@@ -313,6 +472,7 @@ fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::{validate_bed_payload, UpsertGardenBedRequest};
+    use serde_json::json;
 
     fn payload() -> UpsertGardenBedRequest {
         UpsertGardenBedRequest {
@@ -324,15 +484,22 @@ mod tests {
             width_inches: Some(48),
             location_notes: None,
             sort_order: Some(0),
+            bed_type: Some("raised".to_string()),
+            shape: Some("rect".to_string()),
+            position_x: Some(0),
+            position_y: Some(0),
+            rotation_deg: Some(0),
+            points: None,
+            color: None,
         }
     }
 
     #[test]
     fn accepts_valid_payload() {
-        assert_eq!(
-            validate_bed_payload(&payload()).unwrap(),
-            "Front raised bed"
-        );
+        let result = validate_bed_payload(&payload()).unwrap();
+        assert_eq!(result.name, "Front raised bed");
+        assert_eq!(result.bed_type.as_deref(), Some("raised"));
+        assert_eq!(result.shape.as_deref(), Some("rect"));
     }
 
     #[test]
@@ -354,5 +521,80 @@ mod tests {
         let mut p = payload();
         p.length_inches = Some(-1);
         assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_bed_type() {
+        let mut p = payload();
+        p.bed_type = Some("hydroponic".to_string());
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_shape() {
+        let mut p = payload();
+        p.shape = Some("octagon".to_string());
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_polygon_without_points() {
+        let mut p = payload();
+        p.shape = Some("polygon".to_string());
+        p.points = None;
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_polygon_with_too_few_points() {
+        let mut p = payload();
+        p.shape = Some("polygon".to_string());
+        p.points = Some(json!([{"x": 0, "y": 0}, {"x": 10, "y": 0}]));
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn accepts_polygon_with_three_points() {
+        let mut p = payload();
+        p.shape = Some("polygon".to_string());
+        p.points = Some(json!([{"x": 0, "y": 0}, {"x": 24, "y": 0}, {"x": 12, "y": 24}]));
+        assert!(validate_bed_payload(&p).is_ok());
+    }
+
+    #[test]
+    fn rejects_points_when_not_an_array() {
+        let mut p = payload();
+        p.points = Some(json!({"x": 0, "y": 0}));
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_point_missing_coordinate() {
+        let mut p = payload();
+        p.shape = Some("polygon".to_string());
+        p.points = Some(json!([{"x": 0, "y": 0}, {"x": 24}, {"x": 12, "y": 24}]));
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_rotation_out_of_range() {
+        let mut p = payload();
+        p.rotation_deg = Some(720);
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_color() {
+        let mut p = payload();
+        p.color = Some("blue".to_string());
+        assert!(validate_bed_payload(&p).is_err());
+    }
+
+    #[test]
+    fn accepts_valid_hex_color() {
+        let mut p = payload();
+        p.color = Some("#4F8A3B".to_string());
+        let result = validate_bed_payload(&p).unwrap();
+        assert_eq!(result.color.as_deref(), Some("#4f8a3b"));
     }
 }

--- a/services/grn-api/src/api/handlers/garden_canvas.rs
+++ b/services/grn-api/src/api/handlers/garden_canvas.rs
@@ -1,0 +1,383 @@
+use crate::auth::{extract_auth_context_with_fallback, require_grower};
+use crate::db;
+use crate::handlers::crop::error_response;
+use crate::models::garden_canvas::{
+    BackgroundUploadIntentHeaders, BackgroundUploadIntentRequest, BackgroundUploadIntentResponse,
+    GardenCanvas, UpsertGardenCanvasRequest,
+};
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::presigning::PresigningConfig;
+use lambda_http::{Body, Request, Response};
+use serde::Serialize;
+use std::env;
+use std::time::Duration;
+use tokio_postgres::Row;
+use tracing::{error, info};
+use uuid::Uuid;
+
+const ALLOWED_BACKGROUND_CONTENT_TYPES: [&str; 3] = ["image/jpeg", "image/png", "image/webp"];
+const MAX_BACKGROUND_BYTES: u64 = 8 * 1024 * 1024; // 8 MB
+const UPLOAD_URL_EXPIRES_SECONDS: u64 = 900; // 15 minutes
+const BACKGROUND_KEY_PREFIX: &str = "garden-backgrounds";
+const MIN_CANVAS_INCHES: i32 = 12;
+const MAX_CANVAS_INCHES: i32 = 12_000;
+
+pub async fn get_my_canvas(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+    let user_id = parse_user_id(&auth_context.user_id)?;
+
+    let client = db::connect().await?;
+    let row = client
+        .query_one(
+            "
+            insert into garden_canvases (user_id)
+            values ($1)
+            on conflict (user_id) do update
+              set updated_at = garden_canvases.updated_at
+            returning id, user_id, width_inches, height_inches,
+                      background_image_key, background_opacity, north_offset_deg,
+                      created_at, updated_at
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        "Fetched garden canvas"
+    );
+
+    json_response(200, &row_to_canvas(&row))
+}
+
+pub async fn update_my_canvas(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+    let user_id = parse_user_id(&auth_context.user_id)?;
+
+    let payload: UpsertGardenCanvasRequest = parse_json_body(request)?;
+    validate_canvas_payload(&payload)?;
+
+    let client = db::connect().await?;
+    let row = client
+        .query_one(
+            "
+            insert into garden_canvases (
+                user_id, width_inches, height_inches, background_image_key,
+                background_opacity, north_offset_deg
+            )
+            values (
+                $1,
+                coalesce($2, 360),
+                coalesce($3, 240),
+                $4,
+                coalesce($5, 60),
+                coalesce($6, 0)
+            )
+            on conflict (user_id) do update
+              set width_inches = coalesce(excluded.width_inches, garden_canvases.width_inches),
+                  height_inches = coalesce(excluded.height_inches, garden_canvases.height_inches),
+                  background_image_key = excluded.background_image_key,
+                  background_opacity = coalesce(excluded.background_opacity, garden_canvases.background_opacity),
+                  north_offset_deg = coalesce(excluded.north_offset_deg, garden_canvases.north_offset_deg),
+                  updated_at = now()
+            returning id, user_id, width_inches, height_inches,
+                      background_image_key, background_opacity, north_offset_deg,
+                      created_at, updated_at
+            ",
+            &[
+                &user_id,
+                &payload.width_inches,
+                &payload.height_inches,
+                &payload.background_image_key,
+                &payload.background_opacity,
+                &payload.north_offset_deg,
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        "Updated garden canvas"
+    );
+
+    json_response(200, &row_to_canvas(&row))
+}
+
+pub async fn create_background_upload_url(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+    let user_id = parse_user_id(&auth_context.user_id)?;
+
+    let payload: BackgroundUploadIntentRequest = parse_json_body(request)?;
+    let content_type = payload.content_type.trim();
+    if !ALLOWED_BACKGROUND_CONTENT_TYPES.contains(&content_type) {
+        return Err(lambda_http::Error::from(format!(
+            "contentType must be one of: {}",
+            ALLOWED_BACKGROUND_CONTENT_TYPES.join(", ")
+        )));
+    }
+    if payload.content_length == 0 {
+        return Err(lambda_http::Error::from(
+            "contentLength must be a positive integer".to_string(),
+        ));
+    }
+    if payload.content_length > MAX_BACKGROUND_BYTES {
+        return Err(lambda_http::Error::from(format!(
+            "contentLength must be {MAX_BACKGROUND_BYTES} bytes or fewer"
+        )));
+    }
+
+    let bucket = env::var("MEDIA_BUCKET_NAME")
+        .map_err(|_| lambda_http::Error::from("MEDIA_BUCKET_NAME is not configured".to_string()))?;
+
+    let asset_id = Uuid::new_v4();
+    let key = format!("{BACKGROUND_KEY_PREFIX}/{user_id}/{asset_id}");
+
+    let aws_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let s3 = aws_sdk_s3::Client::new(&aws_config);
+
+    let presigning_config = PresigningConfig::expires_in(Duration::from_secs(
+        UPLOAD_URL_EXPIRES_SECONDS,
+    ))
+    .map_err(|e| {
+        error!(error = %e, "Failed to build presigning config");
+        lambda_http::Error::from(format!("Failed to build presigning config: {e}"))
+    })?;
+
+    // SAFETY: content_length is bounded to MAX_BACKGROUND_BYTES (8 MB), well within i64.
+    let content_length_i64 = i64::try_from(payload.content_length)
+        .map_err(|_| lambda_http::Error::from("contentLength out of range".to_string()))?;
+
+    let presigned = s3
+        .put_object()
+        .bucket(&bucket)
+        .key(&key)
+        .content_type(content_type)
+        .content_length(content_length_i64)
+        .presigned(presigning_config)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to presign garden background upload");
+            lambda_http::Error::from(format!("Failed to presign upload: {e}"))
+        })?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        s3_key = key.as_str(),
+        "Issued garden background presigned upload URL"
+    );
+
+    let response = BackgroundUploadIntentResponse {
+        upload_url: presigned.uri().to_string(),
+        method: "PUT".to_string(),
+        headers: BackgroundUploadIntentHeaders {
+            content_type: content_type.to_string(),
+        },
+        s3_key: key,
+        expires_in_seconds: UPLOAD_URL_EXPIRES_SECONDS,
+    };
+
+    json_response(201, &response)
+}
+
+fn validate_canvas_payload(payload: &UpsertGardenCanvasRequest) -> Result<(), lambda_http::Error> {
+    if let Some(width) = payload.width_inches {
+        if !(MIN_CANVAS_INCHES..=MAX_CANVAS_INCHES).contains(&width) {
+            return Err(lambda_http::Error::from(format!(
+                "widthInches must be between {MIN_CANVAS_INCHES} and {MAX_CANVAS_INCHES}"
+            )));
+        }
+    }
+    if let Some(height) = payload.height_inches {
+        if !(MIN_CANVAS_INCHES..=MAX_CANVAS_INCHES).contains(&height) {
+            return Err(lambda_http::Error::from(format!(
+                "heightInches must be between {MIN_CANVAS_INCHES} and {MAX_CANVAS_INCHES}"
+            )));
+        }
+    }
+    if let Some(opacity) = payload.background_opacity {
+        if !(0..=100).contains(&opacity) {
+            return Err(lambda_http::Error::from(
+                "backgroundOpacity must be between 0 and 100".to_string(),
+            ));
+        }
+    }
+    if let Some(offset) = payload.north_offset_deg {
+        if !(-360..=360).contains(&offset) {
+            return Err(lambda_http::Error::from(
+                "northOffsetDeg must be between -360 and 360".to_string(),
+            ));
+        }
+    }
+    if let Some(key) = payload.background_image_key.as_deref() {
+        let trimmed = key.trim();
+        if trimmed.is_empty() {
+            return Err(lambda_http::Error::from(
+                "backgroundImageKey must not be empty when provided".to_string(),
+            ));
+        }
+        if !trimmed.starts_with(&format!("{BACKGROUND_KEY_PREFIX}/")) {
+            return Err(lambda_http::Error::from(format!(
+                "backgroundImageKey must live under {BACKGROUND_KEY_PREFIX}/"
+            )));
+        }
+        if trimmed.contains("..") {
+            return Err(lambda_http::Error::from(
+                "backgroundImageKey must not contain path traversal segments".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_user_id(value: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(value).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn row_to_canvas(row: &Row) -> GardenCanvas {
+    GardenCanvas {
+        id: row.get::<_, Uuid>("id").to_string(),
+        user_id: row.get::<_, Uuid>("user_id").to_string(),
+        width_inches: row.get("width_inches"),
+        height_inches: row.get("height_inches"),
+        background_image_key: row.get("background_image_key"),
+        background_opacity: row.get("background_opacity"),
+        north_offset_deg: row.get("north_offset_deg"),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+        updated_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("updated_at")
+            .to_rfc3339(),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+#[allow(dead_code)]
+fn not_found_response() -> Result<Response<Body>, lambda_http::Error> {
+    error_response(404, "Garden canvas not found")
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::{validate_canvas_payload, UpsertGardenCanvasRequest};
+
+    fn payload() -> UpsertGardenCanvasRequest {
+        UpsertGardenCanvasRequest {
+            width_inches: Some(360),
+            height_inches: Some(240),
+            background_image_key: None,
+            background_opacity: Some(60),
+            north_offset_deg: Some(0),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_payload() {
+        assert!(validate_canvas_payload(&payload()).is_ok());
+    }
+
+    #[test]
+    fn rejects_too_small_width() {
+        let mut p = payload();
+        p.width_inches = Some(1);
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_too_large_height() {
+        let mut p = payload();
+        p.height_inches = Some(1_000_000);
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_opacity_out_of_range() {
+        let mut p = payload();
+        p.background_opacity = Some(120);
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_north_offset_out_of_range() {
+        let mut p = payload();
+        p.north_offset_deg = Some(1_000);
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_background_key_outside_prefix() {
+        let mut p = payload();
+        p.background_image_key = Some("other-prefix/foo.jpg".to_string());
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_background_key() {
+        let mut p = payload();
+        p.background_image_key = Some("   ".to_string());
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_background_key_with_path_traversal() {
+        let mut p = payload();
+        p.background_image_key = Some("garden-backgrounds/../etc/passwd".to_string());
+        assert!(validate_canvas_payload(&p).is_err());
+    }
+
+    #[test]
+    fn accepts_well_formed_background_key() {
+        let mut p = payload();
+        p.background_image_key =
+            Some("garden-backgrounds/00000000-0000-0000-0000-000000000000/abc.jpg".to_string());
+        assert!(validate_canvas_payload(&p).is_ok());
+    }
+}

--- a/services/grn-api/src/api/handlers/mod.rs
+++ b/services/grn-api/src/api/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod claim;
 pub mod claim_read;
 pub mod crop;
 pub mod feed;
+pub mod garden_canvas;
 pub mod listing;
 pub mod listing_discovery;
 pub mod reminder;

--- a/services/grn-api/src/api/models/bed.rs
+++ b/services/grn-api/src/api/models/bed.rs
@@ -12,6 +12,13 @@ pub struct GardenBed {
     pub width_inches: Option<i32>,
     pub location_notes: Option<String>,
     pub sort_order: i32,
+    pub bed_type: String,
+    pub shape: String,
+    pub position_x: Option<i32>,
+    pub position_y: Option<i32>,
+    pub rotation_deg: i32,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -33,4 +40,18 @@ pub struct UpsertGardenBedRequest {
     pub location_notes: Option<String>,
     #[serde(default, alias = "sortOrder")]
     pub sort_order: Option<i32>,
+    #[serde(default, alias = "bedType")]
+    pub bed_type: Option<String>,
+    #[serde(default)]
+    pub shape: Option<String>,
+    #[serde(default, alias = "positionX")]
+    pub position_x: Option<i32>,
+    #[serde(default, alias = "positionY")]
+    pub position_y: Option<i32>,
+    #[serde(default, alias = "rotationDeg")]
+    pub rotation_deg: Option<i32>,
+    #[serde(default)]
+    pub points: Option<serde_json::Value>,
+    #[serde(default)]
+    pub color: Option<String>,
 }

--- a/services/grn-api/src/api/models/garden_canvas.rs
+++ b/services/grn-api/src/api/models/garden_canvas.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GardenCanvas {
+    pub id: String,
+    pub user_id: String,
+    pub width_inches: i32,
+    pub height_inches: i32,
+    pub background_image_key: Option<String>,
+    pub background_opacity: i16,
+    pub north_offset_deg: i16,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpsertGardenCanvasRequest {
+    #[serde(default, alias = "widthInches")]
+    pub width_inches: Option<i32>,
+    #[serde(default, alias = "heightInches")]
+    pub height_inches: Option<i32>,
+    #[serde(default, alias = "backgroundImageKey")]
+    pub background_image_key: Option<String>,
+    #[serde(default, alias = "backgroundOpacity")]
+    pub background_opacity: Option<i16>,
+    #[serde(default, alias = "northOffsetDeg")]
+    pub north_offset_deg: Option<i16>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BackgroundUploadIntentRequest {
+    #[serde(alias = "contentType")]
+    pub content_type: String,
+    #[serde(alias = "contentLength")]
+    pub content_length: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackgroundUploadIntentResponse {
+    pub upload_url: String,
+    pub method: String,
+    pub headers: BackgroundUploadIntentHeaders,
+    pub s3_key: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackgroundUploadIntentHeaders {
+    #[serde(rename = "Content-Type")]
+    pub content_type: String,
+}

--- a/services/grn-api/src/api/models/mod.rs
+++ b/services/grn-api/src/api/models/mod.rs
@@ -3,5 +3,6 @@ pub mod catalog;
 pub mod crop;
 pub mod entitlements;
 pub mod feed;
+pub mod garden_canvas;
 pub mod listing;
 pub mod profile;

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -1,6 +1,6 @@
 use crate::handlers::{
     agent_task, ai_copilot, analytics, bed, billing, catalog, claim, claim_read, crop, feed,
-    listing, listing_discovery, reminder, request, user,
+    garden_canvas, listing, listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -160,21 +160,7 @@ async fn route_dynamic_routes(
         return handle(result);
     }
 
-    if request_path == "/beds" {
-        let result = match event.method().as_str() {
-            "GET" => bed::list_my_beds(event, correlation_id).await,
-            "POST" => bed::create_my_bed(event, correlation_id).await,
-            _ => method_not_allowed(),
-        };
-        return handle(result);
-    }
-
-    if let Some(bed_id) = request_path.strip_prefix("/beds/") {
-        let result = match event.method().as_str() {
-            "PUT" => bed::update_my_bed(event, correlation_id, bed_id).await,
-            "DELETE" => bed::delete_my_bed(event, correlation_id, bed_id).await,
-            _ => method_not_allowed(),
-        };
+    if let Some(result) = route_garden_designer_request(event, correlation_id, request_path).await {
         return handle(result);
     }
 
@@ -251,6 +237,41 @@ async fn route_dynamic_routes(
         .map_err(|e| lambda_http::Error::from(e.to_string()))
 }
 
+async fn route_garden_designer_request(
+    event: &Request,
+    correlation_id: &str,
+    request_path: &str,
+) -> Option<Result<Response<Body>, lambda_http::Error>> {
+    if request_path == "/garden" {
+        return Some(match event.method().as_str() {
+            "GET" => garden_canvas::get_my_canvas(event, correlation_id).await,
+            "PUT" => garden_canvas::update_my_canvas(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    if request_path == "/garden/background-upload-url" {
+        return Some(match event.method().as_str() {
+            "POST" => garden_canvas::create_background_upload_url(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    if request_path == "/beds" {
+        return Some(match event.method().as_str() {
+            "GET" => bed::list_my_beds(event, correlation_id).await,
+            "POST" => bed::create_my_bed(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    if let Some(bed_id) = request_path.strip_prefix("/beds/") {
+        return Some(match event.method().as_str() {
+            "PUT" => bed::update_my_bed(event, correlation_id, bed_id).await,
+            "DELETE" => bed::delete_my_bed(event, correlation_id, bed_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    None
+}
+
 fn method_not_allowed() -> Result<Response<Body>, lambda_http::Error> {
     Response::builder()
         .status(405)
@@ -269,6 +290,30 @@ fn handle(
             map_api_error_to_response(&error)
         }
     }
+}
+
+fn is_garden_designer_validation_message(message: &str) -> bool {
+    // Bed shape/type/geometry + canvas + presigned-upload validation messages.
+    // Kept here so map_api_error_to_response stays under the clippy
+    // too_many_lines threshold; each contains() check is one phrase that
+    // must round-trip from a handler validation Err to a 400 response.
+    message.contains("Invalid bedType")
+        || message.contains("Invalid bed shape")
+        || message.contains("rotationDeg must be")
+        || message.contains("points is required when shape is polygon")
+        || message.contains("points must be an array")
+        || message.contains("points must contain at least 3 entries")
+        || message.contains("points must contain")
+        || message.contains("each point must")
+        || message.contains("point coordinates must fit")
+        || message.contains("color must be a 7-character hex string")
+        || message.contains("widthInches must be between")
+        || message.contains("heightInches must be between")
+        || message.contains("backgroundOpacity must be")
+        || message.contains("northOffsetDeg must be")
+        || message.contains("backgroundImageKey must")
+        || message.contains("contentType must be one of")
+        || message.contains("contentLength must be")
 }
 
 fn map_api_error_to_response(
@@ -301,6 +346,7 @@ fn map_api_error_to_response(
         || message.contains("Invalid sunExposure")
         || message.contains("bed dimensions must be non-negative")
         || message.contains("bed_id does not reference one of your garden beds")
+        || is_garden_designer_validation_message(&message)
         || message.contains("plantingDate must be")
         || message.contains("expectedHarvestDate must be")
         || message.contains("plantCount must be")
@@ -349,6 +395,7 @@ fn map_api_error_to_response(
         || message.contains("STRIPE_SECRET_KEY")
         || message.contains("STRIPE_PRO_PRICE_ID")
         || message.contains("STRIPE_WEBHOOK_SECRET")
+        || message.contains("MEDIA_BUCKET_NAME")
     {
         return crop::error_response(503, "Service not configured in this environment");
     }

--- a/services/grn-api/template.yaml
+++ b/services/grn-api/template.yaml
@@ -335,6 +335,17 @@ Resources:
               Action:
                 - events:PutEvents
               Resource: !GetAtt EventBus.Arn
+            # Garden designer uploads land here. Presigned PUT URLs are
+            # signed with the ApiFunction's role, so S3 evaluates this
+            # policy when the browser PUTs the image. Restricted to the
+            # garden-backgrounds/ prefix so the role can't be repurposed
+            # to write anywhere else in the shared assets bucket.
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource: !Sub
+                - '${SharedAssetsBucketArn}/garden-backgrounds/*'
+                - SharedAssetsBucketArn: !ImportValue OGF-AssetsBucketArn
       Environment:
         Variables:
           DATABASE_URL: !Ref DatabaseUrl
@@ -346,6 +357,8 @@ Resources:
           STRIPE_SECRET_KEY: !Ref StripeSecretKey
           STRIPE_WEBHOOK_SECRET: !Ref StripeWebhookSecret
           STRIPE_PRO_PRICE_ID: !Ref StripeProPriceId
+          MEDIA_BUCKET_NAME: !ImportValue OGF-AssetsBucketName
+          MEDIA_CDN_DOMAIN: !ImportValue OGF-AssetsPublicDomainName
           RUST_LOG: info
           RUST_BACKTRACE: "1"
       Events:


### PR DESCRIPTION
## Summary

PR 1 of 2 for the garden designer feature. Lands the API + schema so the UI in PR 2 can drop in cleanly.

- **Schema (migration `0029_garden_layout.sql`)**: extends `garden_beds` with `bed_type` (in_ground/raised/mound), `shape` (rect/circle/polygon), `position_x`/`position_y`, `rotation_deg`, `points` jsonb (polygon vertices), and `color`. Adds `garden_canvases` (single canvas per user via `UNIQUE(user_id)`; constraint can be dropped later when multi-garden ships as a paid-tier feature).
- **API**: `/beds` and `/beds/{id}` now persist and round-trip the new geometry fields with allow-list + polygon validation. New `GET /garden` (auto-creates defaults on first read), `PUT /garden`, and `POST /garden/background-upload-url` (15-min presigned S3 PUT under `garden-backgrounds/{userId}/…`, jpeg/png/webp ≤ 8 MB).
- **OpenAPI**: new `schemas/garden.yaml` + `paths/garden.yaml`. Also fills the gap left when 0028 added `/beds` without OpenAPI coverage.
- **IAM**: `ApiFunction` role gets `s3:PutObject` only on `garden-backgrounds/*` of the shared assets bucket. New `MEDIA_BUCKET_NAME` + `MEDIA_CDN_DOMAIN` env vars (matches the admin-api pattern).
- **Testing**: per-team preference, this PR adds an integration test script at `services/grn-api/scripts/integration-test.mjs` instead of Postman tests. Mirrors the admin-api/web-api/okra-api pattern (env-driven, run-prefixed, cleanup-in-finally). 17 new Rust unit tests cover the new validation paths; `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo check` all pass; full unit suite (202 tests) green.

This PR ships **no UI changes** — the existing `/crops/new` bed-creation flow continues to work because every new column has a default or is nullable.

## Test plan

- [ ] CI: `cargo fmt`, `cargo clippy`, `cargo check`, `cargo test` (already passing locally)
- [ ] Run migration `0029_garden_layout.sql` against a non-prod database and confirm existing rows pick up `bed_type='raised'`, `shape='rect'`, `rotation_deg=0` defaults without rewrites
- [ ] Provision tokens via `ci-auth-seed` Lambda, then run `npm run --prefix services/grn-api test:integration` against a deployed environment with `GRN_API_BASE_URL`/`GROWER_TOKEN` (and optionally `GATHERER_TOKEN`) set
- [ ] Verify the existing `/crops/new` flow still creates beds successfully (no regressions on the 0028 surface)
- [ ] Confirm `POST /garden/background-upload-url` returns a presigned URL whose host points at the shared assets bucket and whose path begins with `garden-backgrounds/<userId>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)