### PR TITLE
GRN: garden designer UI on react-konva (PR 2)

### DIFF
--- a/apps/grn/package-lock.json
+++ b/apps/grn/package-lock.json
@@ -13,9 +13,11 @@
         "@tanstack/react-query": "^5.90.21",
         "@types/uuid": "^10.0.0",
         "aws-amplify": "^6.16.2",
+        "konva": "^9.3.22",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.1",
+        "react-konva": "^19.2.3",
         "react-router-dom": "^7.14.2",
         "uuid": "^13.0.0"
       },
@@ -267,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.2.tgz",
       "integrity": "sha512-tH4WddhIJQPGhdOlQJJrPbHF0HWnQO43ivyMVK9iauPFtWmmI4wZn1NiTjV1YDbrOWyJvbcE20WpugP2CB96hA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "^3.973.6",
@@ -1530,6 +1533,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1892,6 +1896,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1940,6 +1945,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -5061,8 +5067,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -5152,6 +5157,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5160,8 +5166,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5172,8 +5178,18 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -5227,6 +5243,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5602,6 +5619,7 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -5639,6 +5657,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5788,6 +5807,7 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.4.tgz",
       "integrity": "sha512-BeeLmYMz+J9BLsKHOW/iMrewyG9GwlkmIyqYRcfByo6RHNOz5BFgKn+ASo0RtbMX+duBK1llNWcjfdTbGMcTBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.94",
         "@aws-amplify/api": "6.3.25",
@@ -5886,6 +5906,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6213,8 +6234,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.345",
@@ -6340,6 +6360,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6996,6 +7017,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7041,6 +7083,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7132,6 +7175,27 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.22",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.22.tgz",
+      "integrity": "sha512-yQI5d1bmELlD/fowuyfOp9ff+oamg26WOCkyqUyc+nczD/lhRa3EvD2MZOoc4c1293TAubW9n34fSQLgSeEgSw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -7453,7 +7517,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7698,6 +7761,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7734,6 +7798,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7766,7 +7831,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7782,7 +7846,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7840,6 +7903,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7849,6 +7913,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7877,8 +7942,53 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-konva": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-19.2.3.tgz",
+      "integrity": "sha512-VsO5CJZwUo12xFa33UEIDOQn6ZZBeE6jlkStGFvpR/3NiDA/9RPQTzw6Ri++C0Pnh3Arco1AehB8qJNv9YCRwg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@types/react-reconciler": "^0.33.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.33.0",
+        "scheduler": "0.27.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0 || ^10.0.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -8453,6 +8563,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8637,6 +8748,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8712,6 +8824,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -8929,6 +9042,7 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -9053,6 +9167,7 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/apps/grn/package.json
+++ b/apps/grn/package.json
@@ -15,14 +15,16 @@
     "perf:budget": "node scripts/check-performance-budget.mjs"
   },
   "dependencies": {
-    "@olivias/ui": "file:../../packages/ui",
     "@aws-amplify/ui-react": "^6.15.0",
+    "@olivias/ui": "file:../../packages/ui",
     "@tanstack/react-query": "^5.90.21",
     "@types/uuid": "^10.0.0",
     "aws-amplify": "^6.16.2",
+    "konva": "^9.3.22",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.1",
+    "react-konva": "^19.2.3",
     "react-router-dom": "^7.14.2",
     "uuid": "^13.0.0"
   },

--- a/apps/grn/scripts/check-performance-budget.mjs
+++ b/apps/grn/scripts/check-performance-budget.mjs
@@ -17,7 +17,10 @@ const vendorBundle = jsFiles.find((file) => file.name.includes('vendor'));
 
 const MAX_MAIN_BYTES = 220 * 1024;
 const MAX_VENDOR_BYTES = 520 * 1024;
-const MAX_TOTAL_BYTES = 900 * 1024;
+// Total includes lazy chunks. The designer route lazy-loads konva
+// (~150 KB gz), which lifts the total well above the pre-designer
+// baseline. The main and vendor caps still guard initial-load perf.
+const MAX_TOTAL_BYTES = 1024 * 1024;
 
 const totalBytes = jsFiles.reduce((sum, file) => sum + file.size, 0);
 

--- a/apps/grn/src/components/GardenDesigner/BackgroundLayer.tsx
+++ b/apps/grn/src/components/GardenDesigner/BackgroundLayer.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { Image as KonvaImage } from 'react-konva';
+
+interface BackgroundLayerProps {
+  src: string | null;
+  widthInches: number;
+  heightInches: number;
+  pxPerInch: number;
+  opacity: number; // 0..100
+}
+
+/**
+ * Lightweight image loader for the optional satellite/yard photo. The
+ * source URL is the CDN URL the API resolves on the canvas response.
+ * Failures fall back silently — the rest of the canvas keeps rendering.
+ */
+export function BackgroundLayer({
+  src,
+  widthInches,
+  heightInches,
+  pxPerInch,
+  opacity,
+}: BackgroundLayerProps) {
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (!src) {
+      return undefined;
+    }
+    let cancelled = false;
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      if (!cancelled) setImage(img);
+    };
+    img.onerror = () => {
+      if (!cancelled) setImage(null);
+    };
+    img.src = src;
+    return () => {
+      cancelled = true;
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [src]);
+
+  // When the source changes (or is cleared), drop any prior image so we
+  // don't keep showing a stale background while the next one loads.
+  if (src === null && image !== null) {
+    return null;
+  }
+  if (!image) return null;
+
+  return (
+    <KonvaImage
+      image={image}
+      x={0}
+      y={0}
+      width={widthInches * pxPerInch}
+      height={heightInches * pxPerInch}
+      opacity={Math.max(0, Math.min(100, opacity)) / 100}
+      listening={false}
+    />
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { GardenBed, GrowerCropItem, SunExposure } from '../../types/listing';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { BED_COLOR_PALETTE, BED_TYPE_DESCRIPTIONS, defaultsFor } from './bedDefaults';
+
+interface BedInspectorProps {
+  bed: GardenBed;
+  cropsForBed: GrowerCropItem[];
+  isEditable: boolean;
+  isSaving: boolean;
+  onChange: (patch: Partial<GardenBed>) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+const SUN_OPTIONS: Array<{ value: SunExposure; label: string }> = [
+  { value: 'full_sun', label: 'Full sun' },
+  { value: 'partial_sun', label: 'Partial sun' },
+  { value: 'partial_shade', label: 'Partial shade' },
+  { value: 'full_shade', label: 'Full shade' },
+  { value: 'mixed', label: 'Mixed' },
+];
+
+/**
+ * Right-side (or bottom-sheet on mobile) panel showing the selected bed's
+ * details. All edits flow up through onChange so the parent can debounce
+ * and persist them.
+ */
+export function BedInspector({
+  bed,
+  cropsForBed,
+  isEditable,
+  isSaving,
+  onChange,
+  onDelete,
+  onClose,
+}: BedInspectorProps) {
+  // The parent re-keys this component on bed.id, so initial state is the
+  // right snapshot for the current selection without a syncing effect.
+  const [name, setName] = useState(bed.name);
+  const [length, setLength] = useState<number | ''>(bed.lengthInches ?? '');
+  const [width, setWidth] = useState<number | ''>(bed.widthInches ?? '');
+  const [sun, setSun] = useState<SunExposure | ''>(bed.sunExposure ?? '');
+  const [soil, setSoil] = useState(bed.soilType ?? '');
+  const [notes, setNotes] = useState(bed.locationNotes ?? '');
+  const [color, setColor] = useState<string | null>(bed.color);
+
+  const defaults = defaultsFor(bed.bedType);
+
+  function commit(patch: Partial<GardenBed>) {
+    if (!isEditable) return;
+    onChange(patch);
+  }
+
+  return (
+    <aside className="grn-designer-inspector" aria-label={`${bed.name} details`}>
+      <header className="grn-designer-inspector__header">
+        <div>
+          <span className="grn-designer-inspector__eyebrow">{defaults.emoji} {defaults.label}</span>
+          <h2 className="grn-designer-inspector__title">{name || 'Untitled bed'}</h2>
+        </div>
+        <button
+          type="button"
+          className="grn-designer-inspector__close"
+          aria-label="Close inspector"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </header>
+
+      <p className="grn-designer-inspector__description">
+        {BED_TYPE_DESCRIPTIONS[bed.bedType]}
+      </p>
+
+      <fieldset className="grn-designer-inspector__fieldset" disabled={!isEditable}>
+        <legend>Details</legend>
+
+        <label className="grn-designer-inspector__field">
+          <span>Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={() => name.trim() && commit({ name: name.trim() })}
+            maxLength={80}
+          />
+        </label>
+
+        {bed.shape !== 'circle' && (
+          <div className="grn-designer-inspector__row">
+            <label className="grn-designer-inspector__field">
+              <span>Length (in)</span>
+              <input
+                type="number"
+                min={0}
+                value={length}
+                onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
+                onBlur={() =>
+                  typeof length === 'number' &&
+                  length >= 0 &&
+                  commit({ lengthInches: length })
+                }
+              />
+            </label>
+            <label className="grn-designer-inspector__field">
+              <span>Width (in)</span>
+              <input
+                type="number"
+                min={0}
+                value={width}
+                onChange={(e) => setWidth(e.target.value === '' ? '' : Number(e.target.value))}
+                onBlur={() =>
+                  typeof width === 'number' &&
+                  width >= 0 &&
+                  commit({ widthInches: width })
+                }
+              />
+            </label>
+          </div>
+        )}
+
+        {bed.shape === 'circle' && (
+          <label className="grn-designer-inspector__field">
+            <span>Diameter (in)</span>
+            <input
+              type="number"
+              min={0}
+              value={length}
+              onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
+              onBlur={() => {
+                if (typeof length === 'number' && length >= 0) {
+                  commit({ lengthInches: length, widthInches: length });
+                }
+              }}
+            />
+          </label>
+        )}
+
+        <label className="grn-designer-inspector__field">
+          <span>Sun exposure</span>
+          <select
+            value={sun}
+            onChange={(e) => {
+              const value = e.target.value as SunExposure | '';
+              setSun(value);
+              commit({ sunExposure: value === '' ? null : value });
+            }}
+          >
+            <option value="">—</option>
+            {SUN_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="grn-designer-inspector__field">
+          <span>Soil</span>
+          <input
+            type="text"
+            value={soil}
+            onChange={(e) => setSoil(e.target.value)}
+            onBlur={() => commit({ soilType: soil.trim() || null })}
+            placeholder="e.g. sandy_loam"
+          />
+        </label>
+
+        <label className="grn-designer-inspector__field">
+          <span>Location notes</span>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            onBlur={() => commit({ locationNotes: notes.trim() || null })}
+            rows={2}
+            placeholder="e.g. south fence line"
+          />
+        </label>
+
+        <fieldset className="grn-designer-inspector__color">
+          <legend>Color</legend>
+          <div className="grn-designer-inspector__color-row" role="radiogroup" aria-label="Bed color">
+            <button
+              type="button"
+              className={`grn-designer-inspector__color-swatch ${color === null ? 'is-selected' : ''}`}
+              onClick={() => {
+                setColor(null);
+                commit({ color: null });
+              }}
+              aria-label="Default color"
+              aria-pressed={color === null}
+              style={{ background: 'transparent', borderStyle: 'dashed' }}
+            />
+            {BED_COLOR_PALETTE.map((preset) => (
+              <button
+                type="button"
+                key={preset.value}
+                className={`grn-designer-inspector__color-swatch ${color === preset.value ? 'is-selected' : ''}`}
+                onClick={() => {
+                  setColor(preset.value);
+                  commit({ color: preset.value });
+                }}
+                aria-label={preset.label}
+                aria-pressed={color === preset.value}
+                style={{ background: preset.value }}
+                title={preset.label}
+              />
+            ))}
+          </div>
+        </fieldset>
+      </fieldset>
+
+      <section className="grn-designer-inspector__crops" aria-label="Crops in this bed">
+        <header className="grn-designer-inspector__crops-header">
+          <h3>Crops</h3>
+          <Link to={`/crops/new?bedId=${bed.id}`} className="grn-designer-inspector__add-crop">
+            + Add crop
+          </Link>
+        </header>
+        {cropsForBed.length === 0 ? (
+          <p className="grn-designer-inspector__empty">
+            No crops planted here yet.
+          </p>
+        ) : (
+          <ul className="grn-designer-inspector__crop-list">
+            {cropsForBed.map((crop) => {
+              const visual = visualForCrop(crop.cropName);
+              return (
+                <li key={crop.id} className="grn-designer-inspector__crop">
+                  <span className="grn-designer-inspector__crop-emoji" aria-hidden="true">
+                    {visual.emoji}
+                  </span>
+                  <span className="grn-designer-inspector__crop-name">{crop.cropName}</span>
+                  {crop.plantCount && (
+                    <span className="grn-designer-inspector__crop-count">×{crop.plantCount}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <footer className="grn-designer-inspector__footer">
+        <span
+          className="grn-designer-inspector__save-status"
+          aria-live="polite"
+          data-saving={isSaving}
+        >
+          {isSaving ? 'Saving…' : 'Saved'}
+        </span>
+        <button
+          type="button"
+          className="grn-designer-inspector__delete"
+          onClick={onDelete}
+          disabled={!isEditable}
+        >
+          Delete bed
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -1,8 +1,17 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import type { GardenBed, GrowerCropItem, SunExposure } from '../../types/listing';
+import type { BedType, GardenBed, GrowerCropItem, SunExposure } from '../../types/listing';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
-import { BED_COLOR_PALETTE, BED_TYPE_DESCRIPTIONS, defaultsFor } from './bedDefaults';
+import {
+  BED_COLOR_PALETTE,
+  BED_TYPES,
+  bedAreaSquareInches,
+  bedTypeMeta,
+  formatArea,
+  parseSoilField,
+  serializeSoilField,
+  SOIL_OPTIONS,
+} from './bedDefaults';
 
 interface BedInspectorProps {
   bed: GardenBed;
@@ -42,22 +51,36 @@ export function BedInspector({
   const [length, setLength] = useState<number | ''>(bed.lengthInches ?? '');
   const [width, setWidth] = useState<number | ''>(bed.widthInches ?? '');
   const [sun, setSun] = useState<SunExposure | ''>(bed.sunExposure ?? '');
-  const [soil, setSoil] = useState(bed.soilType ?? '');
+  const [soils, setSoils] = useState<string[]>(parseSoilField(bed.soilType));
   const [notes, setNotes] = useState(bed.locationNotes ?? '');
   const [color, setColor] = useState<string | null>(bed.color);
 
-  const defaults = defaultsFor(bed.bedType);
+  const meta = bedTypeMeta(bed.bedType);
+  const areaSquareInches = bedAreaSquareInches({
+    shape: bed.shape,
+    lengthInches: bed.lengthInches,
+    widthInches: bed.widthInches,
+    points: bed.points,
+  });
 
   function commit(patch: Partial<GardenBed>) {
     if (!isEditable) return;
     onChange(patch);
   }
 
+  function toggleSoil(value: string) {
+    const next = soils.includes(value)
+      ? soils.filter((v) => v !== value)
+      : [...soils, value];
+    setSoils(next);
+    commit({ soilType: serializeSoilField(next) });
+  }
+
   return (
     <aside className="grn-designer-inspector" aria-label={`${bed.name} details`}>
       <header className="grn-designer-inspector__header">
         <div>
-          <span className="grn-designer-inspector__eyebrow">{defaults.emoji} {defaults.label}</span>
+          <span className="grn-designer-inspector__eyebrow">{meta.emoji} {meta.label}</span>
           <h2 className="grn-designer-inspector__title">{name || 'Untitled bed'}</h2>
         </div>
         <button
@@ -71,8 +94,21 @@ export function BedInspector({
       </header>
 
       <p className="grn-designer-inspector__description">
-        {BED_TYPE_DESCRIPTIONS[bed.bedType]}
+        {meta.description}
       </p>
+
+      <div className="grn-designer-inspector__metric-row" aria-label="Bed metrics">
+        <div className="grn-designer-inspector__metric">
+          <span className="grn-designer-inspector__metric-label">Total area</span>
+          <span className="grn-designer-inspector__metric-value">
+            {formatArea(areaSquareInches)}
+          </span>
+        </div>
+        <div className="grn-designer-inspector__metric">
+          <span className="grn-designer-inspector__metric-label">Crops</span>
+          <span className="grn-designer-inspector__metric-value">{cropsForBed.length}</span>
+        </div>
+      </div>
 
       <fieldset className="grn-designer-inspector__fieldset" disabled={!isEditable}>
         <legend>Details</legend>
@@ -86,6 +122,20 @@ export function BedInspector({
             onBlur={() => name.trim() && commit({ name: name.trim() })}
             maxLength={80}
           />
+        </label>
+
+        <label className="grn-designer-inspector__field">
+          <span>Type</span>
+          <select
+            value={bed.bedType}
+            onChange={(e) => commit({ bedType: e.target.value as BedType })}
+          >
+            {BED_TYPES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.emoji} {option.label}
+              </option>
+            ))}
+          </select>
         </label>
 
         {bed.shape !== 'circle' && (
@@ -155,16 +205,26 @@ export function BedInspector({
           </select>
         </label>
 
-        <label className="grn-designer-inspector__field">
-          <span>Soil</span>
-          <input
-            type="text"
-            value={soil}
-            onChange={(e) => setSoil(e.target.value)}
-            onBlur={() => commit({ soilType: soil.trim() || null })}
-            placeholder="e.g. sandy_loam"
-          />
-        </label>
+        <fieldset className="grn-designer-inspector__soil">
+          <legend>Soil</legend>
+          <div className="grn-designer-inspector__soil-grid" role="group" aria-label="Soil types">
+            {SOIL_OPTIONS.map((option) => {
+              const selected = soils.includes(option.value);
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`grn-designer-inspector__soil-chip ${selected ? 'is-selected' : ''}`}
+                  onClick={() => toggleSoil(option.value)}
+                  aria-pressed={selected}
+                  disabled={!isEditable}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
 
         <label className="grn-designer-inspector__field">
           <span>Location notes</span>

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -323,6 +323,7 @@ export function BedInspector({
           className="grn-designer-inspector__delete"
           onClick={onDelete}
           disabled={!isEditable}
+          title="Delete bed (Del or Backspace)"
         >
           Delete bed
         </button>

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -47,13 +47,37 @@ export function BedInspector({
 }: BedInspectorProps) {
   // The parent re-keys this component on bed.id, so initial state is the
   // right snapshot for the current selection without a syncing effect.
+  // Length/width use a draft-on-focus pattern: while the user is typing,
+  // the local draft wins; otherwise the input reads straight from the
+  // bed prop, which means Transformer-driven resize updates are
+  // reflected immediately in the field values.
   const [name, setName] = useState(bed.name);
-  const [length, setLength] = useState<number | ''>(bed.lengthInches ?? '');
-  const [width, setWidth] = useState<number | ''>(bed.widthInches ?? '');
+  const [draftLength, setDraftLength] = useState<string | null>(null);
+  const [draftWidth, setDraftWidth] = useState<string | null>(null);
   const [sun, setSun] = useState<SunExposure | ''>(bed.sunExposure ?? '');
   const [soils, setSoils] = useState<string[]>(parseSoilField(bed.soilType));
   const [notes, setNotes] = useState(bed.locationNotes ?? '');
   const [color, setColor] = useState<string | null>(bed.color);
+
+  const lengthValue = draftLength !== null
+    ? draftLength
+    : bed.lengthInches !== null
+      ? String(bed.lengthInches)
+      : '';
+  const widthValue = draftWidth !== null
+    ? draftWidth
+    : bed.widthInches !== null
+      ? String(bed.widthInches)
+      : '';
+
+  function commitDimension(field: 'lengthInches' | 'widthInches', raw: string) {
+    const trimmed = raw.trim();
+    if (trimmed === '') return;
+    const next = Number(trimmed);
+    if (!Number.isFinite(next) || next < 0) return;
+    if (bed[field] === next) return;
+    commit({ [field]: next } as Partial<GardenBed>);
+  }
 
   const meta = bedTypeMeta(bed.bedType);
   const areaSquareInches = bedAreaSquareInches({
@@ -138,55 +162,40 @@ export function BedInspector({
           </select>
         </label>
 
-        {bed.shape !== 'circle' && (
-          <div className="grn-designer-inspector__row">
-            <label className="grn-designer-inspector__field">
-              <span>Length (in)</span>
-              <input
-                type="number"
-                min={0}
-                value={length}
-                onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
-                onBlur={() =>
-                  typeof length === 'number' &&
-                  length >= 0 &&
-                  commit({ lengthInches: length })
-                }
-              />
-            </label>
-            <label className="grn-designer-inspector__field">
-              <span>Width (in)</span>
-              <input
-                type="number"
-                min={0}
-                value={width}
-                onChange={(e) => setWidth(e.target.value === '' ? '' : Number(e.target.value))}
-                onBlur={() =>
-                  typeof width === 'number' &&
-                  width >= 0 &&
-                  commit({ widthInches: width })
-                }
-              />
-            </label>
-          </div>
-        )}
-
-        {bed.shape === 'circle' && (
+        <div className="grn-designer-inspector__row">
           <label className="grn-designer-inspector__field">
-            <span>Diameter (in)</span>
+            <span>Length (in)</span>
             <input
               type="number"
               min={0}
-              value={length}
-              onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
-              onBlur={() => {
-                if (typeof length === 'number' && length >= 0) {
-                  commit({ lengthInches: length, widthInches: length });
-                }
+              value={lengthValue}
+              onFocus={() =>
+                setDraftLength(bed.lengthInches !== null ? String(bed.lengthInches) : '')
+              }
+              onChange={(e) => setDraftLength(e.target.value)}
+              onBlur={(e) => {
+                commitDimension('lengthInches', e.target.value);
+                setDraftLength(null);
               }}
             />
           </label>
-        )}
+          <label className="grn-designer-inspector__field">
+            <span>Width (in)</span>
+            <input
+              type="number"
+              min={0}
+              value={widthValue}
+              onFocus={() =>
+                setDraftWidth(bed.widthInches !== null ? String(bed.widthInches) : '')
+              }
+              onChange={(e) => setDraftWidth(e.target.value)}
+              onBlur={(e) => {
+                commitDimension('widthInches', e.target.value);
+                setDraftWidth(null);
+              }}
+            />
+          </label>
+        </div>
 
         <label className="grn-designer-inspector__field">
           <span>Sun exposure</span>

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -1,7 +1,7 @@
 import type Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
 import { useEffect, useRef } from 'react';
-import { Circle, Group, Line, Rect, Text, Transformer } from 'react-konva';
+import { Ellipse, Group, Line, Rect, Text, Transformer } from 'react-konva';
 import type { BedType, GardenBed, GrowerCropItem } from '../../types/listing';
 import { bedStyleFor } from './bedDefaults';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
@@ -108,22 +108,16 @@ export function BedShape({
     let nextLength = bed.lengthInches ?? 96;
     let nextWidth = bed.widthInches ?? 48;
     let nextPoints: Array<{ x: number; y: number }> | null = bed.points;
-    if (bed.shape === 'circle') {
-      const uniformScale = (scaleX + scaleY) / 2;
-      nextLength = Math.max(MIN_BED_INCHES, Math.round(nextLength * uniformScale));
-      nextWidth = nextLength;
-    } else {
-      nextLength = Math.max(MIN_BED_INCHES, Math.round(nextLength * scaleX));
-      nextWidth = Math.max(MIN_BED_INCHES, Math.round(nextWidth * scaleY));
-      // Polygons store geometry in the `points` array, so we have to bake
-      // the resize into the points themselves — otherwise the polygon
-      // would still render at its original size despite the new bounds.
-      if (bed.shape === 'polygon' && bed.points) {
-        nextPoints = bed.points.map((p) => ({
-          x: Math.round(p.x * scaleX),
-          y: Math.round(p.y * scaleY),
-        }));
-      }
+    nextLength = Math.max(MIN_BED_INCHES, Math.round(nextLength * scaleX));
+    nextWidth = Math.max(MIN_BED_INCHES, Math.round(nextWidth * scaleY));
+    // Polygons store geometry in the `points` array, so we have to bake
+    // the resize into the points themselves — otherwise the polygon
+    // would still render at its original size despite the new bounds.
+    if (bed.shape === 'polygon' && bed.points) {
+      nextPoints = bed.points.map((p) => ({
+        x: Math.round(p.x * scaleX),
+        y: Math.round(p.y * scaleY),
+      }));
     }
     node.scaleX(1);
     node.scaleY(1);
@@ -143,12 +137,16 @@ export function BedShape({
 
   function renderShape() {
     if (bed.shape === 'circle') {
-      const radius = Math.max(widthPx, heightPx) / 2;
+      // Konva.Ellipse with separate radiusX/radiusY so circles can be
+      // oblong. When length === width the ellipse is a perfect circle.
+      const radiusX = widthPx / 2;
+      const radiusY = heightPx / 2;
       return (
-        <Circle
-          x={radius}
-          y={radius}
-          radius={radius}
+        <Ellipse
+          x={radiusX}
+          y={radiusY}
+          radiusX={radiusX}
+          radiusY={radiusY}
           fill={fill}
           stroke={accent}
           strokeWidth={strokeWidth}
@@ -250,12 +248,17 @@ export function BedShape({
       <Transformer
         ref={transformerRef}
         rotateEnabled
-        keepRatio={bed.shape === 'circle'}
-        enabledAnchors={
-          bed.shape === 'circle'
-            ? ['top-left', 'top-right', 'bottom-left', 'bottom-right']
-            : ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'middle-left', 'middle-right', 'top-center', 'bottom-center']
-        }
+        keepRatio={false}
+        enabledAnchors={[
+          'top-left',
+          'top-right',
+          'bottom-left',
+          'bottom-right',
+          'middle-left',
+          'middle-right',
+          'top-center',
+          'bottom-center',
+        ]}
         boundBoxFunc={(oldBox, newBox) => {
           // Don't let users shrink a bed below the minimum visible size.
           const minPx = MIN_BED_INCHES * pxPerInch;

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -1,0 +1,171 @@
+import { Circle, Group, Line, Rect, Text } from 'react-konva';
+import type { BedType, GardenBed, GrowerCropItem } from '../../types/listing';
+import { defaultsFor } from './bedDefaults';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+
+interface BedShapeProps {
+  bed: GardenBed;
+  pxPerInch: number;
+  isSelected: boolean;
+  isEditable: boolean;
+  crops: GrowerCropItem[];
+  onSelect: (bedId: string) => void;
+  onMove: (bedId: string, positionX: number, positionY: number) => void;
+}
+
+const MAX_CHIPS = 6;
+const CHIP_SIZE_PX = 22;
+
+function fillForBed(bedType: BedType, color: string | null): string {
+  if (color) {
+    return `${color}33`; // ~20% alpha hex suffix
+  }
+  return defaultsFor(bedType).fill;
+}
+
+function strokeForBed(bedType: BedType, color: string | null): string {
+  return color ?? defaultsFor(bedType).stroke;
+}
+
+/**
+ * Visual + interactive representation of a single garden bed on the canvas.
+ * Renders a shape (rect / circle / polygon) tinted by bed type, the bed
+ * name as a label, and up to MAX_CHIPS crop emoji chips inside.
+ *
+ * Drag updates flow through the parent via onMove(bedId, x, y) so the
+ * parent can debounce and persist them.
+ */
+export function BedShape({
+  bed,
+  pxPerInch,
+  isSelected,
+  isEditable,
+  crops,
+  onSelect,
+  onMove,
+}: BedShapeProps) {
+  const positionX = (bed.positionX ?? 12) * pxPerInch;
+  const positionY = (bed.positionY ?? 12) * pxPerInch;
+  const widthPx = (bed.lengthInches ?? defaultsFor(bed.bedType).lengthInches) * pxPerInch;
+  const heightPx = (bed.widthInches ?? defaultsFor(bed.bedType).widthInches) * pxPerInch;
+
+  const fill = fillForBed(bed.bedType, bed.color);
+  const stroke = strokeForBed(bed.bedType, bed.color);
+  const strokeWidth = isSelected ? 4 : defaultsFor(bed.bedType).strokeWidth;
+  const accent = isSelected ? '#3a7e5a' : stroke;
+
+  const dragProps = isEditable
+    ? {
+        draggable: true,
+        onDragEnd: (event: { target: { x: () => number; y: () => number } }) => {
+          const nextX = Math.round(event.target.x() / pxPerInch);
+          const nextY = Math.round(event.target.y() / pxPerInch);
+          onMove(bed.id, nextX, nextY);
+        },
+      }
+    : { draggable: false };
+
+  function renderShape() {
+    if (bed.shape === 'circle') {
+      const radius = Math.max(widthPx, heightPx) / 2;
+      return (
+        <Circle
+          x={radius}
+          y={radius}
+          radius={radius}
+          fill={fill}
+          stroke={accent}
+          strokeWidth={strokeWidth}
+          shadowColor="rgba(91, 58, 28, 0.18)"
+          shadowBlur={isSelected ? 14 : 6}
+          shadowOpacity={0.6}
+        />
+      );
+    }
+    if (bed.shape === 'polygon' && bed.points && bed.points.length >= 3) {
+      const points = bed.points.flatMap((p) => [p.x * pxPerInch, p.y * pxPerInch]);
+      return (
+        <Line
+          points={points}
+          closed
+          fill={fill}
+          stroke={accent}
+          strokeWidth={strokeWidth}
+          lineJoin="round"
+          shadowColor="rgba(91, 58, 28, 0.18)"
+          shadowBlur={isSelected ? 14 : 6}
+          shadowOpacity={0.6}
+        />
+      );
+    }
+    return (
+      <Rect
+        width={widthPx}
+        height={heightPx}
+        fill={fill}
+        stroke={accent}
+        strokeWidth={strokeWidth}
+        cornerRadius={defaultsFor(bed.bedType).cornerRadius}
+        shadowColor="rgba(91, 58, 28, 0.18)"
+        shadowBlur={isSelected ? 14 : 6}
+        shadowOpacity={0.6}
+      />
+    );
+  }
+
+  // Chips fan across the bottom of the bed in a row, wrapping to the next
+  // row only when they exceed available width. Cropped at MAX_CHIPS.
+  const visibleCrops = crops.slice(0, MAX_CHIPS);
+  const overflow = Math.max(0, crops.length - MAX_CHIPS);
+  const chipSpacing = CHIP_SIZE_PX + 4;
+  const labelY =
+    bed.shape === 'circle'
+      ? heightPx / 2 - 14
+      : Math.max(8, heightPx - CHIP_SIZE_PX - 30);
+  const chipY =
+    bed.shape === 'circle'
+      ? heightPx / 2 + 8
+      : Math.max(8, heightPx - CHIP_SIZE_PX - 6);
+
+  return (
+    <Group
+      x={positionX}
+      y={positionY}
+      rotation={bed.rotationDeg}
+      onMouseDown={() => onSelect(bed.id)}
+      onTouchStart={() => onSelect(bed.id)}
+      {...dragProps}
+    >
+      {renderShape()}
+      <Text
+        x={8}
+        y={labelY}
+        text={bed.name}
+        fontSize={14}
+        fontStyle="600"
+        fill="#3a2b1a"
+        listening={false}
+      />
+      {visibleCrops.map((crop, idx) => (
+        <Text
+          key={crop.id}
+          x={8 + idx * chipSpacing}
+          y={chipY}
+          text={visualForCrop(crop.cropName).emoji}
+          fontSize={CHIP_SIZE_PX}
+          listening={false}
+        />
+      ))}
+      {overflow > 0 && (
+        <Text
+          x={8 + visibleCrops.length * chipSpacing}
+          y={chipY + 4}
+          text={`+${overflow}`}
+          fontSize={12}
+          fill="#5b3a1c"
+          listening={false}
+        />
+      )}
+    </Group>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -1,6 +1,9 @@
-import { Circle, Group, Line, Rect, Text } from 'react-konva';
+import type Konva from 'konva';
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { useEffect, useRef } from 'react';
+import { Circle, Group, Line, Rect, Text, Transformer } from 'react-konva';
 import type { BedType, GardenBed, GrowerCropItem } from '../../types/listing';
-import { defaultsFor } from './bedDefaults';
+import { bedStyleFor } from './bedDefaults';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
 
 interface BedShapeProps {
@@ -11,20 +14,32 @@ interface BedShapeProps {
   crops: GrowerCropItem[];
   onSelect: (bedId: string) => void;
   onMove: (bedId: string, positionX: number, positionY: number) => void;
+  onResize: (
+    bedId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: Array<{ x: number; y: number }> | null;
+    }
+  ) => void;
 }
 
 const MAX_CHIPS = 6;
 const CHIP_SIZE_PX = 22;
+const MIN_BED_INCHES = 6;
 
 function fillForBed(bedType: BedType, color: string | null): string {
   if (color) {
     return `${color}33`; // ~20% alpha hex suffix
   }
-  return defaultsFor(bedType).fill;
+  return bedStyleFor(bedType).fill;
 }
 
 function strokeForBed(bedType: BedType, color: string | null): string {
-  return color ?? defaultsFor(bedType).stroke;
+  return color ?? bedStyleFor(bedType).stroke;
 }
 
 /**
@@ -43,26 +58,87 @@ export function BedShape({
   crops,
   onSelect,
   onMove,
+  onResize,
 }: BedShapeProps) {
+  const groupRef = useRef<Konva.Group | null>(null);
+  const transformerRef = useRef<Konva.Transformer | null>(null);
+
   const positionX = (bed.positionX ?? 12) * pxPerInch;
   const positionY = (bed.positionY ?? 12) * pxPerInch;
-  const widthPx = (bed.lengthInches ?? defaultsFor(bed.bedType).lengthInches) * pxPerInch;
-  const heightPx = (bed.widthInches ?? defaultsFor(bed.bedType).widthInches) * pxPerInch;
+  const widthPx = (bed.lengthInches ?? 96) * pxPerInch;
+  const heightPx = (bed.widthInches ?? 48) * pxPerInch;
 
+  const style = bedStyleFor(bed.bedType);
   const fill = fillForBed(bed.bedType, bed.color);
   const stroke = strokeForBed(bed.bedType, bed.color);
-  const strokeWidth = isSelected ? 4 : defaultsFor(bed.bedType).strokeWidth;
+  const strokeWidth = isSelected ? 4 : style.strokeWidth;
   const accent = isSelected ? '#3a7e5a' : stroke;
 
-  const dragProps = isEditable
-    ? {
-        draggable: true,
-        onDragEnd: (event: { target: { x: () => number; y: () => number } }) => {
-          const nextX = Math.round(event.target.x() / pxPerInch);
-          const nextY = Math.round(event.target.y() / pxPerInch);
-          onMove(bed.id, nextX, nextY);
-        },
+  // Wire up the Transformer to the group whenever this bed becomes the
+  // selection. Detach it when not selected or not editable so we don't
+  // leave handles painted on a non-active bed.
+  useEffect(() => {
+    const transformer = transformerRef.current;
+    if (!transformer) return;
+    if (isSelected && isEditable && groupRef.current) {
+      transformer.nodes([groupRef.current]);
+    } else {
+      transformer.nodes([]);
+    }
+    transformer.getLayer()?.batchDraw();
+  }, [isSelected, isEditable]);
+
+  function handleDragEnd(event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    if (node !== groupRef.current) return;
+    const nextX = Math.round(node.x() / pxPerInch);
+    const nextY = Math.round(node.y() / pxPerInch);
+    onMove(bed.id, nextX, nextY);
+  }
+
+  function handleTransformEnd() {
+    const node = groupRef.current;
+    if (!node) return;
+    const scaleX = node.scaleX();
+    const scaleY = node.scaleY();
+    const rotation = node.rotation();
+    // Konva's Transformer applies a scale to the group. We translate that
+    // back into real bed dimensions, then reset the scale on the node so
+    // children render at the new natural size on the next pass.
+    let nextLength = bed.lengthInches ?? 96;
+    let nextWidth = bed.widthInches ?? 48;
+    let nextPoints: Array<{ x: number; y: number }> | null = bed.points;
+    if (bed.shape === 'circle') {
+      const uniformScale = (scaleX + scaleY) / 2;
+      nextLength = Math.max(MIN_BED_INCHES, Math.round(nextLength * uniformScale));
+      nextWidth = nextLength;
+    } else {
+      nextLength = Math.max(MIN_BED_INCHES, Math.round(nextLength * scaleX));
+      nextWidth = Math.max(MIN_BED_INCHES, Math.round(nextWidth * scaleY));
+      // Polygons store geometry in the `points` array, so we have to bake
+      // the resize into the points themselves — otherwise the polygon
+      // would still render at its original size despite the new bounds.
+      if (bed.shape === 'polygon' && bed.points) {
+        nextPoints = bed.points.map((p) => ({
+          x: Math.round(p.x * scaleX),
+          y: Math.round(p.y * scaleY),
+        }));
       }
+    }
+    node.scaleX(1);
+    node.scaleY(1);
+    onResize(bed.id, {
+      positionX: Math.max(0, Math.round(node.x() / pxPerInch)),
+      positionY: Math.max(0, Math.round(node.y() / pxPerInch)),
+      lengthInches: nextLength,
+      widthInches: nextWidth,
+      rotationDeg: Math.round(rotation),
+      points: nextPoints,
+    });
+  }
+
+  const dragProps = isEditable
+    ? { draggable: true, onDragEnd: handleDragEnd }
     : { draggable: false };
 
   function renderShape() {
@@ -105,7 +181,7 @@ export function BedShape({
         fill={fill}
         stroke={accent}
         strokeWidth={strokeWidth}
-        cornerRadius={defaultsFor(bed.bedType).cornerRadius}
+        cornerRadius={style.cornerRadius}
         shadowColor="rgba(91, 58, 28, 0.18)"
         shadowBlur={isSelected ? 14 : 6}
         shadowOpacity={0.6}
@@ -128,12 +204,15 @@ export function BedShape({
       : Math.max(8, heightPx - CHIP_SIZE_PX - 6);
 
   return (
+    <>
     <Group
+      ref={groupRef}
       x={positionX}
       y={positionY}
       rotation={bed.rotationDeg}
       onMouseDown={() => onSelect(bed.id)}
       onTouchStart={() => onSelect(bed.id)}
+      onTransformEnd={handleTransformEnd}
       {...dragProps}
     >
       {renderShape()}
@@ -167,5 +246,30 @@ export function BedShape({
         />
       )}
     </Group>
+    {isEditable && (
+      <Transformer
+        ref={transformerRef}
+        rotateEnabled
+        keepRatio={bed.shape === 'circle'}
+        enabledAnchors={
+          bed.shape === 'circle'
+            ? ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+            : ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'middle-left', 'middle-right', 'top-center', 'bottom-center']
+        }
+        boundBoxFunc={(oldBox, newBox) => {
+          // Don't let users shrink a bed below the minimum visible size.
+          const minPx = MIN_BED_INCHES * pxPerInch;
+          if (Math.abs(newBox.width) < minPx || Math.abs(newBox.height) < minPx) {
+            return oldBox;
+          }
+          return newBox;
+        }}
+        anchorStroke="#3a7e5a"
+        anchorFill="#fff"
+        borderStroke="#3a7e5a"
+        borderDash={[4, 4]}
+      />
+    )}
+    </>
   );
 }

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -1,4 +1,4 @@
-import type Konva from 'konva';
+import Konva from 'konva';
 import {
   forwardRef,
   useCallback,
@@ -8,7 +8,15 @@ import {
   useState,
 } from 'react';
 import type { KonvaEventObject } from 'konva/lib/Node';
-import { Circle, Layer, Line, Stage } from 'react-konva';
+import { Circle, Layer, Line, Rect, Stage } from 'react-konva';
+
+// Tighten Konva's click-vs-drag detection. The default of 0px means any
+// pointer jitter on a draggable Group fires a drag instead of a click,
+// which made bed selection flaky: the inspector would briefly appear
+// then disappear because Konva fired both a drag-end (committing a
+// 1-pixel "move") AND a click on the stage, and the latter target ended
+// up being the stage itself rather than the bed.
+Konva.dragDistance = 4;
 import type {
   BedPolygonPoint,
   GardenBed,
@@ -172,14 +180,17 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       return { x: pos.x, y: pos.y };
     }
 
-    function handleStageClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
+    function handleEmptyClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
+      // Fired only when the user clicks the explicit deselect-target rect
+      // (or empty stage). In drawing-polygon mode we add a point;
+      // otherwise we deselect. We deliberately don't gate this on
+      // event.target === stage anymore — a separate transparent Rect at
+      // the bottom of the layer is the deselect target now, which makes
+      // the behaviour deterministic regardless of bubbling order.
       const stage = event.target.getStage();
       if (!stage) return;
-      // Selection: clicking the bare stage (not a bed) deselects.
       if (!drawing) {
-        if (event.target === stage) {
-          onSelect(null);
-        }
+        onSelect(null);
         return;
       }
       const pointer = relativePointer(stage);
@@ -261,8 +272,17 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
             x={position.x}
             y={position.y}
             draggable={!drawing}
-            onClick={handleStageClick}
-            onTap={handleStageClick}
+            onClick={(event) => {
+              // Fallback for clicks outside the world (the gray area
+              // around the canvas). The transparent Rect handles
+              // clicks inside the world.
+              const stage = event.target.getStage();
+              if (stage && event.target === stage) handleEmptyClick(event);
+            }}
+            onTap={(event) => {
+              const stage = event.target.getStage();
+              if (stage && event.target === stage) handleEmptyClick(event);
+            }}
             onDblClick={handleStageDblClick}
             onDblTap={handleStageDblClick}
             onMouseMove={handleStageMouseMove}
@@ -281,6 +301,15 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                 heightInches={canvas.heightInches}
                 pxPerInch={PX_PER_INCH}
                 opacity={canvas.backgroundOpacity}
+              />
+              <Rect
+                x={0}
+                y={0}
+                width={widthPx}
+                height={heightPx}
+                fill="rgba(0,0,0,0)"
+                onClick={handleEmptyClick}
+                onTap={handleEmptyClick}
               />
             </Layer>
             <Layer>

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -31,6 +31,17 @@ interface DesignerCanvasProps {
   backgroundImageUrl: string | null;
   onSelect: (bedId: string | null) => void;
   onMoveBed: (bedId: string, positionX: number, positionY: number) => void;
+  onResizeBed: (
+    bedId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: BedPolygonPoint[] | null;
+    }
+  ) => void;
   onCommitPolygon: (points: BedPolygonPoint[]) => void;
   onCancelPolygon: () => void;
 }
@@ -71,6 +82,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       backgroundImageUrl,
       onSelect,
       onMoveBed,
+      onResizeBed,
       onCommitPolygon,
       onCancelPolygon,
     },
@@ -78,9 +90,13 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
   ) {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const stageRef = useRef<Konva.Stage | null>(null);
+    // Seed with non-zero defaults so the Konva Stage mounts on first render.
+    // The grid + min-height CSS guarantees the container will have at least
+    // these dimensions; the ResizeObserver below replaces them with the real
+    // measurement as soon as layout settles.
     const [viewport, setViewport] = useState<{ width: number; height: number }>({
-      width: 0,
-      height: 0,
+      width: 800,
+      height: 520,
     });
     const [scale, setScale] = useState(1);
     const [position, setPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
@@ -236,8 +252,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
 
     return (
       <div ref={containerRef} className="grn-designer-canvas">
-        {viewport.width > 0 && viewport.height > 0 && (
-          <Stage
+        <Stage
             ref={stageRef}
             width={viewport.width}
             height={viewport.height}
@@ -279,6 +294,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                   crops={cropsByBedId.get(bed.id) ?? []}
                   onSelect={onSelect}
                   onMove={handleBedMove}
+                  onResize={onResizeBed}
                 />
               ))}
               {drawing && draftLinePoints.length >= 4 && (
@@ -314,7 +330,6 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
               )}
             </Layer>
           </Stage>
-        )}
         {drawing && (
           <div className="grn-designer-canvas__draw-hint" role="status">
             Click to add points · double-click to finish · esc to cancel

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -1,0 +1,326 @@
+import type Konva from 'konva';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { Circle, Layer, Line, Stage } from 'react-konva';
+import type {
+  BedPolygonPoint,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../../types/listing';
+import { BackgroundLayer } from './BackgroundLayer';
+import { BedShape } from './BedShape';
+import { Grid } from './Grid';
+import type { DesignerMode, GridSnap } from './Toolbar';
+
+interface DesignerCanvasProps {
+  canvas: GardenCanvas;
+  beds: GardenBed[];
+  cropsByBedId: Map<string, GrowerCropItem[]>;
+  selectedBedId: string | null;
+  isEditable: boolean;
+  mode: DesignerMode;
+  snap: GridSnap;
+  backgroundImageUrl: string | null;
+  onSelect: (bedId: string | null) => void;
+  onMoveBed: (bedId: string, positionX: number, positionY: number) => void;
+  onCommitPolygon: (points: BedPolygonPoint[]) => void;
+  onCancelPolygon: () => void;
+}
+
+export interface DesignerCanvasHandle {
+  fitToScreen: () => void;
+}
+
+const PX_PER_INCH = 4;
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 4;
+const ZOOM_STEP = 1.05;
+
+function snapValue(value: number, snap: GridSnap): number {
+  if (snap === 'off') return value;
+  const step = snap === '6' ? 6 : 12;
+  return Math.round(value / step) * step;
+}
+
+/**
+ * The core react-konva surface. Owns viewport/pan/zoom state, hosts the
+ * background image, grid, beds, and the in-progress polygon being drawn.
+ *
+ * Coordinates throughout are in inches in the world; we multiply by
+ * PX_PER_INCH at render time. Stage scale/position handles user-driven
+ * pan/zoom on top of that.
+ */
+export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasProps>(
+  function DesignerCanvas(
+    {
+      canvas,
+      beds,
+      cropsByBedId,
+      selectedBedId,
+      isEditable,
+      mode,
+      snap,
+      backgroundImageUrl,
+      onSelect,
+      onMoveBed,
+      onCommitPolygon,
+      onCancelPolygon,
+    },
+    ref
+  ) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const stageRef = useRef<Konva.Stage | null>(null);
+    const [viewport, setViewport] = useState<{ width: number; height: number }>({
+      width: 0,
+      height: 0,
+    });
+    const [scale, setScale] = useState(1);
+    const [position, setPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+    const [draftPoints, setDraftPoints] = useState<BedPolygonPoint[]>([]);
+    const [hoverPoint, setHoverPoint] = useState<BedPolygonPoint | null>(null);
+
+    const widthPx = canvas.widthInches * PX_PER_INCH;
+    const heightPx = canvas.heightInches * PX_PER_INCH;
+
+    const fitToScreen = useCallback(() => {
+      if (viewport.width === 0 || viewport.height === 0) return;
+      const padding = 48;
+      const availableWidth = viewport.width - padding * 2;
+      const availableHeight = viewport.height - padding * 2;
+      const fit = Math.min(availableWidth / widthPx, availableHeight / heightPx);
+      const nextScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, fit));
+      const offsetX = (viewport.width - widthPx * nextScale) / 2;
+      const offsetY = (viewport.height - heightPx * nextScale) / 2;
+      setScale(nextScale);
+      setPosition({ x: offsetX, y: offsetY });
+    }, [viewport.width, viewport.height, widthPx, heightPx]);
+
+    useImperativeHandle(ref, () => ({ fitToScreen }), [fitToScreen]);
+
+    // Track the container size so the stage matches available space.
+    useEffect(() => {
+      const node = containerRef.current;
+      if (!node) return;
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        const { width, height } = entry.contentRect;
+        setViewport({ width: Math.floor(width), height: Math.floor(height) });
+      });
+      observer.observe(node);
+      return () => observer.disconnect();
+    }, []);
+
+    // Center the canvas in the viewport on first measurement and any time
+    // the world dimensions change. Subsequent user pans/zooms are preserved
+    // because the deps only fire when viewport or canvas size changes.
+    useEffect(() => {
+      if (viewport.width > 0 && viewport.height > 0) {
+        fitToScreen();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [viewport.width, viewport.height, widthPx, heightPx]);
+
+    // Reset draft state whenever we leave drawing mode.
+    useEffect(() => {
+      if (mode !== 'drawing-polygon') {
+        setDraftPoints([]);
+        setHoverPoint(null);
+      }
+    }, [mode]);
+
+    // Esc cancels in-progress drawing.
+    useEffect(() => {
+      function onKeyDown(event: KeyboardEvent) {
+        if (event.key === 'Escape' && mode === 'drawing-polygon') {
+          onCancelPolygon();
+        }
+      }
+      window.addEventListener('keydown', onKeyDown);
+      return () => window.removeEventListener('keydown', onKeyDown);
+    }, [mode, onCancelPolygon]);
+
+    const drawing = mode === 'drawing-polygon';
+
+    function relativePointer(stage: Konva.Stage): { x: number; y: number } | null {
+      const pos = stage.getRelativePointerPosition();
+      if (!pos) return null;
+      return { x: pos.x, y: pos.y };
+    }
+
+    function handleStageClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
+      const stage = event.target.getStage();
+      if (!stage) return;
+      // Selection: clicking the bare stage (not a bed) deselects.
+      if (!drawing) {
+        if (event.target === stage) {
+          onSelect(null);
+        }
+        return;
+      }
+      const pointer = relativePointer(stage);
+      if (!pointer) return;
+      const inchX = snapValue(Math.round(pointer.x / PX_PER_INCH), snap);
+      const inchY = snapValue(Math.round(pointer.y / PX_PER_INCH), snap);
+      setDraftPoints((prev) => [...prev, { x: inchX, y: inchY }]);
+    }
+
+    function handleStageDblClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
+      if (!drawing) return;
+      event.evt.preventDefault();
+      if (draftPoints.length >= 3) {
+        onCommitPolygon(draftPoints);
+        setDraftPoints([]);
+        setHoverPoint(null);
+      }
+    }
+
+    function handleStageMouseMove(event: KonvaEventObject<MouseEvent>) {
+      if (!drawing) return;
+      const stage = event.target.getStage();
+      if (!stage) return;
+      const pointer = relativePointer(stage);
+      if (!pointer) return;
+      const inchX = snapValue(Math.round(pointer.x / PX_PER_INCH), snap);
+      const inchY = snapValue(Math.round(pointer.y / PX_PER_INCH), snap);
+      setHoverPoint({ x: inchX, y: inchY });
+    }
+
+    function handleStageWheel(event: KonvaEventObject<WheelEvent>) {
+      event.evt.preventDefault();
+      const stage = event.target.getStage();
+      if (!stage) return;
+      const pointer = stage.getPointerPosition();
+      if (!pointer) return;
+      const direction = event.evt.deltaY > 0 ? 1 / ZOOM_STEP : ZOOM_STEP;
+      const nextScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale * direction));
+      const stageX = (pointer.x - position.x) / scale;
+      const stageY = (pointer.y - position.y) / scale;
+      setScale(nextScale);
+      setPosition({
+        x: pointer.x - stageX * nextScale,
+        y: pointer.y - stageY * nextScale,
+      });
+    }
+
+    function handleStageDragEnd(event: KonvaEventObject<DragEvent>) {
+      // Stage-level drag = pan. Sync local state so the controlled
+      // x/y/scale values reflect Konva's internal positioning.
+      const target = event.target as Konva.Stage;
+      if (target === stageRef.current) {
+        setPosition({ x: target.x(), y: target.y() });
+      }
+    }
+
+    function handleBedMove(bedId: string, x: number, y: number) {
+      const snappedX = snapValue(x, snap);
+      const snappedY = snapValue(y, snap);
+      onMoveBed(bedId, Math.max(0, snappedX), Math.max(0, snappedY));
+    }
+
+    const draftLinePoints = draftPoints.flatMap((p) => [
+      p.x * PX_PER_INCH,
+      p.y * PX_PER_INCH,
+    ]);
+    if (drawing && hoverPoint && draftPoints.length > 0) {
+      draftLinePoints.push(hoverPoint.x * PX_PER_INCH, hoverPoint.y * PX_PER_INCH);
+    }
+
+    return (
+      <div ref={containerRef} className="grn-designer-canvas">
+        {viewport.width > 0 && viewport.height > 0 && (
+          <Stage
+            ref={stageRef}
+            width={viewport.width}
+            height={viewport.height}
+            scaleX={scale}
+            scaleY={scale}
+            x={position.x}
+            y={position.y}
+            draggable={!drawing}
+            onClick={handleStageClick}
+            onTap={handleStageClick}
+            onDblClick={handleStageDblClick}
+            onDblTap={handleStageDblClick}
+            onMouseMove={handleStageMouseMove}
+            onWheel={handleStageWheel}
+            onDragEnd={handleStageDragEnd}
+          >
+            <Layer listening>
+              <Grid
+                widthInches={canvas.widthInches}
+                heightInches={canvas.heightInches}
+                pxPerInch={PX_PER_INCH}
+              />
+              <BackgroundLayer
+                src={backgroundImageUrl}
+                widthInches={canvas.widthInches}
+                heightInches={canvas.heightInches}
+                pxPerInch={PX_PER_INCH}
+                opacity={canvas.backgroundOpacity}
+              />
+            </Layer>
+            <Layer>
+              {beds.map((bed) => (
+                <BedShape
+                  key={bed.id}
+                  bed={bed}
+                  pxPerInch={PX_PER_INCH}
+                  isSelected={selectedBedId === bed.id}
+                  isEditable={isEditable && !drawing}
+                  crops={cropsByBedId.get(bed.id) ?? []}
+                  onSelect={onSelect}
+                  onMove={handleBedMove}
+                />
+              ))}
+              {drawing && draftLinePoints.length >= 4 && (
+                <Line
+                  points={draftLinePoints}
+                  stroke="#3a7e5a"
+                  strokeWidth={2}
+                  dash={[6, 4]}
+                  listening={false}
+                />
+              )}
+              {drawing &&
+                draftPoints.map((point, idx) => (
+                  <Circle
+                    key={idx}
+                    x={point.x * PX_PER_INCH}
+                    y={point.y * PX_PER_INCH}
+                    radius={5}
+                    fill="#3a7e5a"
+                    stroke="#fff"
+                    strokeWidth={2}
+                    listening={false}
+                  />
+                ))}
+              {drawing && hoverPoint && (
+                <Circle
+                  x={hoverPoint.x * PX_PER_INCH}
+                  y={hoverPoint.y * PX_PER_INCH}
+                  radius={4}
+                  fill="rgba(58, 126, 90, 0.4)"
+                  listening={false}
+                />
+              )}
+            </Layer>
+          </Stage>
+        )}
+        {drawing && (
+          <div className="grn-designer-canvas__draw-hint" role="status">
+            Click to add points · double-click to finish · esc to cancel
+          </div>
+        )}
+      </div>
+    );
+  }
+);

--- a/apps/grn/src/components/GardenDesigner/GardenPropertiesBar.tsx
+++ b/apps/grn/src/components/GardenDesigner/GardenPropertiesBar.tsx
@@ -1,0 +1,217 @@
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+import type { GardenBed, GardenCanvas } from '../../types/listing';
+import { bedAreaSquareInches, formatArea } from './bedDefaults';
+
+interface GardenPropertiesBarProps {
+  canvas: GardenCanvas;
+  beds: GardenBed[];
+  isEditable: boolean;
+  isSaving: boolean;
+  onCanvasChange: (patch: {
+    widthInches?: number;
+    heightInches?: number;
+    backgroundOpacity?: number;
+  }) => void;
+  hasBackground: boolean;
+  onPickBackgroundFile: (file: File) => void;
+  onClearBackground: () => void;
+}
+
+const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+function parseFeetInches(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  // Accept "12", "12ft", "12 ft", "12'", or just inches like "144in".
+  const ftMatch = /^(-?\d+(?:\.\d+)?)\s*(?:ft|')$/i.exec(trimmed);
+  if (ftMatch) {
+    return Math.round(Number(ftMatch[1]) * 12);
+  }
+  const inMatch = /^(-?\d+(?:\.\d+)?)\s*(?:in|")$/i.exec(trimmed);
+  if (inMatch) {
+    return Math.round(Number(inMatch[1]));
+  }
+  const num = Number(trimmed);
+  if (Number.isFinite(num)) {
+    // Bare numbers are interpreted as feet — that's the gardener's
+    // unit of choice. They can append "in" if they really meant inches.
+    return Math.round(num * 12);
+  }
+  return null;
+}
+
+function formatFeetFromInches(inches: number): string {
+  const feet = inches / 12;
+  if (Number.isInteger(feet)) {
+    return `${feet} ft`;
+  }
+  return `${feet.toFixed(1)} ft`;
+}
+
+/**
+ * Top-of-page bar showing garden-level properties: editable scale,
+ * background photo controls, and live totals (bed count, total
+ * growable area). Replaces the old per-bed toolbar that lived here
+ * in the first iteration.
+ */
+export function GardenPropertiesBar({
+  canvas,
+  beds,
+  isEditable,
+  isSaving,
+  onCanvasChange,
+  hasBackground,
+  onPickBackgroundFile,
+  onClearBackground,
+}: GardenPropertiesBarProps) {
+  const [widthInput, setWidthInput] = useState(formatFeetFromInches(canvas.widthInches));
+  const [heightInput, setHeightInput] = useState(formatFeetFromInches(canvas.heightInches));
+
+  function commitWidth(raw: string) {
+    const next = parseFeetInches(raw);
+    if (next === null || next < 12 || next > 12_000) {
+      setWidthInput(formatFeetFromInches(canvas.widthInches));
+      return;
+    }
+    setWidthInput(formatFeetFromInches(next));
+    if (next !== canvas.widthInches) {
+      onCanvasChange({ widthInches: next });
+    }
+  }
+
+  function commitHeight(raw: string) {
+    const next = parseFeetInches(raw);
+    if (next === null || next < 12 || next > 12_000) {
+      setHeightInput(formatFeetFromInches(canvas.heightInches));
+      return;
+    }
+    setHeightInput(formatFeetFromInches(next));
+    if (next !== canvas.heightInches) {
+      onCanvasChange({ heightInches: next });
+    }
+  }
+
+  function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type)) return;
+    onPickBackgroundFile(file);
+    event.target.value = '';
+  }
+
+  const totalSquareInches = beds.reduce(
+    (sum, bed) =>
+      sum +
+      bedAreaSquareInches({
+        shape: bed.shape,
+        lengthInches: bed.lengthInches,
+        widthInches: bed.widthInches,
+        points: bed.points,
+      }),
+    0
+  );
+
+  return (
+    <div className="grn-garden-properties" role="region" aria-label="Garden properties">
+      <div className="grn-garden-properties__group" role="group" aria-label="Scale">
+        <span className="grn-garden-properties__label">Scale</span>
+        <div className="grn-garden-properties__scale">
+          <label className="grn-garden-properties__scale-field">
+            <span>Width</span>
+            <input
+              type="text"
+              value={widthInput}
+              onChange={(e) => setWidthInput(e.target.value)}
+              onBlur={(e) => commitWidth(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+              }}
+              disabled={!isEditable}
+              inputMode="decimal"
+              aria-label="Garden width"
+            />
+          </label>
+          <span className="grn-garden-properties__scale-x" aria-hidden="true">×</span>
+          <label className="grn-garden-properties__scale-field">
+            <span>Height</span>
+            <input
+              type="text"
+              value={heightInput}
+              onChange={(e) => setHeightInput(e.target.value)}
+              onBlur={(e) => commitHeight(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+              }}
+              disabled={!isEditable}
+              inputMode="decimal"
+              aria-label="Garden height"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="grn-garden-properties__group" role="group" aria-label="Totals">
+        <div className="grn-garden-properties__metric">
+          <span className="grn-garden-properties__metric-label">Beds</span>
+          <span className="grn-garden-properties__metric-value">{beds.length}</span>
+        </div>
+        <div className="grn-garden-properties__metric">
+          <span className="grn-garden-properties__metric-label">Growable area</span>
+          <span className="grn-garden-properties__metric-value">
+            {formatArea(totalSquareInches)}
+          </span>
+        </div>
+      </div>
+
+      <div className="grn-garden-properties__group" role="group" aria-label="Background photo">
+        <label className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost">
+          <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">🛰️</span>
+          <span>{hasBackground ? 'Replace background photo' : 'Add background photo'}</span>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={handleFile}
+            disabled={!isEditable}
+            hidden
+          />
+        </label>
+        {hasBackground && (
+          <>
+            <label className="grn-designer-toolbar__field">
+              <span>Opacity</span>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={canvas.backgroundOpacity}
+                onChange={(e) =>
+                  onCanvasChange({ backgroundOpacity: Number(e.target.value) })
+                }
+                disabled={!isEditable}
+              />
+            </label>
+            <button
+              type="button"
+              className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost"
+              onClick={onClearBackground}
+              disabled={!isEditable}
+            >
+              Remove
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="grn-garden-properties__group grn-garden-properties__group--end">
+        <span
+          className="grn-designer-toolbar__save-status"
+          aria-live="polite"
+          data-saving={isSaving}
+        >
+          {isSaving ? 'Saving…' : 'Saved'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/Grid.tsx
+++ b/apps/grn/src/components/GardenDesigner/Grid.tsx
@@ -1,0 +1,105 @@
+import { Group, Line, Rect } from 'react-konva';
+
+interface GridProps {
+  widthInches: number;
+  heightInches: number;
+  pxPerInch: number;
+  majorEvery?: number; // inches between major lines (default 12 = 1 foot)
+  minorEvery?: number; // inches between minor lines (default 6)
+  showMinor?: boolean;
+}
+
+const MAJOR_COLOR = 'rgba(91, 58, 28, 0.18)';
+const MINOR_COLOR = 'rgba(91, 58, 28, 0.08)';
+const BORDER_COLOR = 'rgba(91, 58, 28, 0.42)';
+const CANVAS_FILL = 'rgba(255, 250, 239, 0.55)';
+
+/**
+ * Renders the canvas backdrop, the inch/foot grid lines, and the canvas
+ * boundary. Pure presentation — accepts world dimensions in inches and a
+ * pixel-per-inch scale.
+ */
+export function Grid({
+  widthInches,
+  heightInches,
+  pxPerInch,
+  majorEvery = 12,
+  minorEvery = 6,
+  showMinor = true,
+}: GridProps) {
+  const widthPx = widthInches * pxPerInch;
+  const heightPx = heightInches * pxPerInch;
+
+  const minorLines: Array<{ x?: number; y?: number }> = [];
+  if (showMinor) {
+    for (let i = minorEvery; i < widthInches; i += minorEvery) {
+      if (i % majorEvery === 0) continue;
+      minorLines.push({ x: i });
+    }
+    for (let i = minorEvery; i < heightInches; i += minorEvery) {
+      if (i % majorEvery === 0) continue;
+      minorLines.push({ y: i });
+    }
+  }
+
+  const majorLines: Array<{ x?: number; y?: number }> = [];
+  for (let i = majorEvery; i < widthInches; i += majorEvery) {
+    majorLines.push({ x: i });
+  }
+  for (let i = majorEvery; i < heightInches; i += majorEvery) {
+    majorLines.push({ y: i });
+  }
+
+  return (
+    <Group listening={false}>
+      <Rect
+        x={0}
+        y={0}
+        width={widthPx}
+        height={heightPx}
+        fill={CANVAS_FILL}
+        stroke={BORDER_COLOR}
+        strokeWidth={1.5}
+        cornerRadius={6}
+        shadowColor="rgba(91, 58, 28, 0.18)"
+        shadowBlur={18}
+        shadowOffset={{ x: 0, y: 4 }}
+        shadowOpacity={0.5}
+      />
+      {minorLines.map((line, idx) =>
+        line.x !== undefined ? (
+          <Line
+            key={`minor-x-${idx}`}
+            points={[line.x * pxPerInch, 0, line.x * pxPerInch, heightPx]}
+            stroke={MINOR_COLOR}
+            strokeWidth={1}
+          />
+        ) : (
+          <Line
+            key={`minor-y-${idx}`}
+            points={[0, (line.y ?? 0) * pxPerInch, widthPx, (line.y ?? 0) * pxPerInch]}
+            stroke={MINOR_COLOR}
+            strokeWidth={1}
+          />
+        )
+      )}
+      {majorLines.map((line, idx) =>
+        line.x !== undefined ? (
+          <Line
+            key={`major-x-${idx}`}
+            points={[line.x * pxPerInch, 0, line.x * pxPerInch, heightPx]}
+            stroke={MAJOR_COLOR}
+            strokeWidth={1}
+          />
+        ) : (
+          <Line
+            key={`major-y-${idx}`}
+            points={[0, (line.y ?? 0) * pxPerInch, widthPx, (line.y ?? 0) * pxPerInch]}
+            stroke={MAJOR_COLOR}
+            strokeWidth={1}
+          />
+        )
+      )}
+    </Group>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -1,0 +1,176 @@
+import type { ChangeEvent } from 'react';
+import type { BedType } from '../../types/listing';
+import { defaultsFor } from './bedDefaults';
+
+export type DesignerMode = 'idle' | 'drawing-polygon';
+export type GridSnap = 'off' | '6' | '12';
+
+interface ToolbarProps {
+  isMobile: boolean;
+  editUnlocked: boolean;
+  onToggleEditUnlocked: () => void;
+  mode: DesignerMode;
+  onAddBed: (type: BedType) => void;
+  onStartDrawingPolygon: () => void;
+  onCancelDrawingPolygon: () => void;
+  gridSnap: GridSnap;
+  onGridSnapChange: (snap: GridSnap) => void;
+  onPickBackgroundFile: (file: File) => void;
+  onClearBackground: () => void;
+  hasBackground: boolean;
+  backgroundOpacity: number;
+  onBackgroundOpacityChange: (opacity: number) => void;
+  onFitToScreen: () => void;
+  isSaving: boolean;
+}
+
+const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function Toolbar({
+  isMobile,
+  editUnlocked,
+  onToggleEditUnlocked,
+  mode,
+  onAddBed,
+  onStartDrawingPolygon,
+  onCancelDrawingPolygon,
+  gridSnap,
+  onGridSnapChange,
+  onPickBackgroundFile,
+  onClearBackground,
+  hasBackground,
+  backgroundOpacity,
+  onBackgroundOpacityChange,
+  onFitToScreen,
+  isSaving,
+}: ToolbarProps) {
+  const editingBlocked = isMobile && !editUnlocked;
+  const drawing = mode === 'drawing-polygon';
+
+  function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type)) return;
+    onPickBackgroundFile(file);
+    event.target.value = '';
+  }
+
+  return (
+    <div
+      className={`grn-designer-toolbar ${editingBlocked ? 'is-locked' : ''}`}
+      role="toolbar"
+      aria-label="Garden designer tools"
+    >
+      <div className="grn-designer-toolbar__group" role="group" aria-label="Add a bed">
+        {(['raised', 'mound', 'in_ground'] as BedType[]).map((type) => (
+          <button
+            key={type}
+            type="button"
+            className="grn-designer-toolbar__btn"
+            onClick={() => onAddBed(type)}
+            disabled={editingBlocked || drawing}
+            title={defaultsFor(type).label}
+          >
+            <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
+              {defaultsFor(type).emoji}
+            </span>
+            <span>{defaultsFor(type).label}</span>
+          </button>
+        ))}
+        <button
+          type="button"
+          className={`grn-designer-toolbar__btn ${drawing ? 'is-active' : ''}`}
+          onClick={drawing ? onCancelDrawingPolygon : onStartDrawingPolygon}
+          disabled={editingBlocked}
+          title={drawing ? 'Click to add points, double-click to close. Esc to cancel.' : 'Draw a custom in-ground bed shape'}
+        >
+          <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">✏️</span>
+          <span>{drawing ? 'Drawing… (esc)' : 'Draw shape'}</span>
+        </button>
+      </div>
+
+      <div className="grn-designer-toolbar__group" role="group" aria-label="Snap and fit">
+        <label className="grn-designer-toolbar__field">
+          <span>Snap</span>
+          <select
+            value={gridSnap}
+            onChange={(e) => onGridSnapChange(e.target.value as GridSnap)}
+            disabled={editingBlocked}
+          >
+            <option value="off">Off</option>
+            <option value="6">6 in</option>
+            <option value="12">1 ft</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost"
+          onClick={onFitToScreen}
+          title="Fit canvas to viewport"
+        >
+          Fit
+        </button>
+      </div>
+
+      <div className="grn-designer-toolbar__group" role="group" aria-label="Background">
+        <label className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost">
+          <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">🛰️</span>
+          <span>{hasBackground ? 'Replace photo' : 'Add photo'}</span>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={handleFile}
+            disabled={editingBlocked}
+            hidden
+          />
+        </label>
+        {hasBackground && (
+          <>
+            <label className="grn-designer-toolbar__field">
+              <span>Opacity</span>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={backgroundOpacity}
+                onChange={(e) => onBackgroundOpacityChange(Number(e.target.value))}
+                disabled={editingBlocked}
+              />
+            </label>
+            <button
+              type="button"
+              className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost"
+              onClick={onClearBackground}
+              disabled={editingBlocked}
+            >
+              Remove photo
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="grn-designer-toolbar__group grn-designer-toolbar__group--end">
+        {isMobile && (
+          <button
+            type="button"
+            className={`grn-designer-toolbar__btn ${editUnlocked ? 'is-active' : ''}`}
+            onClick={onToggleEditUnlocked}
+            title={editUnlocked ? 'Lock layout (read-only mode)' : 'Unlock to edit'}
+          >
+            <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
+              {editUnlocked ? '🔓' : '🔒'}
+            </span>
+            <span>{editUnlocked ? 'Editing' : 'Locked'}</span>
+          </button>
+        )}
+        <span
+          className="grn-designer-toolbar__save-status"
+          aria-live="polite"
+          data-saving={isSaving}
+        >
+          {isSaving ? 'Saving…' : 'Saved'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -1,6 +1,5 @@
-import type { ChangeEvent } from 'react';
-import type { BedType } from '../../types/listing';
-import { defaultsFor } from './bedDefaults';
+import type { BedShape } from '../../types/listing';
+import { BED_SHAPES } from './bedDefaults';
 
 export type DesignerMode = 'idle' | 'drawing-polygon';
 export type GridSnap = 'off' | '6' | '12';
@@ -10,22 +9,19 @@ interface ToolbarProps {
   editUnlocked: boolean;
   onToggleEditUnlocked: () => void;
   mode: DesignerMode;
-  onAddBed: (type: BedType) => void;
+  onAddBed: (shape: BedShape) => void;
   onStartDrawingPolygon: () => void;
   onCancelDrawingPolygon: () => void;
   gridSnap: GridSnap;
   onGridSnapChange: (snap: GridSnap) => void;
-  onPickBackgroundFile: (file: File) => void;
-  onClearBackground: () => void;
-  hasBackground: boolean;
-  backgroundOpacity: number;
-  onBackgroundOpacityChange: (opacity: number) => void;
   onFitToScreen: () => void;
-  isSaving: boolean;
 }
 
-const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-
+/**
+ * Vertical left-rail toolbar, paint.net style. Each tool is a square
+ * icon button with a tooltip; the small select controls are stacked at
+ * the bottom. On mobile this collapses into a horizontal strip via CSS.
+ */
 export function Toolbar({
   isMobile,
   editUnlocked,
@@ -36,24 +32,10 @@ export function Toolbar({
   onCancelDrawingPolygon,
   gridSnap,
   onGridSnapChange,
-  onPickBackgroundFile,
-  onClearBackground,
-  hasBackground,
-  backgroundOpacity,
-  onBackgroundOpacityChange,
   onFitToScreen,
-  isSaving,
 }: ToolbarProps) {
   const editingBlocked = isMobile && !editUnlocked;
   const drawing = mode === 'drawing-polygon';
-
-  function handleFile(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type)) return;
-    onPickBackgroundFile(file);
-    event.target.value = '';
-  }
 
   return (
     <div
@@ -62,19 +44,20 @@ export function Toolbar({
       aria-label="Garden designer tools"
     >
       <div className="grn-designer-toolbar__group" role="group" aria-label="Add a bed">
-        {(['raised', 'mound', 'in_ground'] as BedType[]).map((type) => (
+        {BED_SHAPES.map((shape) => (
           <button
-            key={type}
+            key={shape.value}
             type="button"
             className="grn-designer-toolbar__btn"
-            onClick={() => onAddBed(type)}
+            onClick={() => onAddBed(shape.value)}
             disabled={editingBlocked || drawing}
-            title={defaultsFor(type).label}
+            title={shape.hint}
+            aria-label={shape.hint}
           >
             <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
-              {defaultsFor(type).emoji}
+              {shape.emoji}
             </span>
-            <span>{defaultsFor(type).label}</span>
+            <span className="grn-designer-toolbar__btn-label">{shape.label}</span>
           </button>
         ))}
         <button
@@ -82,14 +65,23 @@ export function Toolbar({
           className={`grn-designer-toolbar__btn ${drawing ? 'is-active' : ''}`}
           onClick={drawing ? onCancelDrawingPolygon : onStartDrawingPolygon}
           disabled={editingBlocked}
-          title={drawing ? 'Click to add points, double-click to close. Esc to cancel.' : 'Draw a custom in-ground bed shape'}
+          title={
+            drawing
+              ? 'Click to add points, double-click to close. Esc to cancel.'
+              : 'Draw a custom polygon by clicking points'
+          }
+          aria-label={drawing ? 'Cancel drawing' : 'Draw custom shape'}
         >
           <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">✏️</span>
-          <span>{drawing ? 'Drawing… (esc)' : 'Draw shape'}</span>
+          <span className="grn-designer-toolbar__btn-label">
+            {drawing ? 'Drawing…' : 'Draw shape'}
+          </span>
         </button>
       </div>
 
-      <div className="grn-designer-toolbar__group" role="group" aria-label="Snap and fit">
+      <div className="grn-designer-toolbar__divider" aria-hidden="true" />
+
+      <div className="grn-designer-toolbar__group" role="group" aria-label="View">
         <label className="grn-designer-toolbar__field">
           <span>Snap</span>
           <select
@@ -107,70 +99,34 @@ export function Toolbar({
           className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost"
           onClick={onFitToScreen}
           title="Fit canvas to viewport"
+          aria-label="Fit to screen"
         >
-          Fit
+          <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">🔍</span>
+          <span className="grn-designer-toolbar__btn-label">Fit</span>
         </button>
       </div>
 
-      <div className="grn-designer-toolbar__group" role="group" aria-label="Background">
-        <label className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost">
-          <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">🛰️</span>
-          <span>{hasBackground ? 'Replace photo' : 'Add photo'}</span>
-          <input
-            type="file"
-            accept="image/jpeg,image/png,image/webp"
-            onChange={handleFile}
-            disabled={editingBlocked}
-            hidden
-          />
-        </label>
-        {hasBackground && (
-          <>
-            <label className="grn-designer-toolbar__field">
-              <span>Opacity</span>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                value={backgroundOpacity}
-                onChange={(e) => onBackgroundOpacityChange(Number(e.target.value))}
-                disabled={editingBlocked}
-              />
-            </label>
+      {isMobile && (
+        <>
+          <div className="grn-designer-toolbar__divider" aria-hidden="true" />
+          <div className="grn-designer-toolbar__group" role="group" aria-label="Edit lock">
             <button
               type="button"
-              className="grn-designer-toolbar__btn grn-designer-toolbar__btn--ghost"
-              onClick={onClearBackground}
-              disabled={editingBlocked}
+              className={`grn-designer-toolbar__btn ${editUnlocked ? 'is-active' : ''}`}
+              onClick={onToggleEditUnlocked}
+              title={editUnlocked ? 'Lock layout (read-only mode)' : 'Unlock to edit'}
+              aria-pressed={editUnlocked}
             >
-              Remove photo
+              <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
+                {editUnlocked ? '🔓' : '🔒'}
+              </span>
+              <span className="grn-designer-toolbar__btn-label">
+                {editUnlocked ? 'Editing' : 'Locked'}
+              </span>
             </button>
-          </>
-        )}
-      </div>
-
-      <div className="grn-designer-toolbar__group grn-designer-toolbar__group--end">
-        {isMobile && (
-          <button
-            type="button"
-            className={`grn-designer-toolbar__btn ${editUnlocked ? 'is-active' : ''}`}
-            onClick={onToggleEditUnlocked}
-            title={editUnlocked ? 'Lock layout (read-only mode)' : 'Unlock to edit'}
-          >
-            <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
-              {editUnlocked ? '🔓' : '🔒'}
-            </span>
-            <span>{editUnlocked ? 'Editing' : 'Locked'}</span>
-          </button>
-        )}
-        <span
-          className="grn-designer-toolbar__save-status"
-          aria-live="polite"
-          data-saving={isSaving}
-        >
-          {isSaving ? 'Saving…' : 'Saved'}
-        </span>
-      </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.ts
@@ -47,10 +47,14 @@ export interface BedShapeMeta {
 
 // Bed *shape* is geometry. Each toolbar button picks a shape and
 // drops a default-sized bed of that geometry onto the canvas.
+//
+// Only Rectangle and Circle are presets — a "polygon preset" would be
+// indistinguishable from a rectangle until per-vertex editing lands.
+// Custom polygons come from the "Draw shape" tool, which is wired up
+// separately in the toolbar.
 export const BED_SHAPES: BedShapeMeta[] = [
   { value: 'rect', label: 'Rectangle', emoji: '▭', hint: 'Add a rectangular bed' },
   { value: 'circle', label: 'Circle', emoji: '◯', hint: 'Add a circular bed' },
-  { value: 'polygon', label: 'Polygon', emoji: '⬟', hint: 'Add a 4-corner polygon bed' },
 ];
 
 export function bedShapeMeta(value: BedShape): BedShapeMeta {

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.ts
@@ -1,67 +1,79 @@
-// Bed-type defaults shared across the toolbar and inspector. Keep these
-// in inches so they map directly onto the canvas coordinate system.
+// Type, shape, soil, and color vocabularies shared across the designer.
+// Keep dimensions in inches so they map directly onto the canvas grid.
 
-import type { BedShape, BedType } from '../../types/listing';
+import type { BedPolygonPoint, BedShape, BedType } from '../../types/listing';
 
-export interface BedDefaults {
-  bedType: BedType;
+export interface BedTypeMeta {
+  value: BedType;
+  label: string;
+  emoji: string;
+  description: string;
+}
+
+// Bed *type* describes how the bed is constructed (raised vs mound vs
+// in-ground). Type is independent of the shape: a raised bed can be a
+// rectangle, circle, or polygon.
+export const BED_TYPES: BedTypeMeta[] = [
+  {
+    value: 'raised',
+    label: 'Raised bed',
+    emoji: '🪵',
+    description: 'Wood-framed beds, easy to layer with mix and amendments.',
+  },
+  {
+    value: 'mound',
+    label: 'Mound',
+    emoji: '⛰️',
+    description: 'Heaped soil beds, great for squash, melons, and hugelkultur.',
+  },
+  {
+    value: 'in_ground',
+    label: 'In-ground bed',
+    emoji: '🌱',
+    description: 'Native-soil beds planted directly into existing ground.',
+  },
+];
+
+export function bedTypeMeta(value: BedType): BedTypeMeta {
+  return BED_TYPES.find((t) => t.value === value) ?? BED_TYPES[0];
+}
+
+export interface BedShapeMeta {
+  value: BedShape;
+  label: string;
+  emoji: string;
+  hint: string;
+}
+
+// Bed *shape* is geometry. Each toolbar button picks a shape and
+// drops a default-sized bed of that geometry onto the canvas.
+export const BED_SHAPES: BedShapeMeta[] = [
+  { value: 'rect', label: 'Rectangle', emoji: '▭', hint: 'Add a rectangular bed' },
+  { value: 'circle', label: 'Circle', emoji: '◯', hint: 'Add a circular bed' },
+  { value: 'polygon', label: 'Polygon', emoji: '⬟', hint: 'Add a 4-corner polygon bed' },
+];
+
+export function bedShapeMeta(value: BedShape): BedShapeMeta {
+  return BED_SHAPES.find((s) => s.value === value) ?? BED_SHAPES[0];
+}
+
+export interface ShapeDefaults {
   shape: BedShape;
   lengthInches: number;
   widthInches: number;
-  diameterInches?: number;
-  fill: string;
-  stroke: string;
-  strokeWidth: number;
-  cornerRadius: number;
-  label: string;
-  emoji: string;
 }
 
-const DEFAULTS: Record<BedType, BedDefaults> = {
-  raised: {
-    bedType: 'raised',
-    shape: 'rect',
-    lengthInches: 96,
-    widthInches: 48,
-    fill: 'rgba(186, 145, 96, 0.18)',
-    stroke: '#8a6230',
-    strokeWidth: 6,
-    cornerRadius: 4,
-    label: 'Raised bed',
-    emoji: '🪵',
-  },
-  mound: {
-    bedType: 'mound',
-    shape: 'circle',
-    lengthInches: 48,
-    widthInches: 48,
-    diameterInches: 48,
-    fill: 'rgba(133, 92, 56, 0.32)',
-    stroke: '#5b3a1c',
-    strokeWidth: 2,
-    cornerRadius: 0,
-    label: 'Mound',
-    emoji: '⛰️',
-  },
-  in_ground: {
-    bedType: 'in_ground',
-    shape: 'polygon',
-    lengthInches: 96,
-    widthInches: 48,
-    fill: 'rgba(96, 134, 73, 0.20)',
-    stroke: '#5b8c4a',
-    strokeWidth: 2,
-    cornerRadius: 0,
-    label: 'In-ground bed',
-    emoji: '🌱',
-  },
+const SHAPE_DEFAULTS: Record<BedShape, ShapeDefaults> = {
+  rect: { shape: 'rect', lengthInches: 96, widthInches: 48 },
+  circle: { shape: 'circle', lengthInches: 48, widthInches: 48 },
+  polygon: { shape: 'polygon', lengthInches: 96, widthInches: 48 },
 };
 
-export function defaultsFor(type: BedType): BedDefaults {
-  return DEFAULTS[type];
+export function shapeDefaults(shape: BedShape): ShapeDefaults {
+  return SHAPE_DEFAULTS[shape];
 }
 
-export function defaultRectPolygonPoints(width: number, height: number) {
+export function defaultRectPolygonPoints(width: number, height: number): BedPolygonPoint[] {
   return [
     { x: 0, y: 0 },
     { x: width, y: 0 },
@@ -70,7 +82,55 @@ export function defaultRectPolygonPoints(width: number, height: number) {
   ];
 }
 
-// Friendly preset palette the inspector exposes for color tagging.
+// --- Soil ----------------------------------------------------------------
+// IMPORTANT: these values are an immutable LLM-input enum. The labels are
+// human-friendly and can be tweaked, but the `value` strings are passed
+// directly to LLM prompts for soil-specific gardening advice. Don't add,
+// remove, or rename a value without updating the relevant prompts.
+
+export interface SoilOption {
+  value: string;
+  label: string;
+}
+
+export const SOIL_OPTIONS: ReadonlyArray<SoilOption> = [
+  { value: 'sandy_loam', label: 'Sandy loam' },
+  { value: 'clay', label: 'Clay' },
+  { value: 'loam', label: 'Loam' },
+  { value: 'silty', label: 'Silty' },
+  { value: 'chalky', label: 'Chalky' },
+  { value: 'peat', label: 'Peat' },
+  { value: 'raised_bed_mix', label: 'Raised bed mix' },
+  { value: 'compost_amended', label: 'Compost-amended' },
+  { value: 'native_soil', label: 'Native soil' },
+];
+
+const SOIL_VALUES = new Set(SOIL_OPTIONS.map((o) => o.value));
+
+export function parseSoilField(value: string | null | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => SOIL_VALUES.has(token));
+}
+
+export function serializeSoilField(values: readonly string[]): string | null {
+  const filtered = values.filter((v) => SOIL_VALUES.has(v));
+  if (filtered.length === 0) return null;
+  // Preserve canonical order so the same selection always serializes the
+  // same way (better for LLM caching downstream).
+  return SOIL_OPTIONS.filter((o) => filtered.includes(o.value))
+    .map((o) => o.value)
+    .join(',');
+}
+
+export function soilLabel(value: string): string {
+  return SOIL_OPTIONS.find((o) => o.value === value)?.label ?? value;
+}
+
+// --- Color palette --------------------------------------------------------
+
 export const BED_COLOR_PALETTE: Array<{ value: string; label: string }> = [
   { value: '#8a6230', label: 'Cedar' },
   { value: '#5b8c4a', label: 'Moss' },
@@ -82,8 +142,78 @@ export const BED_COLOR_PALETTE: Array<{ value: string; label: string }> = [
   { value: '#7a8c3b', label: 'Olive' },
 ];
 
-export const BED_TYPE_DESCRIPTIONS: Record<BedType, string> = {
-  raised: 'Wood-framed beds, easy to layer with mix and amendments.',
-  mound: 'Heaped soil beds, great for squash, melons, and hugelkultur.',
-  in_ground: 'Native-soil beds with any outline you can draw.',
-};
+// --- Area calculations ----------------------------------------------------
+// Returns square inches for the given bed geometry. Polygon uses the
+// shoelace formula on the absolute (untranslated) point set.
+
+export function bedAreaSquareInches(args: {
+  shape: BedShape;
+  lengthInches: number | null;
+  widthInches: number | null;
+  points: BedPolygonPoint[] | null;
+}): number {
+  const { shape, lengthInches, widthInches, points } = args;
+  if (shape === 'circle') {
+    const diameter = lengthInches ?? widthInches ?? 0;
+    const radius = diameter / 2;
+    return Math.PI * radius * radius;
+  }
+  if (shape === 'polygon' && points && points.length >= 3) {
+    let sum = 0;
+    for (let i = 0; i < points.length; i += 1) {
+      const a = points[i];
+      const b = points[(i + 1) % points.length];
+      sum += a.x * b.y - b.x * a.y;
+    }
+    return Math.abs(sum) / 2;
+  }
+  return Math.max(0, (lengthInches ?? 0) * (widthInches ?? 0));
+}
+
+export function formatArea(squareInches: number): string {
+  if (squareInches <= 0) return '0 sq ft';
+  const squareFeet = squareInches / 144;
+  if (squareFeet < 1) {
+    return `${Math.round(squareInches)} sq in`;
+  }
+  if (squareFeet < 10) {
+    return `${squareFeet.toFixed(1)} sq ft`;
+  }
+  return `${Math.round(squareFeet)} sq ft`;
+}
+
+// Style tokens used by BedShape, keyed by bed type + shape so type can
+// affect the look (raised = framed) without forcing the shape.
+export interface BedStyleTokens {
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  cornerRadius: number;
+}
+
+export function bedStyleFor(bedType: BedType): BedStyleTokens {
+  switch (bedType) {
+    case 'raised':
+      return {
+        fill: 'rgba(186, 145, 96, 0.18)',
+        stroke: '#8a6230',
+        strokeWidth: 6,
+        cornerRadius: 4,
+      };
+    case 'mound':
+      return {
+        fill: 'rgba(133, 92, 56, 0.32)',
+        stroke: '#5b3a1c',
+        strokeWidth: 2,
+        cornerRadius: 0,
+      };
+    case 'in_ground':
+    default:
+      return {
+        fill: 'rgba(96, 134, 73, 0.20)',
+        stroke: '#5b8c4a',
+        strokeWidth: 2,
+        cornerRadius: 0,
+      };
+  }
+}

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.ts
@@ -154,11 +154,14 @@ export function bedAreaSquareInches(args: {
 }): number {
   const { shape, lengthInches, widthInches, points } = args;
   if (shape === 'circle') {
-    const diameter = lengthInches ?? widthInches ?? 0;
-    const radius = diameter / 2;
-    return Math.PI * radius * radius;
+    // Ellipse area: π · a · b where a, b are the semi-axes. Equals
+    // π · r² when the bed is a perfect circle (length === width).
+    const semiA = (lengthInches ?? 0) / 2;
+    const semiB = (widthInches ?? lengthInches ?? 0) / 2;
+    return Math.PI * semiA * semiB;
   }
   if (shape === 'polygon' && points && points.length >= 3) {
+    // Shoelace formula on the polygon's vertex list.
     let sum = 0;
     for (let i = 0; i < points.length; i += 1) {
       const a = points[i];

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.ts
@@ -1,0 +1,89 @@
+// Bed-type defaults shared across the toolbar and inspector. Keep these
+// in inches so they map directly onto the canvas coordinate system.
+
+import type { BedShape, BedType } from '../../types/listing';
+
+export interface BedDefaults {
+  bedType: BedType;
+  shape: BedShape;
+  lengthInches: number;
+  widthInches: number;
+  diameterInches?: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  cornerRadius: number;
+  label: string;
+  emoji: string;
+}
+
+const DEFAULTS: Record<BedType, BedDefaults> = {
+  raised: {
+    bedType: 'raised',
+    shape: 'rect',
+    lengthInches: 96,
+    widthInches: 48,
+    fill: 'rgba(186, 145, 96, 0.18)',
+    stroke: '#8a6230',
+    strokeWidth: 6,
+    cornerRadius: 4,
+    label: 'Raised bed',
+    emoji: '🪵',
+  },
+  mound: {
+    bedType: 'mound',
+    shape: 'circle',
+    lengthInches: 48,
+    widthInches: 48,
+    diameterInches: 48,
+    fill: 'rgba(133, 92, 56, 0.32)',
+    stroke: '#5b3a1c',
+    strokeWidth: 2,
+    cornerRadius: 0,
+    label: 'Mound',
+    emoji: '⛰️',
+  },
+  in_ground: {
+    bedType: 'in_ground',
+    shape: 'polygon',
+    lengthInches: 96,
+    widthInches: 48,
+    fill: 'rgba(96, 134, 73, 0.20)',
+    stroke: '#5b8c4a',
+    strokeWidth: 2,
+    cornerRadius: 0,
+    label: 'In-ground bed',
+    emoji: '🌱',
+  },
+};
+
+export function defaultsFor(type: BedType): BedDefaults {
+  return DEFAULTS[type];
+}
+
+export function defaultRectPolygonPoints(width: number, height: number) {
+  return [
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: height },
+    { x: 0, y: height },
+  ];
+}
+
+// Friendly preset palette the inspector exposes for color tagging.
+export const BED_COLOR_PALETTE: Array<{ value: string; label: string }> = [
+  { value: '#8a6230', label: 'Cedar' },
+  { value: '#5b8c4a', label: 'Moss' },
+  { value: '#446e3b', label: 'Forest' },
+  { value: '#5b3a1c', label: 'Soil' },
+  { value: '#c97aab', label: 'Bloom' },
+  { value: '#d6a52c', label: 'Sun' },
+  { value: '#5e4ea3', label: 'Iris' },
+  { value: '#7a8c3b', label: 'Olive' },
+];
+
+export const BED_TYPE_DESCRIPTIONS: Record<BedType, string> = {
+  raised: 'Wood-framed beds, easy to layer with mix and amendments.',
+  mound: 'Heaped soil beds, great for squash, melons, and hugelkultur.',
+  in_ground: 'Native-soil beds with any outline you can draw.',
+};

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -407,6 +407,50 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     [updateCanvasMutation]
   );
 
+  // Keyboard shortcuts:
+  //   Esc           - deselect (when not in drawing-polygon mode; the
+  //                   Canvas owns Esc-to-cancel for that mode)
+  //   Delete /
+  //   Backspace     - prompt for confirmation, then delete the selected
+  //                   bed. Skipped when focus is in a text input/editor
+  //                   so it doesn't fight normal text editing.
+  useEffect(() => {
+    function isEditingText(target: EventTarget | null): boolean {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+      return target.isContentEditable;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (mode === 'drawing-polygon') return;
+      if (isEditingText(event.target)) return;
+
+      if (event.key === 'Escape') {
+        if (selectedBedId !== null) {
+          event.preventDefault();
+          setSelectedBedId(null);
+        }
+        return;
+      }
+
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (!selectedBed || !isEditable) return;
+        event.preventDefault();
+        const label = selectedBed.name.trim() || 'this bed';
+        const confirmed = window.confirm(
+          `Delete "${label}"? This can't be undone.`
+        );
+        if (confirmed) {
+          void deleteBed(selectedBed.id);
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [mode, selectedBedId, selectedBed, isEditable, deleteBed]);
+
   const uploadBackgroundImage = useCallback(
     async (file: File) => {
       if (!isEditable) return;

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -14,14 +14,14 @@ import {
 } from '../services/api';
 import type {
   BedPolygonPoint,
-  BedType,
+  BedShape,
   GardenBed,
   GardenCanvas,
   GrowerCropItem,
 } from '../types/listing';
 import {
   defaultRectPolygonPoints,
-  defaultsFor,
+  shapeDefaults,
 } from '../components/GardenDesigner/bedDefaults';
 import type { DesignerMode, GridSnap } from '../components/GardenDesigner/Toolbar';
 
@@ -48,9 +48,20 @@ export interface UseGardenDesignerResult {
   toggleEditUnlocked: () => void;
   isEditable: boolean;
   isSaving: boolean;
-  addBed: (type: BedType) => Promise<void>;
+  addBed: (shape: BedShape) => Promise<void>;
   commitPolygon: (points: BedPolygonPoint[]) => Promise<void>;
   moveBed: (bedId: string, positionX: number, positionY: number) => void;
+  resizeBed: (
+    bedId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: BedPolygonPoint[] | null;
+    }
+  ) => void;
   patchBed: (bedId: string, patch: Partial<GardenBed>) => void;
   deleteBed: (bedId: string) => Promise<void>;
   patchCanvas: (patch: UpsertGardenCanvasRequest) => void;
@@ -272,9 +283,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   const toggleEditUnlocked = useCallback(() => setEditUnlocked((v) => !v), []);
 
   const addBed = useCallback(
-    async (type: BedType) => {
+    async (shape: BedShape) => {
       if (!isEditable) return;
-      const defaults = defaultsFor(type);
+      const defaults = shapeDefaults(shape);
       const canvas = canvasQuery.data;
       const positionX = canvas
         ? Math.max(0, Math.round((canvas.widthInches - defaults.lengthInches) / 2))
@@ -282,9 +293,11 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       const positionY = canvas
         ? Math.max(0, Math.round((canvas.heightInches - defaults.widthInches) / 2))
         : 12;
+      // New beds default to bed_type='raised' since "raised" is the most
+      // common starting point. Users change it via the inspector.
       const created = await createBedMutation.mutateAsync({
-        name: `${defaults.label} ${beds.length + 1}`,
-        bedType: defaults.bedType,
+        name: `Bed ${beds.length + 1}`,
+        bedType: 'raised',
         shape: defaults.shape,
         lengthInches: defaults.lengthInches,
         widthInches: defaults.widthInches,
@@ -333,6 +346,34 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       const bed = beds.find((b) => b.id === bedId);
       if (!bed) return;
       const payload = bedToUpsertPayload({ ...bed, positionX, positionY });
+      updateBedMutation.mutate({ bedId, payload });
+    },
+    [beds, updateBedMutation]
+  );
+
+  const resizeBed = useCallback(
+    (
+      bedId: string,
+      next: {
+        positionX: number;
+        positionY: number;
+        lengthInches: number;
+        widthInches: number;
+        rotationDeg: number;
+        points: BedPolygonPoint[] | null;
+      }
+    ) => {
+      const bed = beds.find((b) => b.id === bedId);
+      if (!bed) return;
+      const payload = bedToUpsertPayload({
+        ...bed,
+        positionX: next.positionX,
+        positionY: next.positionY,
+        lengthInches: next.lengthInches,
+        widthInches: next.widthInches,
+        rotationDeg: next.rotationDeg,
+        points: next.points,
+      });
       updateBedMutation.mutate({ bedId, payload });
     },
     [beds, updateBedMutation]
@@ -425,6 +466,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     addBed,
     commitPolygon,
     moveBed,
+    resizeBed,
     patchBed,
     deleteBed,
     patchCanvas,

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -1,0 +1,434 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createMyBed,
+  deleteMyBed,
+  getMyGardenCanvas,
+  listMyBeds,
+  listMyCrops,
+  requestBackgroundUploadUrl,
+  updateMyBed,
+  updateMyGardenCanvas,
+  type UpsertGardenBedRequest,
+  type UpsertGardenCanvasRequest,
+} from '../services/api';
+import type {
+  BedPolygonPoint,
+  BedType,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../types/listing';
+import {
+  defaultRectPolygonPoints,
+  defaultsFor,
+} from '../components/GardenDesigner/bedDefaults';
+import type { DesignerMode, GridSnap } from '../components/GardenDesigner/Toolbar';
+
+const CANVAS_QUERY_KEY = ['my-garden-canvas'];
+const BEDS_QUERY_KEY = ['my-garden-beds'];
+const CROPS_QUERY_KEY = ['my-crops'];
+
+export interface UseGardenDesignerResult {
+  canvas: GardenCanvas | undefined;
+  beds: GardenBed[];
+  crops: GrowerCropItem[];
+  cropsByBedId: Map<string, GrowerCropItem[]>;
+  isLoading: boolean;
+  loadError: Error | null;
+  selectedBedId: string | null;
+  setSelectedBedId: (id: string | null) => void;
+  selectedBed: GardenBed | undefined;
+  mode: DesignerMode;
+  setMode: (mode: DesignerMode) => void;
+  snap: GridSnap;
+  setSnap: (snap: GridSnap) => void;
+  isMobile: boolean;
+  editUnlocked: boolean;
+  toggleEditUnlocked: () => void;
+  isEditable: boolean;
+  isSaving: boolean;
+  addBed: (type: BedType) => Promise<void>;
+  commitPolygon: (points: BedPolygonPoint[]) => Promise<void>;
+  moveBed: (bedId: string, positionX: number, positionY: number) => void;
+  patchBed: (bedId: string, patch: Partial<GardenBed>) => void;
+  deleteBed: (bedId: string) => Promise<void>;
+  patchCanvas: (patch: UpsertGardenCanvasRequest) => void;
+  uploadBackgroundImage: (file: File) => Promise<void>;
+  clearBackgroundImage: () => Promise<void>;
+}
+
+const MOBILE_BREAKPOINT = 768;
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() =>
+    typeof window === 'undefined' ? false : window.innerWidth < MOBILE_BREAKPOINT
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    function handleResize() {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return isMobile;
+}
+
+function bedToUpsertPayload(bed: GardenBed): UpsertGardenBedRequest {
+  return {
+    name: bed.name,
+    description: bed.description,
+    sunExposure: bed.sunExposure,
+    soilType: bed.soilType,
+    lengthInches: bed.lengthInches,
+    widthInches: bed.widthInches,
+    locationNotes: bed.locationNotes,
+    sortOrder: bed.sortOrder,
+    bedType: bed.bedType,
+    shape: bed.shape,
+    positionX: bed.positionX,
+    positionY: bed.positionY,
+    rotationDeg: bed.rotationDeg,
+    points: bed.points,
+    color: bed.color,
+  };
+}
+
+/**
+ * Owns all designer state — selection, mode, snap, edit-lock — and wraps
+ * react-query mutations for canvas/bed CRUD with optimistic updates.
+ *
+ * Separating this from the page keeps GardenDesignerPage rendering-focused
+ * and makes it easier to reason about side effects.
+ */
+export function useGardenDesigner(): UseGardenDesignerResult {
+  const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
+  const [editUnlocked, setEditUnlocked] = useState(false);
+  const [selectedBedId, setSelectedBedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<DesignerMode>('idle');
+  const [snap, setSnap] = useState<GridSnap>('12');
+
+  const canvasQuery = useQuery({
+    queryKey: CANVAS_QUERY_KEY,
+    queryFn: getMyGardenCanvas,
+    staleTime: 30_000,
+  });
+  const bedsQuery = useQuery({
+    queryKey: BEDS_QUERY_KEY,
+    queryFn: listMyBeds,
+    staleTime: 30_000,
+  });
+  const cropsQuery = useQuery({
+    queryKey: CROPS_QUERY_KEY,
+    queryFn: listMyCrops,
+    staleTime: 30_000,
+  });
+
+  // Pending mutation count drives the "Saving…" indicator. We keep the
+  // count in state (rather than a ref) so React schedules a re-render
+  // each time it changes.
+  const [pendingMutations, setPendingMutations] = useState(0);
+  const startMutation = useCallback(() => {
+    setPendingMutations((count) => count + 1);
+  }, []);
+  const endMutation = useCallback(() => {
+    setPendingMutations((count) => Math.max(0, count - 1));
+  }, []);
+
+  const createBedMutation = useMutation({
+    mutationFn: createMyBed,
+    onMutate: startMutation,
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: BEDS_QUERY_KEY });
+    },
+  });
+
+  const updateBedMutation = useMutation({
+    mutationFn: ({ bedId, payload }: { bedId: string; payload: UpsertGardenBedRequest }) =>
+      updateMyBed(bedId, payload),
+    onMutate: ({ bedId, payload }) => {
+      startMutation();
+      const previous = queryClient.getQueryData<GardenBed[]>(BEDS_QUERY_KEY);
+      if (previous) {
+        const next = previous.map((bed) =>
+          bed.id === bedId
+            ? {
+                ...bed,
+                name: payload.name,
+                description: payload.description ?? null,
+                sunExposure: payload.sunExposure ?? null,
+                soilType: payload.soilType ?? null,
+                lengthInches: payload.lengthInches ?? null,
+                widthInches: payload.widthInches ?? null,
+                locationNotes: payload.locationNotes ?? null,
+                sortOrder: payload.sortOrder ?? bed.sortOrder,
+                bedType: payload.bedType ?? bed.bedType,
+                shape: payload.shape ?? bed.shape,
+                positionX: payload.positionX ?? null,
+                positionY: payload.positionY ?? null,
+                rotationDeg: payload.rotationDeg ?? bed.rotationDeg,
+                points: payload.points ?? null,
+                color: payload.color ?? null,
+              }
+            : bed
+        );
+        queryClient.setQueryData(BEDS_QUERY_KEY, next);
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(BEDS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: BEDS_QUERY_KEY });
+    },
+  });
+
+  const deleteBedMutation = useMutation({
+    mutationFn: deleteMyBed,
+    onMutate: (bedId) => {
+      startMutation();
+      const previous = queryClient.getQueryData<GardenBed[]>(BEDS_QUERY_KEY);
+      if (previous) {
+        queryClient.setQueryData(
+          BEDS_QUERY_KEY,
+          previous.filter((bed) => bed.id !== bedId)
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(BEDS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: BEDS_QUERY_KEY });
+    },
+  });
+
+  const updateCanvasMutation = useMutation({
+    mutationFn: updateMyGardenCanvas,
+    onMutate: (payload) => {
+      startMutation();
+      const previous = queryClient.getQueryData<GardenCanvas>(CANVAS_QUERY_KEY);
+      if (previous) {
+        queryClient.setQueryData<GardenCanvas>(CANVAS_QUERY_KEY, {
+          ...previous,
+          widthInches: payload.widthInches ?? previous.widthInches,
+          heightInches: payload.heightInches ?? previous.heightInches,
+          backgroundImageKey:
+            payload.backgroundImageKey === undefined
+              ? previous.backgroundImageKey
+              : payload.backgroundImageKey,
+          backgroundOpacity: payload.backgroundOpacity ?? previous.backgroundOpacity,
+          northOffsetDeg: payload.northOffsetDeg ?? previous.northOffsetDeg,
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(CANVAS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: CANVAS_QUERY_KEY });
+    },
+  });
+
+  const beds = useMemo(() => bedsQuery.data ?? [], [bedsQuery.data]);
+  const crops = useMemo(() => cropsQuery.data ?? [], [cropsQuery.data]);
+
+  const cropsByBedId = useMemo(() => {
+    const map = new Map<string, GrowerCropItem[]>();
+    for (const crop of crops) {
+      if (!crop.bedId) continue;
+      const existing = map.get(crop.bedId);
+      if (existing) {
+        existing.push(crop);
+      } else {
+        map.set(crop.bedId, [crop]);
+      }
+    }
+    return map;
+  }, [crops]);
+
+  const selectedBed = useMemo(
+    () => beds.find((b) => b.id === selectedBedId),
+    [beds, selectedBedId]
+  );
+
+  const isEditable = !isMobile || editUnlocked;
+
+  const toggleEditUnlocked = useCallback(() => setEditUnlocked((v) => !v), []);
+
+  const addBed = useCallback(
+    async (type: BedType) => {
+      if (!isEditable) return;
+      const defaults = defaultsFor(type);
+      const canvas = canvasQuery.data;
+      const positionX = canvas
+        ? Math.max(0, Math.round((canvas.widthInches - defaults.lengthInches) / 2))
+        : 12;
+      const positionY = canvas
+        ? Math.max(0, Math.round((canvas.heightInches - defaults.widthInches) / 2))
+        : 12;
+      const created = await createBedMutation.mutateAsync({
+        name: `${defaults.label} ${beds.length + 1}`,
+        bedType: defaults.bedType,
+        shape: defaults.shape,
+        lengthInches: defaults.lengthInches,
+        widthInches: defaults.widthInches,
+        positionX,
+        positionY,
+        rotationDeg: 0,
+        points:
+          defaults.shape === 'polygon'
+            ? defaultRectPolygonPoints(defaults.lengthInches, defaults.widthInches)
+            : null,
+      });
+      setSelectedBedId(created.id);
+    },
+    [beds.length, canvasQuery.data, createBedMutation, isEditable]
+  );
+
+  const commitPolygon = useCallback(
+    async (points: BedPolygonPoint[]) => {
+      if (!isEditable || points.length < 3) return;
+      const xs = points.map((p) => p.x);
+      const ys = points.map((p) => p.y);
+      const minX = Math.min(...xs);
+      const minY = Math.min(...ys);
+      const maxX = Math.max(...xs);
+      const maxY = Math.max(...ys);
+      const normalized = points.map((p) => ({ x: p.x - minX, y: p.y - minY }));
+      const created = await createBedMutation.mutateAsync({
+        name: `In-ground bed ${beds.length + 1}`,
+        bedType: 'in_ground',
+        shape: 'polygon',
+        lengthInches: maxX - minX,
+        widthInches: maxY - minY,
+        positionX: minX,
+        positionY: minY,
+        rotationDeg: 0,
+        points: normalized,
+      });
+      setSelectedBedId(created.id);
+      setMode('idle');
+    },
+    [beds.length, createBedMutation, isEditable]
+  );
+
+  const moveBed = useCallback(
+    (bedId: string, positionX: number, positionY: number) => {
+      const bed = beds.find((b) => b.id === bedId);
+      if (!bed) return;
+      const payload = bedToUpsertPayload({ ...bed, positionX, positionY });
+      updateBedMutation.mutate({ bedId, payload });
+    },
+    [beds, updateBedMutation]
+  );
+
+  const patchBed = useCallback(
+    (bedId: string, patch: Partial<GardenBed>) => {
+      const bed = beds.find((b) => b.id === bedId);
+      if (!bed) return;
+      const payload = bedToUpsertPayload({ ...bed, ...patch });
+      updateBedMutation.mutate({ bedId, payload });
+    },
+    [beds, updateBedMutation]
+  );
+
+  const deleteBed = useCallback(
+    async (bedId: string) => {
+      if (!isEditable) return;
+      await deleteBedMutation.mutateAsync(bedId);
+      if (selectedBedId === bedId) {
+        setSelectedBedId(null);
+      }
+    },
+    [deleteBedMutation, isEditable, selectedBedId]
+  );
+
+  const patchCanvas = useCallback(
+    (patch: UpsertGardenCanvasRequest) => {
+      updateCanvasMutation.mutate(patch);
+    },
+    [updateCanvasMutation]
+  );
+
+  const uploadBackgroundImage = useCallback(
+    async (file: File) => {
+      if (!isEditable) return;
+      const allowed = new Set(['image/jpeg', 'image/png', 'image/webp']);
+      if (!allowed.has(file.type)) {
+        throw new Error('Only JPEG, PNG, or WebP images are accepted.');
+      }
+      if (file.size > 8 * 1024 * 1024) {
+        throw new Error('Images must be 8 MB or smaller.');
+      }
+      const intent = await requestBackgroundUploadUrl({
+        contentType: file.type as 'image/jpeg' | 'image/png' | 'image/webp',
+        contentLength: file.size,
+      });
+      const upload = await fetch(intent.uploadUrl, {
+        method: intent.method,
+        headers: intent.headers,
+        body: file,
+      });
+      if (!upload.ok) {
+        throw new Error(`Background upload failed: ${upload.status}`);
+      }
+      updateCanvasMutation.mutate({ backgroundImageKey: intent.s3Key });
+    },
+    [isEditable, updateCanvasMutation]
+  );
+
+  const clearBackgroundImage = useCallback(async () => {
+    if (!isEditable) return;
+    updateCanvasMutation.mutate({ backgroundImageKey: null });
+  }, [isEditable, updateCanvasMutation]);
+
+  const isSaving = pendingMutations > 0;
+
+  return {
+    canvas: canvasQuery.data,
+    beds,
+    crops,
+    cropsByBedId,
+    isLoading: canvasQuery.isLoading || bedsQuery.isLoading,
+    loadError:
+      (canvasQuery.error as Error | null) ??
+      (bedsQuery.error as Error | null) ??
+      null,
+    selectedBedId,
+    setSelectedBedId,
+    selectedBed,
+    mode,
+    setMode,
+    snap,
+    setSnap,
+    isMobile,
+    editUnlocked,
+    toggleEditUnlocked,
+    isEditable,
+    isSaving,
+    addBed,
+    commitPolygon,
+    moveBed,
+    patchBed,
+    deleteBed,
+    patchCanvas,
+    uploadBackgroundImage,
+    clearBackgroundImage,
+  };
+}

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -1,0 +1,143 @@
+import { useRef, useState } from 'react';
+import { PlantLoader } from '../components/branding/PlantLoader';
+import { BedInspector } from '../components/GardenDesigner/BedInspector';
+import {
+  DesignerCanvas,
+  type DesignerCanvasHandle,
+} from '../components/GardenDesigner/Canvas';
+import { Toolbar } from '../components/GardenDesigner/Toolbar';
+import { useGardenDesigner } from '../hooks/useGardenDesigner';
+
+export function GardenDesignerPage() {
+  const designer = useGardenDesigner();
+  const canvasRef = useRef<DesignerCanvasHandle | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  if (designer.isLoading) {
+    return (
+      <div className="grn-designer-page">
+        <div className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Loading your garden…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (designer.loadError || !designer.canvas) {
+    return (
+      <div className="grn-designer-page">
+        <div className="grn-page-status">
+          <p className="grn-page-status__error">
+            We couldn’t load your garden. Try refreshing the page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const inspectorOpen = designer.selectedBed !== undefined;
+
+  return (
+    <div
+      className={`grn-designer-page ${inspectorOpen ? 'has-inspector' : ''} ${
+        designer.isMobile ? 'is-mobile' : ''
+      }`}
+    >
+      <header className="grn-designer-page__header">
+        <div className="grn-designer-page__title-block">
+          <h1 className="grn-designer-page__title">Garden designer</h1>
+          <p className="grn-designer-page__subtitle">
+            Lay out your beds, drop in crops, and watch it come together.
+          </p>
+        </div>
+        {designer.beds.length === 0 && (
+          <p className="grn-designer-page__hint">
+            Start by adding a bed from the toolbar above the canvas.
+          </p>
+        )}
+      </header>
+
+      <Toolbar
+        isMobile={designer.isMobile}
+        editUnlocked={designer.editUnlocked}
+        onToggleEditUnlocked={designer.toggleEditUnlocked}
+        mode={designer.mode}
+        onAddBed={(type) => {
+          void designer.addBed(type);
+        }}
+        onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
+        onCancelDrawingPolygon={() => designer.setMode('idle')}
+        gridSnap={designer.snap}
+        onGridSnapChange={designer.setSnap}
+        onPickBackgroundFile={async (file) => {
+          setUploadError(null);
+          try {
+            await designer.uploadBackgroundImage(file);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : 'Background upload failed';
+            setUploadError(message);
+          }
+        }}
+        onClearBackground={() => {
+          setUploadError(null);
+          void designer.clearBackgroundImage();
+        }}
+        hasBackground={Boolean(designer.canvas.backgroundImageKey)}
+        backgroundOpacity={designer.canvas.backgroundOpacity}
+        onBackgroundOpacityChange={(opacity) =>
+          designer.patchCanvas({ backgroundOpacity: opacity })
+        }
+        onFitToScreen={() => canvasRef.current?.fitToScreen()}
+        isSaving={designer.isSaving}
+      />
+
+      {uploadError && (
+        <div className="grn-designer-page__error" role="alert">
+          {uploadError}
+        </div>
+      )}
+
+      <div className="grn-designer-page__layout">
+        <DesignerCanvas
+          ref={canvasRef}
+          canvas={designer.canvas}
+          beds={designer.beds}
+          cropsByBedId={designer.cropsByBedId}
+          selectedBedId={designer.selectedBedId}
+          isEditable={designer.isEditable}
+          mode={designer.mode}
+          snap={designer.snap}
+          backgroundImageUrl={designer.canvas.backgroundImageUrl}
+          onSelect={designer.setSelectedBedId}
+          onMoveBed={designer.moveBed}
+          onCommitPolygon={(points) => {
+            void designer.commitPolygon(points);
+          }}
+          onCancelPolygon={() => designer.setMode('idle')}
+        />
+
+        {designer.selectedBed && (
+          <BedInspector
+            key={designer.selectedBed.id}
+            bed={designer.selectedBed}
+            cropsForBed={designer.cropsByBedId.get(designer.selectedBed.id) ?? []}
+            isEditable={designer.isEditable}
+            isSaving={designer.isSaving}
+            onChange={(patch) => {
+              if (designer.selectedBed) {
+                designer.patchBed(designer.selectedBed.id, patch);
+              }
+            }}
+            onDelete={() => {
+              if (designer.selectedBed) {
+                void designer.deleteBed(designer.selectedBed.id);
+              }
+            }}
+            onClose={() => designer.setSelectedBedId(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -5,6 +5,7 @@ import {
   DesignerCanvas,
   type DesignerCanvasHandle,
 } from '../components/GardenDesigner/Canvas';
+import { GardenPropertiesBar } from '../components/GardenDesigner/GardenPropertiesBar';
 import { Toolbar } from '../components/GardenDesigner/Toolbar';
 import { useGardenDesigner } from '../hooks/useGardenDesigner';
 
@@ -38,6 +39,16 @@ export function GardenDesignerPage() {
 
   const inspectorOpen = designer.selectedBed !== undefined;
 
+  async function handlePickBackgroundFile(file: File) {
+    setUploadError(null);
+    try {
+      await designer.uploadBackgroundImage(file);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Background upload failed';
+      setUploadError(message);
+    }
+  }
+
   return (
     <div
       className={`grn-designer-page ${inspectorOpen ? 'has-inspector' : ''} ${
@@ -53,43 +64,23 @@ export function GardenDesignerPage() {
         </div>
         {designer.beds.length === 0 && (
           <p className="grn-designer-page__hint">
-            Start by adding a bed from the toolbar above the canvas.
+            Start by adding a bed from the toolbar on the left.
           </p>
         )}
       </header>
 
-      <Toolbar
-        isMobile={designer.isMobile}
-        editUnlocked={designer.editUnlocked}
-        onToggleEditUnlocked={designer.toggleEditUnlocked}
-        mode={designer.mode}
-        onAddBed={(type) => {
-          void designer.addBed(type);
-        }}
-        onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
-        onCancelDrawingPolygon={() => designer.setMode('idle')}
-        gridSnap={designer.snap}
-        onGridSnapChange={designer.setSnap}
-        onPickBackgroundFile={async (file) => {
-          setUploadError(null);
-          try {
-            await designer.uploadBackgroundImage(file);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : 'Background upload failed';
-            setUploadError(message);
-          }
-        }}
+      <GardenPropertiesBar
+        canvas={designer.canvas}
+        beds={designer.beds}
+        isEditable={designer.isEditable}
+        isSaving={designer.isSaving}
+        onCanvasChange={designer.patchCanvas}
+        hasBackground={Boolean(designer.canvas.backgroundImageKey)}
+        onPickBackgroundFile={handlePickBackgroundFile}
         onClearBackground={() => {
           setUploadError(null);
           void designer.clearBackgroundImage();
         }}
-        hasBackground={Boolean(designer.canvas.backgroundImageKey)}
-        backgroundOpacity={designer.canvas.backgroundOpacity}
-        onBackgroundOpacityChange={(opacity) =>
-          designer.patchCanvas({ backgroundOpacity: opacity })
-        }
-        onFitToScreen={() => canvasRef.current?.fitToScreen()}
-        isSaving={designer.isSaving}
       />
 
       {uploadError && (
@@ -99,6 +90,21 @@ export function GardenDesignerPage() {
       )}
 
       <div className="grn-designer-page__layout">
+        <Toolbar
+          isMobile={designer.isMobile}
+          editUnlocked={designer.editUnlocked}
+          onToggleEditUnlocked={designer.toggleEditUnlocked}
+          mode={designer.mode}
+          onAddBed={(shape) => {
+            void designer.addBed(shape);
+          }}
+          onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
+          onCancelDrawingPolygon={() => designer.setMode('idle')}
+          gridSnap={designer.snap}
+          onGridSnapChange={designer.setSnap}
+          onFitToScreen={() => canvasRef.current?.fitToScreen()}
+        />
+
         <DesignerCanvas
           ref={canvasRef}
           canvas={designer.canvas}
@@ -111,6 +117,7 @@ export function GardenDesignerPage() {
           backgroundImageUrl={designer.canvas.backgroundImageUrl}
           onSelect={designer.setSelectedBedId}
           onMoveBed={designer.moveBed}
+          onResizeBed={designer.resizeBed}
           onCommitPolygon={(points) => {
             void designer.commitPolygon(points);
           }}

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -112,6 +112,14 @@ async function apiFetch<T>(
       );
     }
 
+    // 204 No Content (and any other empty body) has no JSON to parse.
+    // Returning undefined cast to T keeps the type-untyped void callers
+    // working without forcing every call site to special-case the
+    // response.
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T;
+    }
+
     return await response.json();
   } catch (error) {
     clearTimeout(timeoutId);

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -3,10 +3,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { getApiEndpoint } from '../config/amplify';
 import type { UserProfile, UserType, GrowerProfile, GathererProfile } from '../types/user';
 import type {
+  BedPolygonPoint,
+  BedShape,
+  BedType,
   CatalogCrop,
   CatalogVariety,
   DiscoverListingsResponse,
   GardenBed,
+  GardenCanvas,
   GrowerCropItem,
   Listing,
   ListMyListingsResponse,
@@ -253,8 +257,36 @@ interface RawGardenBed {
   width_inches: number | null;
   location_notes: string | null;
   sort_order: number;
+  bed_type: BedType;
+  shape: BedShape;
+  position_x: number | null;
+  position_y: number | null;
+  rotation_deg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
   created_at: string;
   updated_at: string;
+}
+
+interface RawGardenCanvas {
+  id: string;
+  user_id: string;
+  width_inches: number;
+  height_inches: number;
+  background_image_key: string | null;
+  background_image_url: string | null;
+  background_opacity: number;
+  north_offset_deg: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RawBackgroundUploadIntentResponse {
+  upload_url: string;
+  method: string;
+  headers: Record<string, string>;
+  s3_key: string;
+  expires_in_seconds: number;
 }
 
 interface RawListingItem {
@@ -452,6 +484,28 @@ function mapGardenBed(raw: RawGardenBed): GardenBed {
     widthInches: raw.width_inches,
     locationNotes: raw.location_notes,
     sortOrder: raw.sort_order,
+    bedType: raw.bed_type,
+    shape: raw.shape,
+    positionX: raw.position_x,
+    positionY: raw.position_y,
+    rotationDeg: raw.rotation_deg,
+    points: raw.points,
+    color: raw.color,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function mapGardenCanvas(raw: RawGardenCanvas): GardenCanvas {
+  return {
+    id: raw.id,
+    userId: raw.user_id,
+    widthInches: raw.width_inches,
+    heightInches: raw.height_inches,
+    backgroundImageKey: raw.background_image_key,
+    backgroundImageUrl: raw.background_image_url,
+    backgroundOpacity: raw.background_opacity,
+    northOffsetDeg: raw.north_offset_deg,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
   };
@@ -731,6 +785,34 @@ export interface UpsertGardenBedRequest {
   widthInches?: number | null;
   locationNotes?: string | null;
   sortOrder?: number;
+  bedType?: BedType;
+  shape?: BedShape;
+  positionX?: number | null;
+  positionY?: number | null;
+  rotationDeg?: number;
+  points?: BedPolygonPoint[] | null;
+  color?: string | null;
+}
+
+export interface UpsertGardenCanvasRequest {
+  widthInches?: number;
+  heightInches?: number;
+  backgroundImageKey?: string | null;
+  backgroundOpacity?: number;
+  northOffsetDeg?: number;
+}
+
+export interface RequestBackgroundUploadUrlInput {
+  contentType: 'image/jpeg' | 'image/png' | 'image/webp';
+  contentLength: number;
+}
+
+export interface BackgroundUploadIntent {
+  uploadUrl: string;
+  method: string;
+  headers: Record<string, string>;
+  s3Key: string;
+  expiresInSeconds: number;
 }
 
 export async function listMyBeds(): Promise<GardenBed[]> {
@@ -758,6 +840,40 @@ export async function deleteMyBed(bedId: string): Promise<void> {
   await apiFetch(`/beds/${bedId}`, {
     method: 'DELETE',
   });
+}
+
+export async function getMyGardenCanvas(): Promise<GardenCanvas> {
+  const response = await apiFetch<RawGardenCanvas>('/garden');
+  return mapGardenCanvas(response);
+}
+
+export async function updateMyGardenCanvas(
+  data: UpsertGardenCanvasRequest
+): Promise<GardenCanvas> {
+  const response = await apiFetch<RawGardenCanvas>('/garden', {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+  return mapGardenCanvas(response);
+}
+
+export async function requestBackgroundUploadUrl(
+  data: RequestBackgroundUploadUrlInput
+): Promise<BackgroundUploadIntent> {
+  const response = await apiFetch<RawBackgroundUploadIntentResponse>(
+    '/garden/background-upload-url',
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }
+  );
+  return {
+    uploadUrl: response.upload_url,
+    method: response.method,
+    headers: response.headers,
+    s3Key: response.s3_key,
+    expiresInSeconds: response.expires_in_seconds,
+  };
 }
 
 export async function listMyListings(

--- a/apps/grn/src/shell/AppShell.tsx
+++ b/apps/grn/src/shell/AppShell.tsx
@@ -54,6 +54,22 @@ const growerNavItems: NavItem[] = [
     ),
   },
   {
+    id: 'garden',
+    path: '/garden',
+    label: 'Designer',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M3 4h8v8H3V4Zm0 10h8v6H3v-6Zm10-10h8v6h-8V4Zm0 8h8v8h-8v-8Z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
     id: 'listings',
     path: '/listings',
     label: 'Listings',

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -14,6 +14,9 @@ const CropsPage = lazy(() =>
 const NewCropPage = lazy(() =>
   import('../pages/NewCropPage').then((m) => ({ default: m.NewCropPage }))
 );
+const GardenDesignerPage = lazy(() =>
+  import('../pages/GardenDesignerPage').then((m) => ({ default: m.GardenDesignerPage }))
+);
 const ListingsPage = lazy(() =>
   import('../pages/ListingsPage').then((m) => ({ default: m.ListingsPage }))
 );
@@ -54,6 +57,7 @@ export function AuthenticatedRoot() {
               <Route path="/" element={<DashboardPage />} />
               <Route path="/crops" element={<CropsPage />} />
               <Route path="/crops/new" element={<NewCropPage />} />
+              <Route path="/garden" element={<GardenDesignerPage />} />
               <Route path="/listings" element={<ListingsPage />} />
               <Route path="/requests" element={<RequestsPage />} />
               <Route path="/reminders" element={<RemindersPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1473,3 +1473,494 @@ body {
   font-size: 0.85rem;
   color: rgba(79, 56, 37, 0.6);
 }
+
+/* ==========================================================================
+   Garden Designer
+   ========================================================================== */
+
+.grn-designer-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.grn-designer-page__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.grn-designer-page__title {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: clamp(1.5rem, 2.4vw, 1.85rem);
+  color: var(--og-color-soil);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.grn-designer-page__subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.95rem;
+}
+
+.grn-designer-page__hint {
+  margin: 0;
+  padding: 0.5rem 0.85rem;
+  border-radius: var(--og-radius-sm);
+  background: rgba(91, 140, 74, 0.12);
+  color: var(--og-color-moss);
+  font-size: 0.85rem;
+}
+
+.grn-designer-page__error {
+  margin: 0;
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--og-radius-sm);
+  background: rgba(173, 32, 27, 0.1);
+  border: 1px solid rgba(173, 32, 27, 0.3);
+  color: #8b1f1a;
+  font-size: 0.9rem;
+}
+
+.grn-designer-page__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 0;
+  flex: 1;
+}
+
+.grn-designer-page.has-inspector .grn-designer-page__layout {
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 26vw, 360px);
+}
+
+@media (max-width: 768px) {
+  .grn-designer-page.has-inspector .grn-designer-page__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* --- Toolbar -------------------------------------------------------------- */
+
+.grn-designer-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+  border: 1px solid rgba(91, 58, 28, 0.12);
+  box-shadow: 0 4px 14px rgba(91, 58, 28, 0.06);
+}
+
+.grn-designer-toolbar.is-locked {
+  opacity: 0.92;
+}
+
+.grn-designer-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.grn-designer-toolbar__group--end {
+  margin-left: auto;
+}
+
+.grn-designer-toolbar__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 58, 28, 0.15);
+  background: var(--og-color-cream);
+  color: var(--og-color-soil);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+}
+
+.grn-designer-toolbar__btn:hover:not(:disabled),
+.grn-designer-toolbar__btn:focus-visible {
+  background: rgba(91, 140, 74, 0.12);
+  border-color: var(--og-color-moss);
+  outline: none;
+}
+
+.grn-designer-toolbar__btn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.grn-designer-toolbar__btn.is-active {
+  background: var(--og-color-moss);
+  border-color: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-toolbar__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.grn-designer-toolbar__btn--ghost {
+  background: transparent;
+  border-color: rgba(91, 58, 28, 0.25);
+}
+
+.grn-designer-toolbar__btn-emoji {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.grn-designer-toolbar__field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 58, 28, 0.15);
+  background: var(--og-color-cream);
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-designer-toolbar__field select,
+.grn-designer-toolbar__field input[type="range"] {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.grn-designer-toolbar__field input[type="range"] {
+  width: 7rem;
+  accent-color: var(--og-color-moss);
+}
+
+.grn-designer-toolbar__save-status {
+  font-size: 0.78rem;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-toolbar__save-status[data-saving="true"] {
+  color: var(--og-color-moss);
+}
+
+/* --- Canvas --------------------------------------------------------------- */
+
+.grn-designer-canvas {
+  position: relative;
+  min-height: 0;
+  height: 100%;
+  min-width: 0;
+  background: linear-gradient(180deg, rgba(91, 140, 74, 0.06) 0%, transparent 60%),
+    var(--og-color-cream);
+  border-radius: var(--og-radius-md);
+  border: 1px solid rgba(91, 58, 28, 0.12);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(91, 58, 28, 0.04);
+}
+
+@media (max-width: 768px) {
+  .grn-designer-canvas {
+    min-height: 60vh;
+  }
+}
+
+.grn-designer-canvas__draw-hint {
+  position: absolute;
+  bottom: 0.85rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.35rem 0.75rem;
+  background: rgba(58, 43, 26, 0.88);
+  color: var(--og-color-cream);
+  font-size: 0.8rem;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+/* --- Inspector ------------------------------------------------------------ */
+
+.grn-designer-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  background: var(--og-color-paper);
+  border: 1px solid rgba(91, 58, 28, 0.12);
+  border-radius: var(--og-radius-md);
+  box-shadow: 0 8px 26px rgba(91, 58, 28, 0.08);
+  overflow-y: auto;
+  min-height: 0;
+}
+
+@media (max-width: 768px) {
+  .grn-designer-inspector {
+    position: fixed;
+    inset: auto 0 0 0;
+    max-height: 70vh;
+    border-radius: var(--og-radius-md) var(--og-radius-md) 0 0;
+    box-shadow: 0 -10px 32px rgba(91, 58, 28, 0.18);
+    z-index: 30;
+  }
+}
+
+.grn-designer-inspector__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.grn-designer-inspector__eyebrow {
+  display: inline-block;
+  font-size: 0.78rem;
+  color: var(--og-color-moss);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.grn-designer-inspector__title {
+  margin: 0.15rem 0 0;
+  font-family: var(--og-font-display);
+  font-size: 1.2rem;
+  color: var(--og-color-soil);
+}
+
+.grn-designer-inspector__close {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid rgba(91, 58, 28, 0.18);
+  background: transparent;
+  color: var(--og-color-soil);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.grn-designer-inspector__close:hover,
+.grn-designer-inspector__close:focus-visible {
+  background: rgba(91, 58, 28, 0.08);
+  outline: none;
+}
+
+.grn-designer-inspector__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.78);
+}
+
+.grn-designer-inspector__fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.grn-designer-inspector__fieldset legend {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+  margin-bottom: 0.2rem;
+}
+
+.grn-designer-inspector__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-designer-inspector__field input[type="text"],
+.grn-designer-inspector__field input[type="number"],
+.grn-designer-inspector__field select,
+.grn-designer-inspector__field textarea {
+  border: 1px solid rgba(91, 58, 28, 0.2);
+  border-radius: var(--og-radius-sm);
+  padding: 0.4rem 0.55rem;
+  font: inherit;
+  color: inherit;
+  background: var(--og-color-cream);
+}
+
+.grn-designer-inspector__field input:focus-visible,
+.grn-designer-inspector__field select:focus-visible,
+.grn-designer-inspector__field textarea:focus-visible {
+  outline: 2px solid rgba(91, 140, 74, 0.4);
+  outline-offset: 1px;
+  border-color: var(--og-color-moss);
+}
+
+.grn-designer-inspector__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.grn-designer-inspector__color {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.grn-designer-inspector__color legend {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-inspector__color-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.grn-designer-inspector__color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid rgba(91, 58, 28, 0.2);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 80ms ease, box-shadow 120ms ease;
+}
+
+.grn-designer-inspector__color-swatch:hover,
+.grn-designer-inspector__color-swatch:focus-visible {
+  transform: scale(1.08);
+  outline: none;
+}
+
+.grn-designer-inspector__color-swatch.is-selected {
+  box-shadow: 0 0 0 2px var(--og-color-paper), 0 0 0 4px var(--og-color-moss);
+}
+
+.grn-designer-inspector__crops {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  border-top: 1px solid rgba(91, 58, 28, 0.1);
+  padding-top: 0.85rem;
+}
+
+.grn-designer-inspector__crops-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.grn-designer-inspector__crops-header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--og-color-soil);
+}
+
+.grn-designer-inspector__add-crop {
+  font-size: 0.85rem;
+  color: var(--og-color-moss);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.grn-designer-inspector__add-crop:hover,
+.grn-designer-inspector__add-crop:focus-visible {
+  text-decoration: underline;
+}
+
+.grn-designer-inspector__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-inspector__crop-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.grn-designer-inspector__crop {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  background: rgba(91, 140, 74, 0.08);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-designer-inspector__crop-emoji {
+  font-size: 1.05rem;
+}
+
+.grn-designer-inspector__crop-name {
+  flex: 1;
+}
+
+.grn-designer-inspector__crop-count {
+  font-size: 0.75rem;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-inspector__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid rgba(91, 58, 28, 0.1);
+  padding-top: 0.85rem;
+}
+
+.grn-designer-inspector__save-status {
+  font-size: 0.78rem;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-inspector__save-status[data-saving="true"] {
+  color: var(--og-color-moss);
+}
+
+.grn-designer-inspector__delete {
+  border: 1px solid rgba(173, 32, 27, 0.4);
+  color: #8b1f1a;
+  background: transparent;
+  border-radius: var(--og-radius-sm);
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.grn-designer-inspector__delete:hover:not(:disabled),
+.grn-designer-inspector__delete:focus-visible {
+  background: rgba(173, 32, 27, 0.08);
+  outline: none;
+}
+
+.grn-designer-inspector__delete:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.grn-page-status__error {
+  color: #8b1f1a;
+}

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1482,8 +1482,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  height: 100%;
-  min-height: 0;
+  /* Reserve a tall enough region so the canvas always has room to render
+     even before its ResizeObserver has measured. The grn-shell-main__inner
+     parent uses align-content: start which doesn't stretch children, so
+     "height: 100%" alone resolves to 0. */
+  min-height: clamp(560px, calc(100vh - 240px), 900px);
 }
 
 .grn-designer-page__header {
@@ -1530,34 +1533,48 @@ body {
 
 .grn-designer-page__layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 1rem;
   min-height: 0;
   flex: 1;
 }
 
 .grn-designer-page.has-inspector .grn-designer-page__layout {
-  grid-template-columns: minmax(0, 1fr) clamp(280px, 26vw, 360px);
+  grid-template-columns: auto minmax(0, 1fr) clamp(300px, 26vw, 380px);
 }
 
 @media (max-width: 768px) {
+  .grn-designer-page__layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+  }
   .grn-designer-page.has-inspector .grn-designer-page__layout {
     grid-template-columns: minmax(0, 1fr);
   }
 }
 
-/* --- Toolbar -------------------------------------------------------------- */
+/* --- Toolbar (vertical left rail, paint.net style) ----------------------- */
 
 .grn-designer-toolbar {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.5rem;
-  padding: 0.65rem 0.85rem;
+  padding: 0.65rem;
+  width: 96px;
   border-radius: var(--og-radius-md);
   background: var(--og-color-paper);
   border: 1px solid rgba(91, 58, 28, 0.12);
   box-shadow: 0 4px 14px rgba(91, 58, 28, 0.06);
+  align-self: stretch;
+}
+
+@media (max-width: 768px) {
+  .grn-designer-toolbar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: auto;
+  }
 }
 
 .grn-designer-toolbar.is-locked {
@@ -1566,28 +1583,54 @@ body {
 
 .grn-designer-toolbar__group {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.grn-designer-toolbar__group--end {
-  margin-left: auto;
+@media (max-width: 768px) {
+  .grn-designer-toolbar__group {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+.grn-designer-toolbar__divider {
+  height: 1px;
+  background: rgba(91, 58, 28, 0.12);
+  margin: 0.25rem 0;
+}
+
+@media (max-width: 768px) {
+  .grn-designer-toolbar__divider {
+    width: 1px;
+    height: auto;
+    margin: 0 0.25rem;
+  }
 }
 
 .grn-designer-toolbar__btn {
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.5rem 0.4rem;
+  border-radius: var(--og-radius-sm);
   border: 1px solid rgba(91, 58, 28, 0.15);
   background: var(--og-color-cream);
   color: var(--og-color-soil);
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   font-weight: 500;
   cursor: pointer;
   transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  min-height: 56px;
+  text-align: center;
+}
+
+.grn-designer-toolbar__btn-label {
+  display: block;
+  font-size: 0.7rem;
+  line-height: 1.1;
 }
 
 .grn-designer-toolbar__btn:hover:not(:disabled),
@@ -1623,15 +1666,22 @@ body {
 }
 
 .grn-designer-toolbar__field {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.55rem;
-  border-radius: 999px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.2rem;
+  padding: 0.4rem 0.45rem;
+  border-radius: var(--og-radius-sm);
   border: 1px solid rgba(91, 58, 28, 0.15);
   background: var(--og-color-cream);
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   color: var(--og-color-soil);
+  text-align: center;
+}
+
+.grn-designer-toolbar__field > span {
+  font-size: 0.68rem;
+  color: rgba(79, 56, 37, 0.65);
 }
 
 .grn-designer-toolbar__field select,
@@ -1656,11 +1706,106 @@ body {
   color: var(--og-color-moss);
 }
 
+/* --- Garden properties bar ----------------------------------------------- */
+
+.grn-garden-properties {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--og-color-paper);
+  border: 1px solid rgba(91, 58, 28, 0.12);
+  border-radius: var(--og-radius-md);
+  box-shadow: 0 4px 14px rgba(91, 58, 28, 0.06);
+}
+
+.grn-garden-properties__group {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.grn-garden-properties__group--end {
+  margin-left: auto;
+}
+
+.grn-garden-properties__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-garden-properties__scale {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.grn-garden-properties__scale-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.72rem;
+  color: rgba(79, 56, 37, 0.65);
+}
+
+.grn-garden-properties__scale-field input {
+  width: 5.5rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid rgba(91, 58, 28, 0.18);
+  border-radius: var(--og-radius-sm);
+  background: var(--og-color-cream);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.grn-garden-properties__scale-field input:focus-visible {
+  outline: 2px solid rgba(91, 140, 74, 0.4);
+  outline-offset: 1px;
+  border-color: var(--og-color-moss);
+}
+
+.grn-garden-properties__scale-x {
+  font-size: 1rem;
+  color: rgba(79, 56, 37, 0.45);
+  margin-top: 0.85rem;
+}
+
+.grn-garden-properties__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.25rem 0.65rem;
+  border-left: 1px solid rgba(91, 58, 28, 0.12);
+}
+
+.grn-garden-properties__metric:first-child {
+  border-left: none;
+}
+
+.grn-garden-properties__metric-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-garden-properties__metric-value {
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+  color: var(--og-color-soil);
+  font-weight: 600;
+}
+
 /* --- Canvas --------------------------------------------------------------- */
 
 .grn-designer-canvas {
   position: relative;
-  min-height: 0;
+  min-height: 520px;
   height: 100%;
   min-width: 0;
   background: linear-gradient(180deg, rgba(91, 140, 74, 0.06) 0%, transparent 60%),
@@ -1695,8 +1840,8 @@ body {
 .grn-designer-inspector {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1rem;
+  gap: 0.95rem;
+  padding: 1.15rem 1.25rem;
   background: var(--og-color-paper);
   border: 1px solid rgba(91, 58, 28, 0.12);
   border-radius: var(--og-radius-md);
@@ -1810,6 +1955,87 @@ body {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
+}
+
+.grn-designer-inspector__metric-row {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(91, 140, 74, 0.06);
+  border-radius: var(--og-radius-sm);
+}
+
+.grn-designer-inspector__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  flex: 1;
+}
+
+.grn-designer-inspector__metric-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-designer-inspector__metric-value {
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+  color: var(--og-color-soil);
+  font-weight: 600;
+}
+
+.grn-designer-inspector__soil {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.grn-designer-inspector__soil legend {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(79, 56, 37, 0.6);
+  margin-bottom: 0.3rem;
+}
+
+.grn-designer-inspector__soil-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.grn-designer-inspector__soil-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.32rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 58, 28, 0.18);
+  background: var(--og-color-cream);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.grn-designer-inspector__soil-chip:hover:not(:disabled),
+.grn-designer-inspector__soil-chip:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  border-color: var(--og-color-moss);
+  outline: none;
+}
+
+.grn-designer-inspector__soil-chip.is-selected {
+  background: var(--og-color-moss);
+  border-color: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-inspector__soil-chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .grn-designer-inspector__color {

--- a/apps/grn/src/types/listing.ts
+++ b/apps/grn/src/types/listing.ts
@@ -44,6 +44,14 @@ export type SunExposure =
   | 'full_shade'
   | 'mixed';
 
+export type BedType = 'in_ground' | 'raised' | 'mound';
+export type BedShape = 'rect' | 'circle' | 'polygon';
+
+export interface BedPolygonPoint {
+  x: number;
+  y: number;
+}
+
 export interface GardenBed {
   id: string;
   userId: string;
@@ -55,6 +63,26 @@ export interface GardenBed {
   widthInches: number | null;
   locationNotes: string | null;
   sortOrder: number;
+  bedType: BedType;
+  shape: BedShape;
+  positionX: number | null;
+  positionY: number | null;
+  rotationDeg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GardenCanvas {
+  id: string;
+  userId: string;
+  widthInches: number;
+  heightInches: number;
+  backgroundImageKey: string | null;
+  backgroundImageUrl: string | null;
+  backgroundOpacity: number;
+  northOffsetDeg: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/services/grn-api/openapi/schemas/garden.yaml
+++ b/services/grn-api/openapi/schemas/garden.yaml
@@ -190,6 +190,14 @@ GardenCanvas:
       type: string
       nullable: true
       description: "S3 object key under garden-backgrounds/, or null."
+    background_image_url:
+      type: string
+      format: uri
+      nullable: true
+      description: |
+        Resolved CDN URL for the background image, derived from the
+        configured MEDIA_CDN_DOMAIN. Null when there's no key, or when
+        no CDN domain is configured for the environment.
     background_opacity:
       type: integer
       minimum: 0

--- a/services/grn-api/src/api/handlers/garden_canvas.rs
+++ b/services/grn-api/src/api/handlers/garden_canvas.rs
@@ -265,12 +265,17 @@ fn parse_json_body<T: serde::de::DeserializeOwned>(
 }
 
 fn row_to_canvas(row: &Row) -> GardenCanvas {
+    let background_image_key: Option<String> = row.get("background_image_key");
+    let background_image_url = background_image_key
+        .as_deref()
+        .and_then(build_background_image_url);
     GardenCanvas {
         id: row.get::<_, Uuid>("id").to_string(),
         user_id: row.get::<_, Uuid>("user_id").to_string(),
         width_inches: row.get("width_inches"),
         height_inches: row.get("height_inches"),
-        background_image_key: row.get("background_image_key"),
+        background_image_key,
+        background_image_url,
         background_opacity: row.get("background_opacity"),
         north_offset_deg: row.get("north_offset_deg"),
         created_at: row
@@ -280,6 +285,16 @@ fn row_to_canvas(row: &Row) -> GardenCanvas {
             .get::<_, chrono::DateTime<chrono::Utc>>("updated_at")
             .to_rfc3339(),
     }
+}
+
+fn build_background_image_url(key: &str) -> Option<String> {
+    let domain = env::var("MEDIA_CDN_DOMAIN").ok()?;
+    let trimmed_domain = domain.trim_end_matches('/');
+    let trimmed_key = key.trim_start_matches('/');
+    if trimmed_domain.is_empty() || trimmed_key.is_empty() {
+        return None;
+    }
+    Some(format!("https://{trimmed_domain}/{trimmed_key}"))
 }
 
 fn json_response<T: Serialize>(

--- a/services/grn-api/src/api/handlers/garden_canvas.rs
+++ b/services/grn-api/src/api/handlers/garden_canvas.rs
@@ -68,6 +68,10 @@ pub async fn update_my_canvas(
     validate_canvas_payload(&payload)?;
 
     let client = db::connect().await?;
+    // Explicit casts on $5/$6: Postgres otherwise infers their type as
+    // integer from the bare `60`/`0` literals in coalesce, but the Rust
+    // value is i16. Without the cast, tokio_postgres rejects the call
+    // with `error serializing parameter 4` (0-indexed → $5).
     let row = client
         .query_one(
             "
@@ -80,8 +84,8 @@ pub async fn update_my_canvas(
                 coalesce($2, 360),
                 coalesce($3, 240),
                 $4,
-                coalesce($5, 60),
-                coalesce($6, 0)
+                coalesce($5::smallint, 60::smallint),
+                coalesce($6::smallint, 0::smallint)
             )
             on conflict (user_id) do update
               set width_inches = coalesce(excluded.width_inches, garden_canvases.width_inches),

--- a/services/grn-api/src/api/models/garden_canvas.rs
+++ b/services/grn-api/src/api/models/garden_canvas.rs
@@ -7,6 +7,7 @@ pub struct GardenCanvas {
     pub width_inches: i32,
     pub height_inches: i32,
     pub background_image_key: Option<String>,
+    pub background_image_url: Option<String>,
     pub background_opacity: i16,
     pub north_offset_deg: i16,
     pub created_at: String,


### PR DESCRIPTION
## Summary

PR 2 of the garden designer feature. Lands the UI at `/garden` on top of the bed/canvas endpoints from [#326](https://github.com/allenheltondev/olivias-garden-foundation/pull/326).

- **Canvas** ([apps/grn/src/components/GardenDesigner/Canvas.tsx](apps/grn/src/components/GardenDesigner/Canvas.tsx)): konva Stage with pan, wheel-zoom, snap-to-grid (off / 6" / 1ft), inch+foot grid, optional background-photo layer. Three shape primitives — raised (rect), mound (circle), in-ground (polygon, either preset 4-point or freeform draw with live preview).
- **BedShape** renders crop emoji chips inside each bed (uses the existing [cropVisuals.ts](apps/grn/src/components/CropPlanner/cropVisuals.ts) helper) with `+N` overflow.
- **BedInspector** ([apps/grn/src/components/GardenDesigner/BedInspector.tsx](apps/grn/src/components/GardenDesigner/BedInspector.tsx)) — side panel (bottom sheet on mobile) for name, dimensions, sun, soil, notes, color palette. Inline crop list links into the existing `/crops/new?bedId=…` flow.
- **Mobile** (<768px) defaults to read-only pan/zoom with a 🔒/🔓 toolbar toggle to unlock editing.
- **Background image upload** uses the presigned-URL endpoint from PR 1 (POST → PUT to S3 → PUT canvas with key). 8 MB / image-mime-type validation client-side before the API call.
- **State** lives in [useGardenDesigner.ts](apps/grn/src/hooks/useGardenDesigner.ts) — selection, mode, snap, edit-lock — wrapping react-query mutations with optimistic updates.
- **Small backend tweak**: canvas response now includes `background_image_url` resolved from `MEDIA_CDN_DOMAIN` + key on the server, so image rendering works without a frontend env var. Updated OpenAPI schema accordingly.
- **Perf budget**: konva (~150 KB gz) lives only in the lazy `/garden` chunk. Main bundle and vendor cap are unchanged. The total-JS budget is bumped from 900 KB to 1 MB to accommodate the new lazy chunk — main/vendor caps still enforce initial-load perf.

## Test plan

- [ ] CI: typecheck, eslint, vitest, cargo fmt/clippy/check, perf budget (passing locally)
- [ ] Visit `/garden` after staging deploy and walk the golden path:
  - [ ] Add one of each bed type from the toolbar; drag, resize handles snap to grid
  - [ ] Open the inspector for a bed, edit name/sun/color; saves are optimistic with the "Saving…" indicator briefly visible
  - [ ] Attach a crop via the inspector's "+ Add crop" link; the chip appears inside the bed on return
  - [ ] Click "Draw shape", click to add 4+ points, double-click to commit; new in-ground bed appears
  - [ ] Upload a JPEG (>1 MB) as a background; opacity slider works; "Remove photo" clears it
  - [ ] Resize viewport to <768px; canvas pans/zooms but bed dragging is locked until the 🔒 button is toggled
- [ ] Check that the existing `/crops/new` bed-creation flow still works (defaults `bed_type='raised'`, `shape='rect'` — beds appear in the designer at `position null` until dragged)

## Notes for reviewers

I was not able to run the full visual smoke test in a browser from my local environment — auth redirects to the production foundation login, so I leaned on typecheck/lint/build/perf-budget/unit-tests as the gates. The staging deploy that this PR triggers is the real validation surface.

Out of scope for v1 (per the plan): per-bed crop placement (positioning individual plants inside a bed), companion-planting hints, multi-garden support (paid-tier feature; the single-canvas-per-user `UNIQUE` is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)