### PR TITLE
GRN: garden annotations (non-bed objects on the designer canvas)

### DIFF
--- a/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import type { GardenAnnotation } from '../../types/listing';
+import { BED_COLOR_PALETTE } from './bedDefaults';
+
+interface AnnotationInspectorProps {
+  annotation: GardenAnnotation;
+  isEditable: boolean;
+  isSaving: boolean;
+  onChange: (patch: Partial<GardenAnnotation>) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function AnnotationInspector({
+  annotation,
+  isEditable,
+  isSaving,
+  onChange,
+  onDelete,
+  onClose,
+}: AnnotationInspectorProps) {
+  // Parent re-keys on annotation.id, so initial state matches the current
+  // selection without a syncing effect.
+  const [label, setLabel] = useState(annotation.label);
+  const [icon, setIcon] = useState(annotation.icon ?? '');
+  const [length, setLength] = useState<number | ''>(annotation.lengthInches ?? '');
+  const [width, setWidth] = useState<number | ''>(annotation.widthInches ?? '');
+  const [color, setColor] = useState<string | null>(annotation.color);
+
+  function commit(patch: Partial<GardenAnnotation>) {
+    if (!isEditable) return;
+    onChange(patch);
+  }
+
+  return (
+    <aside className="grn-designer-inspector" aria-label={`${annotation.label} details`}>
+      <header className="grn-designer-inspector__header">
+        <div>
+          <span className="grn-designer-inspector__eyebrow">
+            {icon || '📍'} Annotation · {annotation.shape}
+          </span>
+          <h2 className="grn-designer-inspector__title">{label || 'Untitled'}</h2>
+        </div>
+        <button
+          type="button"
+          className="grn-designer-inspector__close"
+          aria-label="Close inspector"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </header>
+
+      <p className="grn-designer-inspector__description">
+        Annotations are visual context only — they aren’t beds, so they don’t
+        carry soil or crop data.
+      </p>
+
+      <fieldset className="grn-designer-inspector__fieldset" disabled={!isEditable}>
+        <legend>Details</legend>
+
+        <label className="grn-designer-inspector__field">
+          <span>Label</span>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onBlur={() => label.trim() && commit({ label: label.trim() })}
+            maxLength={80}
+          />
+        </label>
+
+        <label className="grn-designer-inspector__field">
+          <span>Icon</span>
+          <input
+            type="text"
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            onBlur={() => commit({ icon: icon.trim() || null })}
+            maxLength={32}
+            placeholder="e.g. 🌳, 💧, 🏚️"
+          />
+        </label>
+
+        {annotation.shape !== 'circle' && annotation.shape !== 'line' && (
+          <div className="grn-designer-inspector__row">
+            <label className="grn-designer-inspector__field">
+              <span>Length (in)</span>
+              <input
+                type="number"
+                min={0}
+                value={length}
+                onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
+                onBlur={() =>
+                  typeof length === 'number' &&
+                  length >= 0 &&
+                  commit({ lengthInches: length })
+                }
+              />
+            </label>
+            <label className="grn-designer-inspector__field">
+              <span>Width (in)</span>
+              <input
+                type="number"
+                min={0}
+                value={width}
+                onChange={(e) => setWidth(e.target.value === '' ? '' : Number(e.target.value))}
+                onBlur={() =>
+                  typeof width === 'number' &&
+                  width >= 0 &&
+                  commit({ widthInches: width })
+                }
+              />
+            </label>
+          </div>
+        )}
+
+        {annotation.shape === 'circle' && (
+          <label className="grn-designer-inspector__field">
+            <span>Diameter (in)</span>
+            <input
+              type="number"
+              min={0}
+              value={length}
+              onChange={(e) => setLength(e.target.value === '' ? '' : Number(e.target.value))}
+              onBlur={() => {
+                if (typeof length === 'number' && length >= 0) {
+                  commit({ lengthInches: length, widthInches: length });
+                }
+              }}
+            />
+          </label>
+        )}
+
+        <fieldset className="grn-designer-inspector__color">
+          <legend>Color</legend>
+          <div className="grn-designer-inspector__color-row" role="radiogroup" aria-label="Annotation color">
+            <button
+              type="button"
+              className={`grn-designer-inspector__color-swatch ${color === null ? 'is-selected' : ''}`}
+              onClick={() => {
+                setColor(null);
+                commit({ color: null });
+              }}
+              aria-label="Default color"
+              aria-pressed={color === null}
+              style={{ background: 'transparent', borderStyle: 'dashed' }}
+            />
+            {BED_COLOR_PALETTE.map((preset) => (
+              <button
+                type="button"
+                key={preset.value}
+                className={`grn-designer-inspector__color-swatch ${color === preset.value ? 'is-selected' : ''}`}
+                onClick={() => {
+                  setColor(preset.value);
+                  commit({ color: preset.value });
+                }}
+                aria-label={preset.label}
+                aria-pressed={color === preset.value}
+                style={{ background: preset.value }}
+                title={preset.label}
+              />
+            ))}
+          </div>
+        </fieldset>
+      </fieldset>
+
+      <footer className="grn-designer-inspector__footer">
+        <span
+          className="grn-designer-inspector__save-status"
+          aria-live="polite"
+          data-saving={isSaving}
+        >
+          {isSaving ? 'Saving…' : 'Saved'}
+        </span>
+        <button
+          type="button"
+          className="grn-designer-inspector__delete"
+          onClick={onDelete}
+          disabled={!isEditable}
+          title="Delete annotation (Del or Backspace)"
+        >
+          Delete
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
@@ -1,0 +1,233 @@
+import type Konva from 'konva';
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { useEffect, useRef } from 'react';
+import { Circle, Group, Line, Rect, Text, Transformer } from 'react-konva';
+import type { GardenAnnotation } from '../../types/listing';
+
+interface AnnotationShapeProps {
+  annotation: GardenAnnotation;
+  pxPerInch: number;
+  isSelected: boolean;
+  isEditable: boolean;
+  onSelect: (annotationId: string) => void;
+  onMove: (annotationId: string, positionX: number, positionY: number) => void;
+  onResize: (
+    annotationId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: Array<{ x: number; y: number }> | null;
+    }
+  ) => void;
+}
+
+const MIN_INCHES = 4;
+const FALLBACK_FILL = 'rgba(255, 255, 255, 0.55)';
+const FALLBACK_STROKE = 'rgba(91, 58, 28, 0.55)';
+
+function applyAlpha(hex: string, alpha: string): string {
+  return /^#[0-9a-fA-F]{6}$/.test(hex) ? `${hex}${alpha}` : hex;
+}
+
+/**
+ * Renders a single non-bed annotation: trees, ponds, sheds, paths, etc.
+ * Visually distinct from beds — no crop chips, lighter fill, dashed
+ * outline so the eye can tell beds and annotations apart at a glance.
+ */
+export function AnnotationShape({
+  annotation,
+  pxPerInch,
+  isSelected,
+  isEditable,
+  onSelect,
+  onMove,
+  onResize,
+}: AnnotationShapeProps) {
+  const groupRef = useRef<Konva.Group | null>(null);
+  const transformerRef = useRef<Konva.Transformer | null>(null);
+
+  const positionX = (annotation.positionX ?? 12) * pxPerInch;
+  const positionY = (annotation.positionY ?? 12) * pxPerInch;
+  const widthPx = (annotation.lengthInches ?? 48) * pxPerInch;
+  const heightPx = (annotation.widthInches ?? 48) * pxPerInch;
+
+  const fill = annotation.color ? applyAlpha(annotation.color, '22') : FALLBACK_FILL;
+  const stroke = annotation.color ?? FALLBACK_STROKE;
+  const accent = isSelected ? '#3a7e5a' : stroke;
+  const strokeWidth = isSelected ? 3 : 2;
+  const dashPattern = annotation.shape === 'line' ? undefined : [6, 4];
+
+  useEffect(() => {
+    const transformer = transformerRef.current;
+    if (!transformer) return;
+    if (isSelected && isEditable && groupRef.current) {
+      transformer.nodes([groupRef.current]);
+    } else {
+      transformer.nodes([]);
+    }
+    transformer.getLayer()?.batchDraw();
+  }, [isSelected, isEditable]);
+
+  function handleDragEnd(event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    if (node !== groupRef.current) return;
+    const nextX = Math.round(node.x() / pxPerInch);
+    const nextY = Math.round(node.y() / pxPerInch);
+    onMove(annotation.id, Math.max(0, nextX), Math.max(0, nextY));
+  }
+
+  function handleTransformEnd() {
+    const node = groupRef.current;
+    if (!node) return;
+    const scaleX = node.scaleX();
+    const scaleY = node.scaleY();
+    const rotation = node.rotation();
+    let nextLength = annotation.lengthInches ?? 48;
+    let nextWidth = annotation.widthInches ?? 48;
+    let nextPoints = annotation.points;
+    if (annotation.shape === 'circle') {
+      const uniformScale = (scaleX + scaleY) / 2;
+      nextLength = Math.max(MIN_INCHES, Math.round(nextLength * uniformScale));
+      nextWidth = nextLength;
+    } else {
+      nextLength = Math.max(MIN_INCHES, Math.round(nextLength * scaleX));
+      nextWidth = Math.max(MIN_INCHES, Math.round(nextWidth * scaleY));
+      if ((annotation.shape === 'polygon' || annotation.shape === 'line') && annotation.points) {
+        nextPoints = annotation.points.map((p) => ({
+          x: Math.round(p.x * scaleX),
+          y: Math.round(p.y * scaleY),
+        }));
+      }
+    }
+    node.scaleX(1);
+    node.scaleY(1);
+    onResize(annotation.id, {
+      positionX: Math.max(0, Math.round(node.x() / pxPerInch)),
+      positionY: Math.max(0, Math.round(node.y() / pxPerInch)),
+      lengthInches: nextLength,
+      widthInches: nextWidth,
+      rotationDeg: Math.round(rotation),
+      points: nextPoints,
+    });
+  }
+
+  const dragProps = isEditable
+    ? { draggable: true, onDragEnd: handleDragEnd }
+    : { draggable: false };
+
+  function renderShape() {
+    if (annotation.shape === 'circle') {
+      const radius = Math.max(widthPx, heightPx) / 2;
+      return (
+        <Circle
+          x={radius}
+          y={radius}
+          radius={radius}
+          fill={fill}
+          stroke={accent}
+          strokeWidth={strokeWidth}
+          dash={dashPattern}
+        />
+      );
+    }
+    if (
+      (annotation.shape === 'polygon' || annotation.shape === 'line') &&
+      annotation.points &&
+      annotation.points.length >= 2
+    ) {
+      const points = annotation.points.flatMap((p) => [
+        p.x * pxPerInch,
+        p.y * pxPerInch,
+      ]);
+      return (
+        <Line
+          points={points}
+          closed={annotation.shape === 'polygon'}
+          fill={annotation.shape === 'polygon' ? fill : undefined}
+          stroke={accent}
+          strokeWidth={annotation.shape === 'line' ? Math.max(strokeWidth, 4) : strokeWidth}
+          lineCap={annotation.shape === 'line' ? 'round' : undefined}
+          lineJoin="round"
+          dash={dashPattern}
+        />
+      );
+    }
+    return (
+      <Rect
+        width={widthPx}
+        height={heightPx}
+        fill={fill}
+        stroke={accent}
+        strokeWidth={strokeWidth}
+        dash={dashPattern}
+        cornerRadius={2}
+      />
+    );
+  }
+
+  // Place the icon + label in the top-left of the annotation box. For
+  // lines the label sits just above the line midpoint.
+  const labelX = annotation.shape === 'line' ? Math.round(widthPx / 2) - 36 : 8;
+  const labelY = annotation.shape === 'line' ? -22 : 8;
+
+  return (
+    <>
+      <Group
+        ref={groupRef}
+        x={positionX}
+        y={positionY}
+        rotation={annotation.rotationDeg}
+        onMouseDown={() => onSelect(annotation.id)}
+        onTouchStart={() => onSelect(annotation.id)}
+        onTransformEnd={handleTransformEnd}
+        {...dragProps}
+      >
+        {renderShape()}
+        {annotation.icon && (
+          <Text
+            x={labelX}
+            y={labelY}
+            text={annotation.icon}
+            fontSize={20}
+            listening={false}
+          />
+        )}
+        <Text
+          x={labelX + (annotation.icon ? 26 : 0)}
+          y={labelY + 4}
+          text={annotation.label}
+          fontSize={12}
+          fontStyle="500"
+          fill="#3a2b1a"
+          listening={false}
+        />
+      </Group>
+      {isEditable && (
+        <Transformer
+          ref={transformerRef}
+          rotateEnabled
+          keepRatio={annotation.shape === 'circle'}
+          enabledAnchors={
+            annotation.shape === 'circle'
+              ? ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+              : ['top-left', 'top-right', 'bottom-left', 'bottom-right', 'middle-left', 'middle-right', 'top-center', 'bottom-center']
+          }
+          boundBoxFunc={(oldBox, newBox) => {
+            const minPx = MIN_INCHES * pxPerInch;
+            if (Math.abs(newBox.width) < minPx || Math.abs(newBox.height) < minPx) {
+              return oldBox;
+            }
+            return newBox;
+          }}
+          anchorStroke="#3a7e5a"
+          anchorFill="#fff"
+          borderStroke="#3a7e5a"
+          borderDash={[4, 4]}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -19,28 +19,44 @@ import { Circle, Layer, Line, Rect, Stage } from 'react-konva';
 Konva.dragDistance = 4;
 import type {
   BedPolygonPoint,
+  GardenAnnotation,
   GardenBed,
   GardenCanvas,
   GrowerCropItem,
 } from '../../types/listing';
+import { AnnotationShape } from './AnnotationShape';
 import { BackgroundLayer } from './BackgroundLayer';
 import { BedShape } from './BedShape';
 import { Grid } from './Grid';
+import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import type { DesignerMode, GridSnap } from './Toolbar';
 
 interface DesignerCanvasProps {
   canvas: GardenCanvas;
   beds: GardenBed[];
+  annotations: GardenAnnotation[];
   cropsByBedId: Map<string, GrowerCropItem[]>;
-  selectedBedId: string | null;
+  selected: SelectedItem;
   isEditable: boolean;
   mode: DesignerMode;
   snap: GridSnap;
   backgroundImageUrl: string | null;
-  onSelect: (bedId: string | null) => void;
+  onSelect: (next: SelectedItem) => void;
   onMoveBed: (bedId: string, positionX: number, positionY: number) => void;
   onResizeBed: (
     bedId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: BedPolygonPoint[] | null;
+    }
+  ) => void;
+  onMoveAnnotation: (annotationId: string, positionX: number, positionY: number) => void;
+  onResizeAnnotation: (
+    annotationId: string,
     next: {
       positionX: number;
       positionY: number;
@@ -82,8 +98,9 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     {
       canvas,
       beds,
+      annotations,
       cropsByBedId,
-      selectedBedId,
+      selected,
       isEditable,
       mode,
       snap,
@@ -91,6 +108,8 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       onSelect,
       onMoveBed,
       onResizeBed,
+      onMoveAnnotation,
+      onResizeAnnotation,
       onCommitPolygon,
       onCancelPolygon,
     },
@@ -313,15 +332,29 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
               />
             </Layer>
             <Layer>
+              {annotations.map((annotation) => (
+                <AnnotationShape
+                  key={annotation.id}
+                  annotation={annotation}
+                  pxPerInch={PX_PER_INCH}
+                  isSelected={
+                    selected?.kind === 'annotation' && selected.id === annotation.id
+                  }
+                  isEditable={isEditable && !drawing}
+                  onSelect={(id) => onSelect({ kind: 'annotation', id })}
+                  onMove={onMoveAnnotation}
+                  onResize={onResizeAnnotation}
+                />
+              ))}
               {beds.map((bed) => (
                 <BedShape
                   key={bed.id}
                   bed={bed}
                   pxPerInch={PX_PER_INCH}
-                  isSelected={selectedBedId === bed.id}
+                  isSelected={selected?.kind === 'bed' && selected.id === bed.id}
                   isEditable={isEditable && !drawing}
                   crops={cropsByBedId.get(bed.id) ?? []}
-                  onSelect={onSelect}
+                  onSelect={(id) => onSelect({ kind: 'bed', id })}
                   onMove={handleBedMove}
                   onResize={onResizeBed}
                 />

--- a/apps/grn/src/components/GardenDesigner/GardenPropertiesBar.tsx
+++ b/apps/grn/src/components/GardenDesigner/GardenPropertiesBar.tsx
@@ -1,11 +1,12 @@
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
-import type { GardenBed, GardenCanvas } from '../../types/listing';
+import type { GardenAnnotation, GardenBed, GardenCanvas } from '../../types/listing';
 import { bedAreaSquareInches, formatArea } from './bedDefaults';
 
 interface GardenPropertiesBarProps {
   canvas: GardenCanvas;
   beds: GardenBed[];
+  annotations: GardenAnnotation[];
   isEditable: boolean;
   isSaving: boolean;
   onCanvasChange: (patch: {
@@ -58,6 +59,7 @@ function formatFeetFromInches(inches: number): string {
 export function GardenPropertiesBar({
   canvas,
   beds,
+  annotations,
   isEditable,
   isSaving,
   onCanvasChange,
@@ -155,6 +157,10 @@ export function GardenPropertiesBar({
         <div className="grn-garden-properties__metric">
           <span className="grn-garden-properties__metric-label">Beds</span>
           <span className="grn-garden-properties__metric-value">{beds.length}</span>
+        </div>
+        <div className="grn-garden-properties__metric">
+          <span className="grn-garden-properties__metric-label">Annotations</span>
+          <span className="grn-garden-properties__metric-value">{annotations.length}</span>
         </div>
         <div className="grn-garden-properties__metric">
           <span className="grn-garden-properties__metric-label">Growable area</span>

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -1,4 +1,5 @@
 import type { BedShape } from '../../types/listing';
+import { ANNOTATION_PRESETS } from './annotationPresets';
 import { BED_SHAPES } from './bedDefaults';
 
 export type DesignerMode = 'idle' | 'drawing-polygon';
@@ -10,6 +11,7 @@ interface ToolbarProps {
   onToggleEditUnlocked: () => void;
   mode: DesignerMode;
   onAddBed: (shape: BedShape) => void;
+  onAddAnnotation: (presetId: string) => void;
   onStartDrawingPolygon: () => void;
   onCancelDrawingPolygon: () => void;
   gridSnap: GridSnap;
@@ -28,6 +30,7 @@ export function Toolbar({
   onToggleEditUnlocked,
   mode,
   onAddBed,
+  onAddAnnotation,
   onStartDrawingPolygon,
   onCancelDrawingPolygon,
   gridSnap,
@@ -77,6 +80,27 @@ export function Toolbar({
             {drawing ? 'Drawing…' : 'Draw shape'}
           </span>
         </button>
+      </div>
+
+      <div className="grn-designer-toolbar__divider" aria-hidden="true" />
+
+      <div className="grn-designer-toolbar__group" role="group" aria-label="Add an annotation">
+        {ANNOTATION_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            className="grn-designer-toolbar__btn"
+            onClick={() => onAddAnnotation(preset.id)}
+            disabled={editingBlocked || drawing}
+            title={preset.description}
+            aria-label={preset.description}
+          >
+            <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">
+              {preset.icon}
+            </span>
+            <span className="grn-designer-toolbar__btn-label">{preset.label}</span>
+          </button>
+        ))}
       </div>
 
       <div className="grn-designer-toolbar__divider" aria-hidden="true" />

--- a/apps/grn/src/components/GardenDesigner/annotationPresets.ts
+++ b/apps/grn/src/components/GardenDesigner/annotationPresets.ts
@@ -1,0 +1,78 @@
+import type { AnnotationShape, BedPolygonPoint } from '../../types/listing';
+import { defaultRectPolygonPoints } from './bedDefaults';
+
+export interface AnnotationPreset {
+  id: string;
+  label: string;
+  icon: string;
+  shape: AnnotationShape;
+  defaultLength: number;
+  defaultWidth: number;
+  defaultColor: string | null;
+  description: string;
+  buildPoints?: (length: number, width: number) => BedPolygonPoint[];
+}
+
+// Picked to keep designer scope sane: visual context only, no soil, no
+// crops, no LLM input. The user can rename freely after creation.
+export const ANNOTATION_PRESETS: AnnotationPreset[] = [
+  {
+    id: 'tree',
+    label: 'Tree',
+    icon: '🌳',
+    shape: 'circle',
+    defaultLength: 60,
+    defaultWidth: 60,
+    defaultColor: '#3a7e5a',
+    description: 'A tree, shrub, or other circular landmark.',
+  },
+  {
+    id: 'pond',
+    label: 'Pond',
+    icon: '💧',
+    shape: 'polygon',
+    defaultLength: 96,
+    defaultWidth: 72,
+    defaultColor: '#4a86c5',
+    description: 'A pond, water feature, or other irregular pool.',
+    buildPoints: (length, width) => defaultRectPolygonPoints(length, width),
+  },
+  {
+    id: 'shed',
+    label: 'Shed',
+    icon: '🏚️',
+    shape: 'rect',
+    defaultLength: 96,
+    defaultWidth: 72,
+    defaultColor: '#5b3a1c',
+    description: 'A shed, greenhouse, or other rectangular structure.',
+  },
+  {
+    id: 'path',
+    label: 'Path',
+    icon: '🛤️',
+    shape: 'line',
+    defaultLength: 240,
+    defaultWidth: 12,
+    defaultColor: '#8a6230',
+    description: 'A pathway, fence, or other linear feature.',
+    buildPoints: (length) => [
+      { x: 0, y: 0 },
+      { x: length, y: 0 },
+    ],
+  },
+  {
+    id: 'custom',
+    label: 'Other',
+    icon: '📍',
+    shape: 'rect',
+    defaultLength: 48,
+    defaultWidth: 48,
+    defaultColor: null,
+    description: 'A generic landmark — name it whatever you like.',
+  },
+];
+
+export function presetById(id: string): AnnotationPreset | undefined {
+  return ANNOTATION_PRESETS.find((p) => p.id === id);
+}

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -1,20 +1,26 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  createMyAnnotation,
   createMyBed,
+  deleteMyAnnotation,
   deleteMyBed,
   getMyGardenCanvas,
+  listMyAnnotations,
   listMyBeds,
   listMyCrops,
   requestBackgroundUploadUrl,
+  updateMyAnnotation,
   updateMyBed,
   updateMyGardenCanvas,
+  type UpsertGardenAnnotationRequest,
   type UpsertGardenBedRequest,
   type UpsertGardenCanvasRequest,
 } from '../services/api';
 import type {
   BedPolygonPoint,
   BedShape,
+  GardenAnnotation,
   GardenBed,
   GardenCanvas,
   GrowerCropItem,
@@ -23,22 +29,34 @@ import {
   defaultRectPolygonPoints,
   shapeDefaults,
 } from '../components/GardenDesigner/bedDefaults';
+import {
+  ANNOTATION_PRESETS,
+  presetById,
+} from '../components/GardenDesigner/annotationPresets';
 import type { DesignerMode, GridSnap } from '../components/GardenDesigner/Toolbar';
 
 const CANVAS_QUERY_KEY = ['my-garden-canvas'];
 const BEDS_QUERY_KEY = ['my-garden-beds'];
+const ANNOTATIONS_QUERY_KEY = ['my-garden-annotations'];
 const CROPS_QUERY_KEY = ['my-crops'];
+
+export type SelectedItem =
+  | { kind: 'bed'; id: string }
+  | { kind: 'annotation'; id: string }
+  | null;
 
 export interface UseGardenDesignerResult {
   canvas: GardenCanvas | undefined;
   beds: GardenBed[];
+  annotations: GardenAnnotation[];
   crops: GrowerCropItem[];
   cropsByBedId: Map<string, GrowerCropItem[]>;
   isLoading: boolean;
   loadError: Error | null;
-  selectedBedId: string | null;
-  setSelectedBedId: (id: string | null) => void;
+  selected: SelectedItem;
+  setSelected: (next: SelectedItem) => void;
   selectedBed: GardenBed | undefined;
+  selectedAnnotation: GardenAnnotation | undefined;
   mode: DesignerMode;
   setMode: (mode: DesignerMode) => void;
   snap: GridSnap;
@@ -64,6 +82,21 @@ export interface UseGardenDesignerResult {
   ) => void;
   patchBed: (bedId: string, patch: Partial<GardenBed>) => void;
   deleteBed: (bedId: string) => Promise<void>;
+  addAnnotation: (presetId: string) => Promise<void>;
+  moveAnnotation: (annotationId: string, positionX: number, positionY: number) => void;
+  resizeAnnotation: (
+    annotationId: string,
+    next: {
+      positionX: number;
+      positionY: number;
+      lengthInches: number;
+      widthInches: number;
+      rotationDeg: number;
+      points: BedPolygonPoint[] | null;
+    }
+  ) => void;
+  patchAnnotation: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
+  deleteAnnotation: (annotationId: string) => Promise<void>;
   patchCanvas: (patch: UpsertGardenCanvasRequest) => void;
   uploadBackgroundImage: (file: File) => Promise<void>;
   clearBackgroundImage: () => Promise<void>;
@@ -106,6 +139,22 @@ function bedToUpsertPayload(bed: GardenBed): UpsertGardenBedRequest {
   };
 }
 
+function annotationToUpsertPayload(a: GardenAnnotation): UpsertGardenAnnotationRequest {
+  return {
+    label: a.label,
+    icon: a.icon,
+    shape: a.shape,
+    positionX: a.positionX,
+    positionY: a.positionY,
+    lengthInches: a.lengthInches,
+    widthInches: a.widthInches,
+    rotationDeg: a.rotationDeg,
+    points: a.points,
+    color: a.color,
+    sortOrder: a.sortOrder,
+  };
+}
+
 /**
  * Owns all designer state — selection, mode, snap, edit-lock — and wraps
  * react-query mutations for canvas/bed CRUD with optimistic updates.
@@ -117,7 +166,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const [editUnlocked, setEditUnlocked] = useState(false);
-  const [selectedBedId, setSelectedBedId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SelectedItem>(null);
   const [mode, setMode] = useState<DesignerMode>('idle');
   const [snap, setSnap] = useState<GridSnap>('12');
 
@@ -129,6 +178,11 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   const bedsQuery = useQuery({
     queryKey: BEDS_QUERY_KEY,
     queryFn: listMyBeds,
+    staleTime: 30_000,
+  });
+  const annotationsQuery = useQuery({
+    queryKey: ANNOTATIONS_QUERY_KEY,
+    queryFn: listMyAnnotations,
     staleTime: 30_000,
   });
   const cropsQuery = useQuery({
@@ -225,6 +279,84 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     },
   });
 
+  const createAnnotationMutation = useMutation({
+    mutationFn: createMyAnnotation,
+    onMutate: startMutation,
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: ANNOTATIONS_QUERY_KEY });
+    },
+  });
+
+  const updateAnnotationMutation = useMutation({
+    mutationFn: ({
+      annotationId,
+      payload,
+    }: {
+      annotationId: string;
+      payload: UpsertGardenAnnotationRequest;
+    }) => updateMyAnnotation(annotationId, payload),
+    onMutate: ({ annotationId, payload }) => {
+      startMutation();
+      const previous = queryClient.getQueryData<GardenAnnotation[]>(ANNOTATIONS_QUERY_KEY);
+      if (previous) {
+        const next = previous.map((a) =>
+          a.id === annotationId
+            ? {
+                ...a,
+                label: payload.label,
+                icon: payload.icon ?? null,
+                shape: payload.shape ?? a.shape,
+                positionX: payload.positionX ?? null,
+                positionY: payload.positionY ?? null,
+                lengthInches: payload.lengthInches ?? null,
+                widthInches: payload.widthInches ?? null,
+                rotationDeg: payload.rotationDeg ?? a.rotationDeg,
+                points: payload.points ?? null,
+                color: payload.color ?? null,
+                sortOrder: payload.sortOrder ?? a.sortOrder,
+              }
+            : a
+        );
+        queryClient.setQueryData(ANNOTATIONS_QUERY_KEY, next);
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(ANNOTATIONS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: ANNOTATIONS_QUERY_KEY });
+    },
+  });
+
+  const deleteAnnotationMutation = useMutation({
+    mutationFn: deleteMyAnnotation,
+    onMutate: (annotationId) => {
+      startMutation();
+      const previous = queryClient.getQueryData<GardenAnnotation[]>(ANNOTATIONS_QUERY_KEY);
+      if (previous) {
+        queryClient.setQueryData(
+          ANNOTATIONS_QUERY_KEY,
+          previous.filter((a) => a.id !== annotationId)
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(ANNOTATIONS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      endMutation();
+      void queryClient.invalidateQueries({ queryKey: ANNOTATIONS_QUERY_KEY });
+    },
+  });
+
   const updateCanvasMutation = useMutation({
     mutationFn: updateMyGardenCanvas,
     onMutate: (payload) => {
@@ -257,6 +389,10 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   });
 
   const beds = useMemo(() => bedsQuery.data ?? [], [bedsQuery.data]);
+  const annotations = useMemo(
+    () => annotationsQuery.data ?? [],
+    [annotationsQuery.data]
+  );
   const crops = useMemo(() => cropsQuery.data ?? [], [cropsQuery.data]);
 
   const cropsByBedId = useMemo(() => {
@@ -274,8 +410,17 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   }, [crops]);
 
   const selectedBed = useMemo(
-    () => beds.find((b) => b.id === selectedBedId),
-    [beds, selectedBedId]
+    () =>
+      selected?.kind === 'bed' ? beds.find((b) => b.id === selected.id) : undefined,
+    [beds, selected]
+  );
+
+  const selectedAnnotation = useMemo(
+    () =>
+      selected?.kind === 'annotation'
+        ? annotations.find((a) => a.id === selected.id)
+        : undefined,
+    [annotations, selected]
   );
 
   const isEditable = !isMobile || editUnlocked;
@@ -309,7 +454,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
             ? defaultRectPolygonPoints(defaults.lengthInches, defaults.widthInches)
             : null,
       });
-      setSelectedBedId(created.id);
+      setSelected({ kind: 'bed', id: created.id });
     },
     [beds.length, canvasQuery.data, createBedMutation, isEditable]
   );
@@ -335,7 +480,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         rotationDeg: 0,
         points: normalized,
       });
-      setSelectedBedId(created.id);
+      setSelected({ kind: 'bed', id: created.id });
       setMode('idle');
     },
     [beds.length, createBedMutation, isEditable]
@@ -393,11 +538,105 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     async (bedId: string) => {
       if (!isEditable) return;
       await deleteBedMutation.mutateAsync(bedId);
-      if (selectedBedId === bedId) {
-        setSelectedBedId(null);
+      if (selected?.kind === 'bed' && selected.id === bedId) {
+        setSelected(null);
       }
     },
-    [deleteBedMutation, isEditable, selectedBedId]
+    [deleteBedMutation, isEditable, selected]
+  );
+
+  const addAnnotation = useCallback(
+    async (presetId: string) => {
+      if (!isEditable) return;
+      const preset = presetById(presetId) ?? ANNOTATION_PRESETS[ANNOTATION_PRESETS.length - 1];
+      const canvasData = canvasQuery.data;
+      const positionX = canvasData
+        ? Math.max(0, Math.round((canvasData.widthInches - preset.defaultLength) / 2))
+        : 12;
+      const positionY = canvasData
+        ? Math.max(0, Math.round((canvasData.heightInches - preset.defaultWidth) / 2))
+        : 12;
+      const points = preset.buildPoints
+        ? preset.buildPoints(preset.defaultLength, preset.defaultWidth)
+        : null;
+      const created = await createAnnotationMutation.mutateAsync({
+        label: preset.label,
+        icon: preset.icon,
+        shape: preset.shape,
+        lengthInches: preset.defaultLength,
+        widthInches: preset.defaultWidth,
+        positionX,
+        positionY,
+        rotationDeg: 0,
+        color: preset.defaultColor,
+        points,
+      });
+      setSelected({ kind: 'annotation', id: created.id });
+    },
+    [canvasQuery.data, createAnnotationMutation, isEditable]
+  );
+
+  const moveAnnotation = useCallback(
+    (annotationId: string, positionX: number, positionY: number) => {
+      const annotation = annotations.find((a) => a.id === annotationId);
+      if (!annotation) return;
+      const payload = annotationToUpsertPayload({
+        ...annotation,
+        positionX,
+        positionY,
+      });
+      updateAnnotationMutation.mutate({ annotationId, payload });
+    },
+    [annotations, updateAnnotationMutation]
+  );
+
+  const resizeAnnotation = useCallback(
+    (
+      annotationId: string,
+      next: {
+        positionX: number;
+        positionY: number;
+        lengthInches: number;
+        widthInches: number;
+        rotationDeg: number;
+        points: BedPolygonPoint[] | null;
+      }
+    ) => {
+      const annotation = annotations.find((a) => a.id === annotationId);
+      if (!annotation) return;
+      const payload = annotationToUpsertPayload({
+        ...annotation,
+        positionX: next.positionX,
+        positionY: next.positionY,
+        lengthInches: next.lengthInches,
+        widthInches: next.widthInches,
+        rotationDeg: next.rotationDeg,
+        points: next.points,
+      });
+      updateAnnotationMutation.mutate({ annotationId, payload });
+    },
+    [annotations, updateAnnotationMutation]
+  );
+
+  const patchAnnotation = useCallback(
+    (annotationId: string, patch: Partial<GardenAnnotation>) => {
+      const annotation = annotations.find((a) => a.id === annotationId);
+      if (!annotation) return;
+      const payload = annotationToUpsertPayload({ ...annotation, ...patch });
+      updateAnnotationMutation.mutate({ annotationId, payload });
+    },
+    [annotations, updateAnnotationMutation]
+  );
+
+  const deleteAnnotation = useCallback(
+    async (annotationId: string) => {
+      if (!isEditable) return;
+      await deleteAnnotationMutation.mutateAsync(annotationId);
+      if (selected?.kind === 'annotation' && selected.id === annotationId) {
+        setSelected(null);
+      }
+    },
+    [deleteAnnotationMutation, isEditable, selected]
   );
 
   const patchCanvas = useCallback(
@@ -412,8 +651,8 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   //                   Canvas owns Esc-to-cancel for that mode)
   //   Delete /
   //   Backspace     - prompt for confirmation, then delete the selected
-  //                   bed. Skipped when focus is in a text input/editor
-  //                   so it doesn't fight normal text editing.
+  //                   bed or annotation. Skipped when focus is in a text
+  //                   input/editor so it doesn't fight normal text editing.
   useEffect(() => {
     function isEditingText(target: EventTarget | null): boolean {
       if (!(target instanceof HTMLElement)) return false;
@@ -427,29 +666,34 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       if (isEditingText(event.target)) return;
 
       if (event.key === 'Escape') {
-        if (selectedBedId !== null) {
+        if (selected !== null) {
           event.preventDefault();
-          setSelectedBedId(null);
+          setSelected(null);
         }
         return;
       }
 
       if (event.key === 'Delete' || event.key === 'Backspace') {
-        if (!selectedBed || !isEditable) return;
-        event.preventDefault();
-        const label = selectedBed.name.trim() || 'this bed';
-        const confirmed = window.confirm(
-          `Delete "${label}"? This can't be undone.`
-        );
-        if (confirmed) {
-          void deleteBed(selectedBed.id);
+        if (!isEditable || !selected) return;
+        if (selected.kind === 'bed' && selectedBed) {
+          event.preventDefault();
+          const label = selectedBed.name.trim() || 'this bed';
+          if (window.confirm(`Delete "${label}"? This can't be undone.`)) {
+            void deleteBed(selectedBed.id);
+          }
+        } else if (selected.kind === 'annotation' && selectedAnnotation) {
+          event.preventDefault();
+          const label = selectedAnnotation.label.trim() || 'this annotation';
+          if (window.confirm(`Delete "${label}"? This can't be undone.`)) {
+            void deleteAnnotation(selectedAnnotation.id);
+          }
         }
       }
     }
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [mode, selectedBedId, selectedBed, isEditable, deleteBed]);
+  }, [mode, selected, selectedBed, selectedAnnotation, isEditable, deleteBed, deleteAnnotation]);
 
   const uploadBackgroundImage = useCallback(
     async (file: File) => {
@@ -488,16 +732,20 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   return {
     canvas: canvasQuery.data,
     beds,
+    annotations,
     crops,
     cropsByBedId,
-    isLoading: canvasQuery.isLoading || bedsQuery.isLoading,
+    isLoading:
+      canvasQuery.isLoading || bedsQuery.isLoading || annotationsQuery.isLoading,
     loadError:
       (canvasQuery.error as Error | null) ??
       (bedsQuery.error as Error | null) ??
+      (annotationsQuery.error as Error | null) ??
       null,
-    selectedBedId,
-    setSelectedBedId,
+    selected,
+    setSelected,
     selectedBed,
+    selectedAnnotation,
     mode,
     setMode,
     snap,
@@ -513,6 +761,11 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     resizeBed,
     patchBed,
     deleteBed,
+    addAnnotation,
+    moveAnnotation,
+    resizeAnnotation,
+    patchAnnotation,
+    deleteAnnotation,
     patchCanvas,
     uploadBackgroundImage,
     clearBackgroundImage,

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { PlantLoader } from '../components/branding/PlantLoader';
+import { AnnotationInspector } from '../components/GardenDesigner/AnnotationInspector';
 import { BedInspector } from '../components/GardenDesigner/BedInspector';
 import {
   DesignerCanvas,
@@ -37,7 +38,8 @@ export function GardenDesignerPage() {
     );
   }
 
-  const inspectorOpen = designer.selectedBed !== undefined;
+  const inspectorOpen =
+    designer.selectedBed !== undefined || designer.selectedAnnotation !== undefined;
 
   async function handlePickBackgroundFile(file: File) {
     setUploadError(null);
@@ -62,9 +64,9 @@ export function GardenDesignerPage() {
             Lay out your beds, drop in crops, and watch it come together.
           </p>
         </div>
-        {designer.beds.length === 0 && (
+        {designer.beds.length === 0 && designer.annotations.length === 0 && (
           <p className="grn-designer-page__hint">
-            Start by adding a bed from the toolbar on the left.
+            Start by adding a bed or a landmark from the toolbar on the left.
           </p>
         )}
       </header>
@@ -72,6 +74,7 @@ export function GardenDesignerPage() {
       <GardenPropertiesBar
         canvas={designer.canvas}
         beds={designer.beds}
+        annotations={designer.annotations}
         isEditable={designer.isEditable}
         isSaving={designer.isSaving}
         onCanvasChange={designer.patchCanvas}
@@ -98,6 +101,9 @@ export function GardenDesignerPage() {
           onAddBed={(shape) => {
             void designer.addBed(shape);
           }}
+          onAddAnnotation={(presetId) => {
+            void designer.addAnnotation(presetId);
+          }}
           onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
           onCancelDrawingPolygon={() => designer.setMode('idle')}
           gridSnap={designer.snap}
@@ -109,15 +115,18 @@ export function GardenDesignerPage() {
           ref={canvasRef}
           canvas={designer.canvas}
           beds={designer.beds}
+          annotations={designer.annotations}
           cropsByBedId={designer.cropsByBedId}
-          selectedBedId={designer.selectedBedId}
+          selected={designer.selected}
           isEditable={designer.isEditable}
           mode={designer.mode}
           snap={designer.snap}
           backgroundImageUrl={designer.canvas.backgroundImageUrl}
-          onSelect={designer.setSelectedBedId}
+          onSelect={designer.setSelected}
           onMoveBed={designer.moveBed}
           onResizeBed={designer.resizeBed}
+          onMoveAnnotation={designer.moveAnnotation}
+          onResizeAnnotation={designer.resizeAnnotation}
           onCommitPolygon={(points) => {
             void designer.commitPolygon(points);
           }}
@@ -141,7 +150,27 @@ export function GardenDesignerPage() {
                 void designer.deleteBed(designer.selectedBed.id);
               }
             }}
-            onClose={() => designer.setSelectedBedId(null)}
+            onClose={() => designer.setSelected(null)}
+          />
+        )}
+
+        {designer.selectedAnnotation && (
+          <AnnotationInspector
+            key={designer.selectedAnnotation.id}
+            annotation={designer.selectedAnnotation}
+            isEditable={designer.isEditable}
+            isSaving={designer.isSaving}
+            onChange={(patch) => {
+              if (designer.selectedAnnotation) {
+                designer.patchAnnotation(designer.selectedAnnotation.id, patch);
+              }
+            }}
+            onDelete={() => {
+              if (designer.selectedAnnotation) {
+                void designer.deleteAnnotation(designer.selectedAnnotation.id);
+              }
+            }}
+            onClose={() => designer.setSelected(null)}
           />
         )}
       </div>

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -3,12 +3,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { getApiEndpoint } from '../config/amplify';
 import type { UserProfile, UserType, GrowerProfile, GathererProfile } from '../types/user';
 import type {
+  AnnotationShape,
   BedPolygonPoint,
   BedShape,
   BedType,
   CatalogCrop,
   CatalogVariety,
   DiscoverListingsResponse,
+  GardenAnnotation,
   GardenBed,
   GardenCanvas,
   GrowerCropItem,
@@ -289,6 +291,24 @@ interface RawGardenCanvas {
   updated_at: string;
 }
 
+interface RawGardenAnnotation {
+  id: string;
+  user_id: string;
+  label: string;
+  icon: string | null;
+  shape: AnnotationShape;
+  position_x: number | null;
+  position_y: number | null;
+  length_inches: number | null;
+  width_inches: number | null;
+  rotation_deg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
 interface RawBackgroundUploadIntentResponse {
   upload_url: string;
   method: string;
@@ -499,6 +519,26 @@ function mapGardenBed(raw: RawGardenBed): GardenBed {
     rotationDeg: raw.rotation_deg,
     points: raw.points,
     color: raw.color,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function mapGardenAnnotation(raw: RawGardenAnnotation): GardenAnnotation {
+  return {
+    id: raw.id,
+    userId: raw.user_id,
+    label: raw.label,
+    icon: raw.icon,
+    shape: raw.shape,
+    positionX: raw.position_x,
+    positionY: raw.position_y,
+    lengthInches: raw.length_inches,
+    widthInches: raw.width_inches,
+    rotationDeg: raw.rotation_deg,
+    points: raw.points,
+    color: raw.color,
+    sortOrder: raw.sort_order,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
   };
@@ -846,6 +886,55 @@ export async function updateMyBed(bedId: string, data: UpsertGardenBedRequest): 
 
 export async function deleteMyBed(bedId: string): Promise<void> {
   await apiFetch(`/beds/${bedId}`, {
+    method: 'DELETE',
+  });
+}
+
+export interface UpsertGardenAnnotationRequest {
+  label: string;
+  icon?: string | null;
+  shape?: AnnotationShape;
+  positionX?: number | null;
+  positionY?: number | null;
+  lengthInches?: number | null;
+  widthInches?: number | null;
+  rotationDeg?: number;
+  points?: BedPolygonPoint[] | null;
+  color?: string | null;
+  sortOrder?: number;
+}
+
+export async function listMyAnnotations(): Promise<GardenAnnotation[]> {
+  const response = await apiFetch<RawGardenAnnotation[]>('/annotations');
+  return response.map(mapGardenAnnotation);
+}
+
+export async function createMyAnnotation(
+  data: UpsertGardenAnnotationRequest
+): Promise<GardenAnnotation> {
+  const response = await apiFetch<RawGardenAnnotation>('/annotations', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return mapGardenAnnotation(response);
+}
+
+export async function updateMyAnnotation(
+  annotationId: string,
+  data: UpsertGardenAnnotationRequest
+): Promise<GardenAnnotation> {
+  const response = await apiFetch<RawGardenAnnotation>(
+    `/annotations/${annotationId}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }
+  );
+  return mapGardenAnnotation(response);
+}
+
+export async function deleteMyAnnotation(annotationId: string): Promise<void> {
+  await apiFetch(`/annotations/${annotationId}`, {
     method: 'DELETE',
   });
 }

--- a/apps/grn/src/types/listing.ts
+++ b/apps/grn/src/types/listing.ts
@@ -87,6 +87,26 @@ export interface GardenCanvas {
   updatedAt: string;
 }
 
+export type AnnotationShape = 'rect' | 'circle' | 'polygon' | 'line';
+
+export interface GardenAnnotation {
+  id: string;
+  userId: string;
+  label: string;
+  icon: string | null;
+  shape: AnnotationShape;
+  positionX: number | null;
+  positionY: number | null;
+  lengthInches: number | null;
+  widthInches: number | null;
+  rotationDeg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Listing {
   id: string;
   userId: string;

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -439,6 +439,44 @@ create index if not exists idx_garden_beds_user
   where archived_at is null;
 
 -- ============================
+-- GARDEN ANNOTATIONS (non-bed objects: trees, ponds, paths, sheds, etc.)
+-- ============================
+create table if not exists garden_annotations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  label text not null,
+  icon text,
+  shape text not null default 'rect',
+  position_x integer,
+  position_y integer,
+  length_inches integer,
+  width_inches integer,
+  rotation_deg integer not null default 0,
+  points jsonb,
+  color text,
+  sort_order integer not null default 0,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_annotations_label_not_empty check (length(trim(label)) > 0),
+  constraint garden_annotations_shape_allowed check (shape in ('rect', 'circle', 'polygon', 'line')),
+  constraint garden_annotations_rotation_range check (rotation_deg between -360 and 360),
+  constraint garden_annotations_length_nonneg check (length_inches is null or length_inches >= 0),
+  constraint garden_annotations_width_nonneg check (width_inches is null or width_inches >= 0),
+  constraint garden_annotations_polygon_requires_points check (
+    shape <> 'polygon' or (points is not null and jsonb_typeof(points) = 'array')
+  ),
+  constraint garden_annotations_line_requires_points check (
+    shape <> 'line' or (points is not null and jsonb_typeof(points) = 'array')
+  )
+);
+
+create index if not exists idx_garden_annotations_user
+  on garden_annotations(user_id)
+  where archived_at is null;
+
+-- ============================
 -- GARDEN CANVAS (single per user in v1; UNIQUE drops when multi-garden ships)
 -- ============================
 create table if not exists garden_canvases (

--- a/services/grn-api/db/migrations/0030_garden_annotations.sql
+++ b/services/grn-api/db/migrations/0030_garden_annotations.sql
@@ -1,0 +1,39 @@
+-- Migration: Garden annotations (non-bed objects on the designer canvas)
+-- Adds a sibling table to garden_beds for things that aren't growing
+-- spaces — trees, ponds, sheds, paths, fences, generic landmarks.
+-- Annotations don't carry soil/crop metadata and aren't LLM-input.
+
+create table if not exists garden_annotations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  label text not null,
+  icon text,                                  -- emoji or icon key
+  shape text not null default 'rect',
+  position_x integer,
+  position_y integer,
+  length_inches integer,
+  width_inches integer,
+  rotation_deg integer not null default 0,
+  points jsonb,                               -- array of {x,y} for polygon/line
+  color text,
+  sort_order integer not null default 0,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint garden_annotations_label_not_empty check (length(trim(label)) > 0),
+  constraint garden_annotations_shape_allowed check (shape in ('rect', 'circle', 'polygon', 'line')),
+  constraint garden_annotations_rotation_range check (rotation_deg between -360 and 360),
+  constraint garden_annotations_length_nonneg check (length_inches is null or length_inches >= 0),
+  constraint garden_annotations_width_nonneg check (width_inches is null or width_inches >= 0),
+  constraint garden_annotations_polygon_requires_points check (
+    shape <> 'polygon' or (points is not null and jsonb_typeof(points) = 'array')
+  ),
+  constraint garden_annotations_line_requires_points check (
+    shape <> 'line' or (points is not null and jsonb_typeof(points) = 'array')
+  )
+);
+
+create index if not exists idx_garden_annotations_user
+  on garden_annotations(user_id)
+  where archived_at is null;

--- a/services/grn-api/openapi.yaml
+++ b/services/grn-api/openapi.yaml
@@ -66,6 +66,10 @@ paths:
     $ref: 'openapi/paths/garden.yaml#/~1beds'
   /beds/{bedId}:
     $ref: 'openapi/paths/garden.yaml#/~1beds~1{bedId}'
+  /annotations:
+    $ref: 'openapi/paths/garden.yaml#/~1annotations'
+  /annotations/{annotationId}:
+    $ref: 'openapi/paths/garden.yaml#/~1annotations~1{annotationId}'
   /garden:
     $ref: 'openapi/paths/garden.yaml#/~1garden'
   /garden/background-upload-url:

--- a/services/grn-api/openapi/paths/garden.yaml
+++ b/services/grn-api/openapi/paths/garden.yaml
@@ -143,6 +143,103 @@
       '500':
         $ref: '../schemas/_responses.yaml#/ErrorResponse'
 
+/annotations:
+  get:
+    tags: [Crop Library, Grower Only, Idempotent]
+    summary: List the current grower's garden annotations
+    operationId: listMyAnnotations
+    responses:
+      '200':
+        description: Garden annotations owned by the caller
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '../schemas/garden.yaml#/GardenAnnotation'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  post:
+    tags: [Crop Library, Grower Only]
+    summary: Create a garden annotation
+    operationId: createMyAnnotation
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/UpsertGardenAnnotationRequest'
+    responses:
+      '201':
+        description: Created annotation
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenAnnotation'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+/annotations/{annotationId}:
+  parameters:
+    - in: path
+      name: annotationId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  put:
+    tags: [Crop Library, Grower Only]
+    summary: Update a garden annotation
+    operationId: updateMyAnnotation
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/garden.yaml#/UpsertGardenAnnotationRequest'
+    responses:
+      '200':
+        description: Updated annotation
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenAnnotation'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  delete:
+    tags: [Crop Library, Grower Only]
+    summary: Archive (soft-delete) a garden annotation
+    operationId: deleteMyAnnotation
+    responses:
+      '204':
+        description: Archived
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '403':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
 /garden/background-upload-url:
   post:
     tags: [Crop Library, Grower Only]

--- a/services/grn-api/openapi/schemas/garden.yaml
+++ b/services/grn-api/openapi/schemas/garden.yaml
@@ -258,6 +258,136 @@ BackgroundUploadIntentRequest:
       maximum: 8388608
       description: "Size of the file in bytes (max 8 MB)."
 
+GardenAnnotation:
+  type: object
+  description: |
+    A non-bed object on the garden designer canvas: trees, ponds, sheds,
+    paths, fences, or generic landmarks. Annotations are visual context
+    only — they don't carry soil, crops, or LLM-input data.
+  required:
+    - id
+    - user_id
+    - label
+    - shape
+    - rotation_deg
+    - sort_order
+    - created_at
+    - updated_at
+  properties:
+    id:
+      type: string
+      format: uuid
+    user_id:
+      type: string
+      format: uuid
+    label:
+      type: string
+      maxLength: 80
+    icon:
+      type: string
+      nullable: true
+      description: "Emoji or short icon key (≤32 chars)."
+    shape:
+      type: string
+      enum: [rect, circle, polygon, line]
+    position_x:
+      type: integer
+      nullable: true
+    position_y:
+      type: integer
+      nullable: true
+    length_inches:
+      type: integer
+      nullable: true
+      minimum: 0
+    width_inches:
+      type: integer
+      nullable: true
+      minimum: 0
+    rotation_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+    points:
+      nullable: true
+      description: |
+        Vertices in canvas inches relative to (position_x, position_y).
+        Required for shape=polygon (≥3) and shape=line (≥2).
+      type: array
+      items:
+        type: object
+        required: [x, y]
+        properties:
+          x:
+            type: integer
+          y:
+            type: integer
+    color:
+      type: string
+      nullable: true
+      pattern: '^#[0-9a-fA-F]{6}$'
+    sort_order:
+      type: integer
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+UpsertGardenAnnotationRequest:
+  type: object
+  required: [label]
+  properties:
+    label:
+      type: string
+      maxLength: 80
+    icon:
+      type: string
+      nullable: true
+    shape:
+      type: string
+      enum: [rect, circle, polygon, line]
+      nullable: true
+    position_x:
+      type: integer
+      nullable: true
+    position_y:
+      type: integer
+      nullable: true
+    length_inches:
+      type: integer
+      minimum: 0
+      nullable: true
+    width_inches:
+      type: integer
+      minimum: 0
+      nullable: true
+    rotation_deg:
+      type: integer
+      minimum: -360
+      maximum: 360
+      nullable: true
+    points:
+      nullable: true
+      type: array
+      maxItems: 64
+      items:
+        type: object
+        required: [x, y]
+        properties:
+          x:
+            type: integer
+          y:
+            type: integer
+    color:
+      type: string
+      nullable: true
+      pattern: '^#[0-9a-fA-F]{6}$'
+    sort_order:
+      type: integer
+      nullable: true
+
 BackgroundUploadIntentResponse:
   type: object
   required: [upload_url, method, headers, s3_key, expires_in_seconds]

--- a/services/grn-api/scripts/integration-test.mjs
+++ b/services/grn-api/scripts/integration-test.mjs
@@ -47,6 +47,24 @@ const GARDEN_BED_FIELDS = [
   'updated_at'
 ];
 
+const GARDEN_ANNOTATION_FIELDS = [
+  'id',
+  'user_id',
+  'label',
+  'icon',
+  'shape',
+  'position_x',
+  'position_y',
+  'length_inches',
+  'width_inches',
+  'rotation_deg',
+  'points',
+  'color',
+  'sort_order',
+  'created_at',
+  'updated_at'
+];
+
 const GARDEN_CANVAS_FIELDS = [
   'id',
   'user_id',
@@ -88,6 +106,7 @@ async function run() {
 
   const reporter = createReporter(runPrefix);
   const createdBedIds = [];
+  const createdAnnotationIds = [];
 
   // --- Auth Boundary ---
   console.log('\n=== Auth Boundary ===');
@@ -128,6 +147,18 @@ async function run() {
       reporter.assert('auth-boundary',
         res.status === 401 || res.status === 403,
         `GET /garden with invalid token returns 401/403 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await noAuthApi.request('/annotations');
+      reporter.assert('auth-boundary', res.status === 401, `GET /annotations without auth returns 401 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await noAuthApi.request('/annotations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'should fail' })
+      });
+      reporter.assert('auth-boundary', res.status === 401, `POST /annotations without auth returns 401 (got ${res.status})`, res.json);
     }
   }
 
@@ -393,6 +424,121 @@ async function run() {
     reporter.fail('garden-canvas', `Garden canvas error: ${err.message}`);
   }
 
+  // --- Annotation validation ---
+  console.log('\n=== Annotation validation ===');
+  {
+    const cases = [
+      { label: 'blank label', body: { label: '   ' } },
+      { label: 'unknown shape', body: { label: 'bad', shape: 'octagon' } },
+      { label: 'polygon without points', body: { label: 'pond', shape: 'polygon' } },
+      { label: 'line with one point', body: { label: 'path', shape: 'line', points: [{ x: 0, y: 0 }] } },
+      { label: 'polygon with 2 points', body: { label: 'pond', shape: 'polygon', points: [{ x: 0, y: 0 }, { x: 10, y: 0 }] } },
+      { label: 'invalid color', body: { label: 'tree', color: 'green' } },
+      { label: 'rotation out of range', body: { label: 'spin', rotationDeg: 720 } },
+      { label: 'negative dimensions', body: { label: 'tiny', lengthInches: -1 } },
+      { label: 'long label', body: { label: 'x'.repeat(200) } }
+    ];
+    for (const { label, body } of cases) {
+      const res = await growerApi.request('/annotations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      reporter.assert('annotation-validation', res.status === 400,
+        `POST /annotations (${label}) returns 400 (got ${res.status})`, res.json);
+    }
+    {
+      const res = await growerApi.request('/annotations/not-a-uuid', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: 'whatever' })
+      });
+      reporter.assert('annotation-validation', res.status === 400,
+        `PUT /annotations/not-a-uuid returns 400 (got ${res.status})`, res.json);
+    }
+  }
+
+  // --- Annotation CRUD ---
+  console.log('\n=== Annotation CRUD ===');
+  try {
+    const lineLabel = `${runPrefix}-path`;
+    const linePayload = {
+      label: lineLabel,
+      icon: '🛤️',
+      shape: 'line',
+      points: [
+        { x: 0, y: 0 },
+        { x: 240, y: 0 },
+        { x: 360, y: 60 }
+      ],
+      positionX: 12,
+      positionY: 60,
+      rotationDeg: 0,
+      color: '#8a6230',
+      sortOrder: 1
+    };
+    const createRes = await growerApi.request('/annotations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(linePayload)
+    });
+    reporter.assert('annotation-crud', createRes.status === 201, `POST /annotations returns 201 (got ${createRes.status})`, createRes.json);
+    const created = createRes.json;
+    if (created?.id) createdAnnotationIds.push(created.id);
+    const fieldGap = missingFields(created ?? {}, GARDEN_ANNOTATION_FIELDS);
+    reporter.assert('annotation-crud', fieldGap.length === 0,
+      fieldGap.length === 0
+        ? 'created annotation has all expected fields'
+        : `created annotation missing fields: ${fieldGap.join(', ')}`,
+      created);
+    reporter.assert('annotation-crud', UUID_PATTERN.test(created?.id ?? ''), `created annotation id is a UUID (got ${created?.id})`, created);
+    reporter.assert('annotation-crud', created?.shape === 'line', `shape roundtrips as line (got ${created?.shape})`, created);
+    reporter.assert('annotation-crud', Array.isArray(created?.points) && created.points.length === 3,
+      `points roundtrip as 3-entry array (got ${created?.points?.length})`, created);
+    reporter.assert('annotation-crud', created?.icon === '🛤️', `icon roundtrips (got ${created?.icon})`, created);
+    reporter.assert('annotation-crud', created?.color === '#8a6230', `color roundtrips (got ${created?.color})`, created);
+
+    if (created?.id) {
+      const updateRes = await growerApi.request(`/annotations/${created.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...linePayload,
+          label: `${lineLabel}-renamed`,
+          shape: 'rect',
+          points: null,
+          positionX: 100,
+          positionY: 100
+        })
+      });
+      reporter.assert('annotation-crud', updateRes.status === 200, `PUT /annotations/:id returns 200 (got ${updateRes.status})`, updateRes.json);
+      reporter.assert('annotation-crud', updateRes.json?.shape === 'rect', `shape updates to rect (got ${updateRes.json?.shape})`, updateRes.json);
+      reporter.assert('annotation-crud', updateRes.json?.points === null, `points cleared on shape change (got ${updateRes.json?.points})`, updateRes.json);
+    }
+
+    {
+      const listRes = await growerApi.request('/annotations');
+      reporter.assert('annotation-crud', listRes.status === 200, `GET /annotations returns 200 (got ${listRes.status})`, listRes.json);
+      const found = Array.isArray(listRes.json) && listRes.json.some((a) => a.id === created?.id);
+      reporter.assert('annotation-crud', found, 'created annotation appears in list', listRes.json);
+    }
+
+    if (created?.id) {
+      const deleteRes = await growerApi.request(`/annotations/${created.id}`, { method: 'DELETE' });
+      reporter.assert('annotation-crud', deleteRes.status === 204, `DELETE /annotations/:id returns 204 (got ${deleteRes.status})`, deleteRes.json);
+      const idx = createdAnnotationIds.indexOf(created.id);
+      if (idx >= 0) createdAnnotationIds.splice(idx, 1);
+    }
+
+    {
+      const dummyId = '00000000-0000-4000-8000-000000000000';
+      const res = await growerApi.request(`/annotations/${dummyId}`, { method: 'DELETE' });
+      reporter.assert('annotation-crud', res.status === 404, `DELETE /annotations/:unknown returns 404 (got ${res.status})`, res.json);
+    }
+  } catch (err) {
+    reporter.fail('annotation-crud', `Annotation CRUD error: ${err.message}`);
+  }
+
   // --- Background upload URL ---
   console.log('\n=== Background upload URL ===');
   try {
@@ -446,12 +592,19 @@ async function run() {
     reporter.fail('background-upload-url', `Background upload URL error: ${err.message}`);
   }
 
-  // --- Cleanup any beds that survived the CRUD scenario ---
+  // --- Cleanup any beds/annotations that survived the CRUD scenario ---
   for (const bedId of createdBedIds) {
     try {
       await growerApi.request(`/beds/${bedId}`, { method: 'DELETE' });
     } catch (err) {
       console.error(`Cleanup failed for bed ${bedId}: ${err.message}`);
+    }
+  }
+  for (const annotationId of createdAnnotationIds) {
+    try {
+      await growerApi.request(`/annotations/${annotationId}`, { method: 'DELETE' });
+    } catch (err) {
+      console.error(`Cleanup failed for annotation ${annotationId}: ${err.message}`);
     }
   }
 

--- a/services/grn-api/src/api/handlers/annotation.rs
+++ b/services/grn-api/src/api/handlers/annotation.rs
@@ -1,0 +1,524 @@
+use crate::auth::{extract_auth_context_with_fallback, require_grower};
+use crate::db;
+use crate::handlers::crop::error_response;
+use crate::models::annotation::{GardenAnnotation, UpsertGardenAnnotationRequest};
+use crate::models::crop::ErrorResponse;
+use lambda_http::{Body, Request, Response};
+use serde::Serialize;
+use tokio_postgres::Row;
+use tracing::info;
+use uuid::Uuid;
+
+const ALLOWED_SHAPES: [&str; 4] = ["rect", "circle", "polygon", "line"];
+const COLOR_HEX_LEN: usize = 7;
+const MAX_LABEL_LEN: usize = 80;
+const MAX_ICON_LEN: usize = 32;
+const MAX_POLYGON_POINTS: usize = 64;
+
+pub async fn list_my_annotations(
+    request: &Request,
+    _correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let client = db::connect().await?;
+
+    let rows = client
+        .query(
+            "
+            select id, user_id, label, icon, shape, position_x, position_y,
+                   length_inches, width_inches, rotation_deg, points, color,
+                   sort_order, created_at, updated_at
+            from garden_annotations
+            where user_id = $1 and archived_at is null
+            order by sort_order asc, created_at asc
+            ",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let annotations = rows
+        .into_iter()
+        .map(|row| row_to_annotation(&row))
+        .collect::<Vec<_>>();
+    json_response(200, &annotations)
+}
+
+pub async fn create_my_annotation(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let payload: UpsertGardenAnnotationRequest = parse_json_body(request)?;
+    let validated = validate_annotation_payload(&payload)?;
+
+    let client = db::connect().await?;
+    let row = client
+        .query_one(
+            "
+            insert into garden_annotations
+                (user_id, label, icon, shape, position_x, position_y,
+                 length_inches, width_inches, rotation_deg, points, color, sort_order)
+            values ($1, $2, $3, coalesce($4, 'rect'), $5, $6, $7, $8,
+                    coalesce($9, 0), $10, $11, coalesce($12, 0))
+            returning id, user_id, label, icon, shape, position_x, position_y,
+                      length_inches, width_inches, rotation_deg, points, color,
+                      sort_order, created_at, updated_at
+            ",
+            &[
+                &user_id,
+                &validated.label,
+                &validated.icon,
+                &validated.shape,
+                &payload.position_x,
+                &payload.position_y,
+                &payload.length_inches,
+                &payload.width_inches,
+                &payload.rotation_deg,
+                &validated.points,
+                &validated.color,
+                &payload.sort_order,
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        annotation_id = %row.get::<_, Uuid>("id"),
+        "Created garden annotation"
+    );
+
+    json_response(201, &row_to_annotation(&row))
+}
+
+pub async fn update_my_annotation(
+    request: &Request,
+    correlation_id: &str,
+    annotation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let payload: UpsertGardenAnnotationRequest = parse_json_body(request)?;
+    let validated = validate_annotation_payload(&payload)?;
+    let id = parse_uuid(annotation_id, "annotation id")?;
+
+    let client = db::connect().await?;
+    let maybe_row = client
+        .query_opt(
+            "
+            update garden_annotations
+            set label = $1,
+                icon = $2,
+                shape = coalesce($3, shape),
+                position_x = $4,
+                position_y = $5,
+                length_inches = $6,
+                width_inches = $7,
+                rotation_deg = coalesce($8, rotation_deg),
+                points = $9,
+                color = $10,
+                sort_order = coalesce($11, sort_order),
+                updated_at = now()
+            where id = $12 and user_id = $13 and archived_at is null
+            returning id, user_id, label, icon, shape, position_x, position_y,
+                      length_inches, width_inches, rotation_deg, points, color,
+                      sort_order, created_at, updated_at
+            ",
+            &[
+                &validated.label,
+                &validated.icon,
+                &validated.shape,
+                &payload.position_x,
+                &payload.position_y,
+                &payload.length_inches,
+                &payload.width_inches,
+                &payload.rotation_deg,
+                &validated.points,
+                &validated.color,
+                &payload.sort_order,
+                &id,
+                &user_id,
+            ],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    if let Some(row) = maybe_row {
+        info!(
+            correlation_id = correlation_id,
+            user_id = %user_id,
+            annotation_id = %id,
+            "Updated garden annotation"
+        );
+        return json_response(200, &row_to_annotation(&row));
+    }
+
+    not_found_response()
+}
+
+pub async fn delete_my_annotation(
+    request: &Request,
+    correlation_id: &str,
+    annotation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = parse_user_id(&auth_context.user_id)?;
+    let id = parse_uuid(annotation_id, "annotation id")?;
+
+    let client = db::connect().await?;
+    let archived = client
+        .execute(
+            "
+            update garden_annotations
+            set archived_at = now(), updated_at = now()
+            where id = $1 and user_id = $2 and archived_at is null
+            ",
+            &[&id, &user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    if archived == 0 {
+        return not_found_response();
+    }
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        annotation_id = %id,
+        "Archived garden annotation"
+    );
+
+    Response::builder()
+        .status(204)
+        .body(Body::Empty)
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+pub struct ValidatedAnnotation {
+    pub label: String,
+    pub icon: Option<String>,
+    pub shape: Option<String>,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
+}
+
+pub fn validate_annotation_payload(
+    payload: &UpsertGardenAnnotationRequest,
+) -> Result<ValidatedAnnotation, lambda_http::Error> {
+    let trimmed_label = payload.label.trim();
+    if trimmed_label.is_empty() {
+        return Err(lambda_http::Error::from(
+            "annotation label is required".to_string(),
+        ));
+    }
+    if trimmed_label.len() > MAX_LABEL_LEN {
+        return Err(lambda_http::Error::from(format!(
+            "annotation label must be {MAX_LABEL_LEN} characters or fewer"
+        )));
+    }
+
+    let icon = match payload.icon.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if value.chars().count() <= MAX_ICON_LEN => Some(value.to_string()),
+        Some(_) => {
+            return Err(lambda_http::Error::from(format!(
+                "annotation icon must be {MAX_ICON_LEN} characters or fewer"
+            )));
+        }
+    };
+
+    let shape = match payload.shape.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if ALLOWED_SHAPES.contains(&value) => Some(value.to_string()),
+        Some(value) => {
+            return Err(lambda_http::Error::from(format!(
+                "Invalid annotation shape '{value}'. Allowed values: {}",
+                ALLOWED_SHAPES.join(", ")
+            )));
+        }
+    };
+
+    if payload.length_inches.is_some_and(|v| v < 0) || payload.width_inches.is_some_and(|v| v < 0) {
+        return Err(lambda_http::Error::from(
+            "annotation dimensions must be non-negative".to_string(),
+        ));
+    }
+
+    if let Some(deg) = payload.rotation_deg {
+        if !(-360..=360).contains(&deg) {
+            return Err(lambda_http::Error::from(
+                "rotationDeg must be between -360 and 360".to_string(),
+            ));
+        }
+    }
+
+    let points = validate_points(payload.points.as_ref(), shape.as_deref())?;
+
+    let color = match payload.color.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(value) if is_valid_hex_color(value) => Some(value.to_lowercase()),
+        Some(_) => {
+            return Err(lambda_http::Error::from(
+                "color must be a 7-character hex string like #4f8a3b".to_string(),
+            ));
+        }
+    };
+
+    Ok(ValidatedAnnotation {
+        label: trimmed_label.to_string(),
+        icon,
+        shape,
+        points,
+        color,
+    })
+}
+
+fn validate_points(
+    raw: Option<&serde_json::Value>,
+    shape: Option<&str>,
+) -> Result<Option<serde_json::Value>, lambda_http::Error> {
+    let Some(value) = raw else {
+        if shape == Some("polygon") {
+            return Err(lambda_http::Error::from(
+                "points is required when shape is polygon".to_string(),
+            ));
+        }
+        if shape == Some("line") {
+            return Err(lambda_http::Error::from(
+                "points is required when shape is line".to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+
+    let array = value
+        .as_array()
+        .ok_or_else(|| lambda_http::Error::from("points must be an array".to_string()))?;
+
+    if shape == Some("polygon") && array.len() < 3 {
+        return Err(lambda_http::Error::from(
+            "points must contain at least 3 entries for a polygon".to_string(),
+        ));
+    }
+    if shape == Some("line") && array.len() < 2 {
+        return Err(lambda_http::Error::from(
+            "points must contain at least 2 entries for a line".to_string(),
+        ));
+    }
+    if array.len() > MAX_POLYGON_POINTS {
+        return Err(lambda_http::Error::from(format!(
+            "points must contain {MAX_POLYGON_POINTS} or fewer entries"
+        )));
+    }
+    for entry in array {
+        let object = entry
+            .as_object()
+            .ok_or_else(|| lambda_http::Error::from("each point must be an object".to_string()))?;
+        let x = object
+            .get("x")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| {
+                lambda_http::Error::from("each point must have integer x".to_string())
+            })?;
+        let y = object
+            .get("y")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| {
+                lambda_http::Error::from("each point must have integer y".to_string())
+            })?;
+        if !(i64::from(i32::MIN)..=i64::from(i32::MAX)).contains(&x)
+            || !(i64::from(i32::MIN)..=i64::from(i32::MAX)).contains(&y)
+        {
+            return Err(lambda_http::Error::from(
+                "point coordinates must fit in a 32-bit integer".to_string(),
+            ));
+        }
+    }
+    Ok(Some(value.clone()))
+}
+
+fn is_valid_hex_color(value: &str) -> bool {
+    value.len() == COLOR_HEX_LEN
+        && value.starts_with('#')
+        && value[1..].chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn parse_user_id(value: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(value).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn parse_uuid(value: &str, field_name: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(value.trim())
+        .map_err(|_| lambda_http::Error::from(format!("{field_name} must be a valid UUID")))
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str::<T>(text)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Binary(bytes) => serde_json::from_slice::<T>(bytes)
+            .map_err(|e| lambda_http::Error::from(format!("Invalid JSON body: {e}"))),
+        Body::Empty => Err(lambda_http::Error::from(
+            "Request body is required".to_string(),
+        )),
+    }
+}
+
+fn row_to_annotation(row: &Row) -> GardenAnnotation {
+    GardenAnnotation {
+        id: row.get::<_, Uuid>("id").to_string(),
+        user_id: row.get::<_, Uuid>("user_id").to_string(),
+        label: row.get("label"),
+        icon: row.get("icon"),
+        shape: row.get("shape"),
+        position_x: row.get("position_x"),
+        position_y: row.get("position_y"),
+        length_inches: row.get("length_inches"),
+        width_inches: row.get("width_inches"),
+        rotation_deg: row.get("rotation_deg"),
+        points: row.get("points"),
+        color: row.get("color"),
+        sort_order: row.get("sort_order"),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+        updated_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("updated_at")
+            .to_rfc3339(),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn not_found_response() -> Result<Response<Body>, lambda_http::Error> {
+    error_response(404, "Garden annotation not found").or_else(|_| {
+        let body = serde_json::to_string(&ErrorResponse {
+            error: "Garden annotation not found".to_string(),
+        })
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+        Response::builder()
+            .status(404)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .map_err(|e| lambda_http::Error::from(e.to_string()))
+    })
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::{validate_annotation_payload, UpsertGardenAnnotationRequest};
+    use serde_json::json;
+
+    fn payload() -> UpsertGardenAnnotationRequest {
+        UpsertGardenAnnotationRequest {
+            label: "Old oak".to_string(),
+            icon: Some("🌳".to_string()),
+            shape: Some("circle".to_string()),
+            position_x: Some(120),
+            position_y: Some(80),
+            length_inches: Some(48),
+            width_inches: Some(48),
+            rotation_deg: Some(0),
+            points: None,
+            color: Some("#3a7e5a".to_string()),
+            sort_order: Some(0),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_payload() {
+        let result = validate_annotation_payload(&payload()).unwrap();
+        assert_eq!(result.label, "Old oak");
+        assert_eq!(result.shape.as_deref(), Some("circle"));
+    }
+
+    #[test]
+    fn rejects_blank_label() {
+        let mut p = payload();
+        p.label = "   ".to_string();
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_shape() {
+        let mut p = payload();
+        p.shape = Some("octagon".to_string());
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_polygon_without_points() {
+        let mut p = payload();
+        p.shape = Some("polygon".to_string());
+        p.points = None;
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_line_with_one_point() {
+        let mut p = payload();
+        p.shape = Some("line".to_string());
+        p.points = Some(json!([{"x": 0, "y": 0}]));
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn accepts_line_with_two_points() {
+        let mut p = payload();
+        p.shape = Some("line".to_string());
+        p.points = Some(json!([{"x": 0, "y": 0}, {"x": 240, "y": 0}]));
+        assert!(validate_annotation_payload(&p).is_ok());
+    }
+
+    #[test]
+    fn rejects_negative_dimensions() {
+        let mut p = payload();
+        p.length_inches = Some(-1);
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_color() {
+        let mut p = payload();
+        p.color = Some("blue".to_string());
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+
+    #[test]
+    fn rejects_long_label() {
+        let mut p = payload();
+        p.label = "x".repeat(200);
+        assert!(validate_annotation_payload(&p).is_err());
+    }
+}

--- a/services/grn-api/src/api/handlers/mod.rs
+++ b/services/grn-api/src/api/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_task;
 pub mod ai_copilot;
 pub mod analytics;
+pub mod annotation;
 pub mod bed;
 pub mod billing;
 pub mod catalog;

--- a/services/grn-api/src/api/models/annotation.rs
+++ b/services/grn-api/src/api/models/annotation.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GardenAnnotation {
+    pub id: String,
+    pub user_id: String,
+    pub label: String,
+    pub icon: Option<String>,
+    pub shape: String,
+    pub position_x: Option<i32>,
+    pub position_y: Option<i32>,
+    pub length_inches: Option<i32>,
+    pub width_inches: Option<i32>,
+    pub rotation_deg: i32,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
+    pub sort_order: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpsertGardenAnnotationRequest {
+    pub label: String,
+    #[serde(default)]
+    pub icon: Option<String>,
+    #[serde(default)]
+    pub shape: Option<String>,
+    #[serde(default, alias = "positionX")]
+    pub position_x: Option<i32>,
+    #[serde(default, alias = "positionY")]
+    pub position_y: Option<i32>,
+    #[serde(default, alias = "lengthInches")]
+    pub length_inches: Option<i32>,
+    #[serde(default, alias = "widthInches")]
+    pub width_inches: Option<i32>,
+    #[serde(default, alias = "rotationDeg")]
+    pub rotation_deg: Option<i32>,
+    #[serde(default)]
+    pub points: Option<serde_json::Value>,
+    #[serde(default)]
+    pub color: Option<String>,
+    #[serde(default, alias = "sortOrder")]
+    pub sort_order: Option<i32>,
+}

--- a/services/grn-api/src/api/models/mod.rs
+++ b/services/grn-api/src/api/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod annotation;
 pub mod bed;
 pub mod catalog;
 pub mod crop;

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -1,6 +1,6 @@
 use crate::handlers::{
-    agent_task, ai_copilot, analytics, bed, billing, catalog, claim, claim_read, crop, feed,
-    garden_canvas, listing, listing_discovery, reminder, request, user,
+    agent_task, ai_copilot, analytics, annotation, bed, billing, catalog, claim, claim_read, crop,
+    feed, garden_canvas, listing, listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -269,6 +269,22 @@ async fn route_garden_designer_request(
             _ => method_not_allowed(),
         });
     }
+    if request_path == "/annotations" {
+        return Some(match event.method().as_str() {
+            "GET" => annotation::list_my_annotations(event, correlation_id).await,
+            "POST" => annotation::create_my_annotation(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    if let Some(annotation_id) = request_path.strip_prefix("/annotations/") {
+        return Some(match event.method().as_str() {
+            "PUT" => annotation::update_my_annotation(event, correlation_id, annotation_id).await,
+            "DELETE" => {
+                annotation::delete_my_annotation(event, correlation_id, annotation_id).await
+            }
+            _ => method_not_allowed(),
+        });
+    }
     None
 }
 
@@ -293,16 +309,24 @@ fn handle(
 }
 
 fn is_garden_designer_validation_message(message: &str) -> bool {
-    // Bed shape/type/geometry + canvas + presigned-upload validation messages.
-    // Kept here so map_api_error_to_response stays under the clippy
-    // too_many_lines threshold; each contains() check is one phrase that
-    // must round-trip from a handler validation Err to a 400 response.
+    // Bed shape/type/geometry + canvas + presigned-upload + annotation
+    // validation messages. Kept here so map_api_error_to_response stays
+    // under the clippy too_many_lines threshold; each contains() check is
+    // one phrase that must round-trip from a handler validation Err to a
+    // 400 response.
     message.contains("Invalid bedType")
         || message.contains("Invalid bed shape")
+        || message.contains("Invalid annotation shape")
+        || message.contains("annotation label is required")
+        || message.contains("annotation label must be")
+        || message.contains("annotation icon must be")
+        || message.contains("annotation dimensions must be")
         || message.contains("rotationDeg must be")
         || message.contains("points is required when shape is polygon")
+        || message.contains("points is required when shape is line")
         || message.contains("points must be an array")
         || message.contains("points must contain at least 3 entries")
+        || message.contains("points must contain at least 2 entries")
         || message.contains("points must contain")
         || message.contains("each point must")
         || message.contains("point coordinates must fit")


### PR DESCRIPTION
## Summary

Adds support for placing **non-bed items** on the garden designer canvas: trees, ponds, sheds, paths/fences, and freeform landmarks. This is item #12 from the [#327](https://github.com/allenheltondev/olivias-garden-foundation/pull/327) review pass — split into its own PR because it warrants its own data model.

**Stacking note:** opened against \`claude/garden-designer-ui\` (PR #327). When that merges to \`main\` GitHub will retarget this PR's base automatically.

### Schema (migration 0030)

- New \`garden_annotations\` table parallel to \`garden_beds\`: \`label\`, \`icon\`, \`shape\` (\`rect\` / \`circle\` / \`polygon\` / **\`line\`**), \`position_x/y\`, \`length/width_inches\`, \`rotation_deg\`, \`points\` jsonb, \`color\`, \`sort_order\`, \`archived_at\`. Annotations don't carry soil or crop data and aren't fed to LLMs.
- \`line\` is the fourth shape (open polyline) for paths/fences. Polygon and line both require points; constraints enforce that.

### API

- \`/annotations\` (GET, POST) and \`/annotations/{id}\` (PUT, DELETE), mirroring the \`/beds\` shape.
- Allow-list validation for shape, polygon-vs-line point counts (≥3 vs ≥2), rotation/dimension/color/icon bounds, soft-delete via \`archived_at\`.
- 9 unit tests + new integration-test scenarios (auth boundary, 9 validation cases, full CRUD with a line→rect shape switch, 404 on unknown id, cleanup in finally).
- OpenAPI: \`GardenAnnotation\` + \`UpsertGardenAnnotationRequest\` schemas and the two new paths.

### Frontend

- 5-button \`ANNOTATION_PRESETS\` toolbar section: Tree (circle), Pond (polygon), Shed (rect), Path (line), Other (rect). Each preset seeds defaults; the user renames freely.
- New \`AnnotationShape\` component on its own layer below beds, with dashed outline + lighter fill so beds and annotations stay visually distinguishable. Drag/resize/rotate via Konva Transformer; polygons and lines bake the scale into their points array.
- New \`AnnotationInspector\` side panel: label, icon, dimensions, color palette. No soil, no crops, no growable-area metric.
- \`useGardenDesigner\` now models selection as a discriminated union (\`{ kind: 'bed' | 'annotation'; id: string } | null\`) so both inspectors are mutually exclusive without two parallel state slots.
- \`GardenPropertiesBar\` adds an "Annotations" metric next to Beds / Growable area. Annotations are **not** counted toward growable area.

### Gates

- \`cargo fmt\`, \`cargo clippy --all-targets -- -D warnings\`, \`cargo check\`, 211 cargo unit tests pass.
- \`tsc --noEmit\`, \`eslint .\`, \`vite build\`, perf budget (954 KB total / 200 KB main / 369 KB designer chunk), 236 vitest tests pass.

## Test plan

- [ ] After deploy, hit \`/garden\` and verify all 5 annotation presets show up in the new toolbar section
- [ ] Add one of each preset — confirm shape, default size, default color match expectations (Path renders as a thick brown line; Pond as a 4-corner polygon you can drag/resize)
- [ ] Open the inspector for an annotation, change label and icon, color — confirm round-trip after refresh
- [ ] Add ≥3 annotations and confirm "Annotations" count in the top properties bar updates; growable area is still beds-only
- [ ] Delete an annotation; \`DELETE /annotations/:id\` returns 204 with no console JSON parse error (the apiFetch fix from PR #327's review iteration applies here too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)