### PR TITLE
GRN: open add-crop in a modal from the designer's bed inspector

### DIFF
--- a/.github/workflows/pull-request-staging-validation-reusable.yml
+++ b/.github/workflows/pull-request-staging-validation-reusable.yml
@@ -421,7 +421,13 @@ jobs:
     name: Deploy GRN Staging Backend
     runs-on: ubuntu-latest
     needs: [deploy-staging-foundation]
-    if: inputs.shared_all == 'true' || inputs.grn_backend == 'true'
+    # Also runs when only the frontend changed: the frontend deploy job
+    # below pulls its target S3 bucket and CloudFront distribution from
+    # this job's outputs, so skipping the backend on a pure-frontend PR
+    # would silently skip the frontend deploy too. The SAM update is a
+    # no-op when no backend artifacts changed, so the cost is small.
+    # (admin/store backends already use the same pattern below.)
+    if: inputs.shared_all == 'true' || inputs.grn_backend == 'true' || inputs.grn_frontend == 'true'
     environment:
       name: staging
     env:

--- a/apps/grn/src/components/CropPlanner/CropForm.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.tsx
@@ -1,0 +1,468 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button, Card, Input, Textarea } from '@olivias/ui';
+import {
+  createMyCrop,
+  listCatalogCrops,
+  listMyBeds,
+  type UpsertGrowerCropRequest,
+} from '../../services/api';
+import type { GardenBed, GrowerCropItem } from '../../types/listing';
+import { BedSelector } from './BedSelector';
+import { CropPicker, type CropPickerSelection } from './CropPicker';
+import { visualForCrop } from './cropVisuals';
+import { createLogger } from '../../utils/logging';
+
+const logger = createLogger('crop-form');
+
+interface PlantingDetails {
+  bedId: string | null;
+  plantingDate: string;
+  expectedHarvestDate: string;
+  plantCount: string;
+  spacingInches: string;
+  status: 'interested' | 'planning' | 'growing' | 'paused';
+}
+
+interface AdvancedDetails {
+  nickname: string;
+  defaultUnit: string;
+  notes: string;
+  visibility: 'private' | 'local' | 'public';
+  surplusEnabled: boolean;
+}
+
+const STATUS_OPTIONS: Array<{
+  id: PlantingDetails['status'];
+  label: string;
+  description: string;
+  emoji: string;
+}> = [
+  { id: 'interested', label: 'Interested', description: 'Just noting it down', emoji: '💭' },
+  { id: 'planning', label: 'Planning', description: 'I plan to plant this season', emoji: '📋' },
+  { id: 'growing', label: 'Growing', description: "It's in the ground right now", emoji: '🌱' },
+  { id: 'paused', label: 'Paused', description: 'Taking a break', emoji: '⏸️' },
+];
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDaysIso(base: string, days: number): string {
+  const d = new Date(`${base}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(a: string, b: string): number | null {
+  if (!a || !b) return null;
+  const start = new Date(`${a}T00:00:00Z`).getTime();
+  const end = new Date(`${b}T00:00:00Z`).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.round((end - start) / (1000 * 60 * 60 * 24));
+}
+
+export interface CropFormProps {
+  /**
+   * If provided, the bed selector is hidden and the crop is forced
+   * onto this bed. Used by the designer's "+ Add crop" modal so the
+   * bed context isn't asked for twice.
+   */
+  lockedBed?: GardenBed | null;
+  /** Initial bed selection when the bed selector is shown. */
+  initialBedId?: string | null;
+  /** Called after the crop is created successfully. */
+  onSuccess: (created: GrowerCropItem) => void;
+  /** Called when the user clicks Cancel. */
+  onCancel: () => void;
+  /** Label for the primary submit button. Defaults to "Add to my garden". */
+  submitLabel?: string;
+}
+
+/**
+ * The full add-crop form, extracted from NewCropPage so it can be
+ * embedded in a modal from the garden designer. The page wrapper still
+ * renders this component — the only behavior differences in modal mode
+ * are: bed selector is hidden, success/cancel are caller-controlled,
+ * and there's no top-level page chrome (SectionHeading/Panel).
+ */
+export function CropForm({
+  lockedBed = null,
+  initialBedId = null,
+  onSuccess,
+  onCancel,
+  submitLabel = 'Add to my garden',
+}: CropFormProps) {
+  const queryClient = useQueryClient();
+
+  const { data: catalog = [], isLoading: isLoadingCatalog } = useQuery({
+    queryKey: ['catalogCrops'],
+    queryFn: listCatalogCrops,
+  });
+
+  const { data: beds = [], isLoading: isLoadingBeds } = useQuery({
+    queryKey: ['myBeds'],
+    queryFn: listMyBeds,
+    // The modal flow already knows the bed; no need to pull the list.
+    enabled: lockedBed === null,
+  });
+
+  const [selection, setSelection] = useState<CropPickerSelection | null>(null);
+  const [planting, setPlanting] = useState<PlantingDetails>({
+    bedId: lockedBed?.id ?? initialBedId,
+    plantingDate: '',
+    expectedHarvestDate: '',
+    plantCount: '',
+    spacingInches: '',
+    status: 'planning',
+  });
+  const [advanced, setAdvanced] = useState<AdvancedDetails>({
+    nickname: '',
+    defaultUnit: '',
+    notes: '',
+    visibility: 'local',
+    surplusEnabled: false,
+  });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const visual = useMemo(
+    () => visualForCrop(selection?.cropName, selection?.category),
+    [selection]
+  );
+
+  const daysToHarvest = useMemo(
+    () => daysBetween(planting.plantingDate, planting.expectedHarvestDate),
+    [planting.plantingDate, planting.expectedHarvestDate]
+  );
+
+  const createMutation = useMutation({
+    mutationFn: createMyCrop,
+    onSuccess: (created) => {
+      void queryClient.invalidateQueries({ queryKey: ['myCrops'] });
+      logger.info('Created crop');
+      onSuccess(created);
+    },
+    onError: (err) => {
+      logger.error('Failed to create crop', err instanceof Error ? err : undefined);
+      setSubmitError(err instanceof Error ? err.message : 'Could not save your crop');
+    },
+  });
+
+  const canSubmit =
+    selection !== null &&
+    selection.cropName.trim().length > 0 &&
+    !createMutation.isPending;
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setSubmitError(null);
+    if (!selection) {
+      setSubmitError('Pick a crop first.');
+      return;
+    }
+    const trimmedName = selection.cropName.trim();
+    if (!trimmedName) {
+      setSubmitError('Crop needs a name.');
+      return;
+    }
+
+    const payload: UpsertGrowerCropRequest = {
+      cropName: trimmedName,
+      canonicalId: selection.catalogCropId ?? undefined,
+      status: planting.status,
+      visibility: advanced.visibility,
+      surplusEnabled: advanced.surplusEnabled,
+      nickname: advanced.nickname.trim() || undefined,
+      defaultUnit: advanced.defaultUnit.trim() || undefined,
+      notes: advanced.notes.trim() || undefined,
+      bedId: lockedBed?.id ?? planting.bedId,
+      plantingDate: planting.plantingDate || null,
+      expectedHarvestDate: planting.expectedHarvestDate || null,
+      plantCount: planting.plantCount ? Number(planting.plantCount) : null,
+      spacingInches: planting.spacingInches ? Number(planting.spacingInches) : null,
+    };
+
+    createMutation.mutate(payload);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grn-new-crop__form">
+      <Card className="grn-new-crop__hero" padding="6">
+        <div
+          className="grn-new-crop__hero-visual"
+          style={{ background: `linear-gradient(135deg, ${visual.accent}33, ${visual.accent}10)` }}
+          aria-hidden="true"
+        >
+          <span className="grn-new-crop__hero-emoji">{visual.emoji}</span>
+        </div>
+        <div className="grn-new-crop__hero-body">
+          <CropPicker
+            catalog={catalog}
+            isLoading={isLoadingCatalog}
+            value={selection}
+            onChange={setSelection}
+          />
+        </div>
+      </Card>
+
+      <Card padding="6">
+        <div className="grn-new-crop__section-head">
+          <span className="grn-new-crop__step">2</span>
+          <div>
+            <h2 className="grn-new-crop__section-title">Planting plan</h2>
+            <p className="grn-new-crop__section-sub">
+              Where it&apos;s going, when, and how many. Skip anything you don&apos;t know yet.
+            </p>
+          </div>
+        </div>
+
+        <fieldset className="grn-status-picker" aria-label="Planting status">
+          {STATUS_OPTIONS.map((option) => {
+            const isActive = planting.status === option.id;
+            return (
+              <label
+                key={option.id}
+                className={`grn-status-option ${isActive ? 'is-active' : ''}`.trim()}
+              >
+                <input
+                  type="radio"
+                  name="planting-status"
+                  value={option.id}
+                  checked={isActive}
+                  onChange={() =>
+                    setPlanting((prev) => ({
+                      ...prev,
+                      status: option.id,
+                      // When the gardener says "it's growing now", default
+                      // planting date to today so the harvest progress bar
+                      // starts ticking.
+                      plantingDate:
+                        option.id === 'growing' && !prev.plantingDate
+                          ? todayIso()
+                          : prev.plantingDate,
+                    }))
+                  }
+                />
+                <span className="grn-status-option__emoji" aria-hidden="true">
+                  {option.emoji}
+                </span>
+                <span className="grn-status-option__text">
+                  <strong>{option.label}</strong>
+                  <span>{option.description}</span>
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+
+        {lockedBed ? (
+          <p className="grn-new-crop__locked-bed" aria-live="polite">
+            Adding to <strong>{lockedBed.name}</strong>
+          </p>
+        ) : (
+          <BedSelector
+            beds={beds}
+            isLoading={isLoadingBeds}
+            value={planting.bedId}
+            onChange={(bedId) => setPlanting((prev) => ({ ...prev, bedId }))}
+          />
+        )}
+
+        <div className="grn-new-crop__row">
+          <Input
+            label="Planting date"
+            type="text"
+            placeholder="YYYY-MM-DD"
+            value={planting.plantingDate}
+            onChange={(event) =>
+              setPlanting((prev) => ({ ...prev, plantingDate: event.target.value }))
+            }
+          />
+          <Input
+            label="Expected first harvest"
+            type="text"
+            placeholder="YYYY-MM-DD"
+            value={planting.expectedHarvestDate}
+            onChange={(event) =>
+              setPlanting((prev) => ({ ...prev, expectedHarvestDate: event.target.value }))
+            }
+          />
+        </div>
+
+        <div className="grn-quick-pick" role="group" aria-label="Quick harvest estimates">
+          <span className="grn-quick-pick__label">Typical harvest window:</span>
+          {[60, 75, 90, 120].map((days) => (
+            <button
+              key={days}
+              type="button"
+              className="grn-quick-pick__chip"
+              onClick={() => {
+                const start = planting.plantingDate || todayIso();
+                setPlanting((prev) => ({
+                  ...prev,
+                  plantingDate: prev.plantingDate || start,
+                  expectedHarvestDate: addDaysIso(start, days),
+                }));
+              }}
+              disabled={!!daysToHarvest && daysToHarvest === days}
+            >
+              {days} days
+            </button>
+          ))}
+        </div>
+
+        {daysToHarvest !== null ? (
+          <p className="grn-new-crop__harvest-hint">
+            {daysToHarvest >= 0
+              ? `🌾 About ${daysToHarvest} day${daysToHarvest === 1 ? '' : 's'} until first harvest`
+              : `⚠️ Harvest date is before planting date — double-check the dates above.`}
+          </p>
+        ) : null}
+
+        <div className="grn-new-crop__row">
+          <Input
+            label="Number of plants"
+            type="number"
+            min={1}
+            placeholder="e.g. 6"
+            value={planting.plantCount}
+            onChange={(event) =>
+              setPlanting((prev) => ({ ...prev, plantCount: event.target.value }))
+            }
+          />
+          <Input
+            label="Spacing (inches)"
+            type="number"
+            min={0}
+            placeholder="e.g. 18"
+            value={planting.spacingInches}
+            onChange={(event) =>
+              setPlanting((prev) => ({ ...prev, spacingInches: event.target.value }))
+            }
+          />
+        </div>
+      </Card>
+
+      <Card padding="6">
+        <button
+          type="button"
+          className="grn-disclosure"
+          aria-expanded={showAdvanced}
+          onClick={() => setShowAdvanced((prev) => !prev)}
+        >
+          <span className="grn-disclosure__chevron" aria-hidden="true">
+            {showAdvanced ? '▾' : '▸'}
+          </span>
+          <span>
+            <strong>Notes &amp; sharing</strong>
+            <span className="grn-disclosure__hint">
+              {' '}
+              — nickname, units, and whether to share surplus with the community.
+            </span>
+          </span>
+        </button>
+
+        {showAdvanced ? (
+          <div className="grn-new-crop__advanced">
+            <div className="grn-new-crop__row">
+              <Input
+                label="Nickname"
+                placeholder="e.g. Big Boy, Sweet 100s"
+                value={advanced.nickname}
+                onChange={(event) =>
+                  setAdvanced((prev) => ({ ...prev, nickname: event.target.value }))
+                }
+              />
+              <Input
+                label="Default harvest unit"
+                placeholder="lb, bunch, each"
+                value={advanced.defaultUnit}
+                onChange={(event) =>
+                  setAdvanced((prev) => ({ ...prev, defaultUnit: event.target.value }))
+                }
+              />
+            </div>
+            <Textarea
+              label="Notes"
+              placeholder="Anything you want to remember — varieties tried, soil amendments, etc."
+              rows={3}
+              value={advanced.notes}
+              onChange={(event) =>
+                setAdvanced((prev) => ({ ...prev, notes: event.target.value }))
+              }
+            />
+
+            <div className="grn-share-toggle">
+              <label className="grn-share-toggle__row">
+                <input
+                  type="checkbox"
+                  checked={advanced.surplusEnabled}
+                  onChange={(event) =>
+                    setAdvanced((prev) => ({
+                      ...prev,
+                      surplusEnabled: event.target.checked,
+                    }))
+                  }
+                />
+                <span>
+                  <strong>Share surplus with neighbors</strong>
+                  <span>
+                    When you have extra, you can list it for nearby gatherers without retyping crop info.
+                  </span>
+                </span>
+              </label>
+
+              {advanced.surplusEnabled ? (
+                <fieldset className="grn-share-toggle__visibility">
+                  <legend>Who can see this crop in your garden?</legend>
+                  {(
+                    [
+                      { id: 'private', label: 'Just me', emoji: '🔒' },
+                      { id: 'local', label: 'Nearby community', emoji: '🤝' },
+                      { id: 'public', label: 'Anyone on GRN', emoji: '🌍' },
+                    ] as const
+                  ).map((option) => (
+                    <label
+                      key={option.id}
+                      className={`grn-share-toggle__option ${
+                        advanced.visibility === option.id ? 'is-active' : ''
+                      }`.trim()}
+                    >
+                      <input
+                        type="radio"
+                        name="visibility"
+                        value={option.id}
+                        checked={advanced.visibility === option.id}
+                        onChange={() =>
+                          setAdvanced((prev) => ({ ...prev, visibility: option.id }))
+                        }
+                      />
+                      <span aria-hidden="true">{option.emoji}</span>
+                      <span>{option.label}</span>
+                    </label>
+                  ))}
+                </fieldset>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </Card>
+
+      {submitError ? (
+        <p className="grn-new-crop__submit-error" role="alert">
+          {submitError}
+        </p>
+      ) : null}
+
+      <div className="grn-new-crop__actions">
+        <Button type="button" variant="ghost" size="md" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary" size="md" disabled={!canSubmit}>
+          {createMutation.isPending ? 'Planting…' : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/AddCropModal.tsx
+++ b/apps/grn/src/components/GardenDesigner/AddCropModal.tsx
@@ -1,0 +1,34 @@
+import { CropForm } from '../CropPlanner/CropForm';
+import { Modal } from '../Modal';
+import type { GardenBed } from '../../types/listing';
+
+interface AddCropModalProps {
+  bed: GardenBed;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Wraps the shared CropForm in the designer's modal so users can attach
+ * a new crop to the currently-selected bed without leaving the canvas.
+ * The bed selector is hidden — the bed context is already obvious from
+ * the inspector — and success closes the modal so the new crop chip
+ * appears immediately on the bed.
+ */
+export function AddCropModal({ bed, open, onClose }: AddCropModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`Add a crop to ${bed.name}`}
+      subtitle="Tell us what's going in — we'll attach it to this bed."
+    >
+      <CropForm
+        lockedBed={bed}
+        onCancel={onClose}
+        onSuccess={onClose}
+        submitLabel="Add to this bed"
+      />
+    </Modal>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import type { BedType, GardenBed, GrowerCropItem, SunExposure } from '../../types/listing';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { AddCropModal } from './AddCropModal';
 import {
   BED_COLOR_PALETTE,
   BED_TYPES,
@@ -58,6 +58,7 @@ export function BedInspector({
   const [soils, setSoils] = useState<string[]>(parseSoilField(bed.soilType));
   const [notes, setNotes] = useState(bed.locationNotes ?? '');
   const [color, setColor] = useState<string | null>(bed.color);
+  const [addCropOpen, setAddCropOpen] = useState(false);
 
   const lengthValue = draftLength !== null
     ? draftLength
@@ -282,9 +283,14 @@ export function BedInspector({
       <section className="grn-designer-inspector__crops" aria-label="Crops in this bed">
         <header className="grn-designer-inspector__crops-header">
           <h3>Crops</h3>
-          <Link to={`/crops/new?bedId=${bed.id}`} className="grn-designer-inspector__add-crop">
+          <button
+            type="button"
+            className="grn-designer-inspector__add-crop"
+            onClick={() => setAddCropOpen(true)}
+            disabled={!isEditable}
+          >
             + Add crop
-          </Link>
+          </button>
         </header>
         {cropsForBed.length === 0 ? (
           <p className="grn-designer-inspector__empty">
@@ -328,6 +334,7 @@ export function BedInspector({
           Delete bed
         </button>
       </footer>
+      <AddCropModal bed={bed} open={addCropOpen} onClose={() => setAddCropOpen(false)} />
     </aside>
   );
 }

--- a/apps/grn/src/components/Modal.tsx
+++ b/apps/grn/src/components/Modal.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  /** Optional descriptive subtitle below the title. */
+  subtitle?: string;
+  /** Width modifier; defaults to "lg" (~720px). */
+  size?: 'md' | 'lg';
+  /** className suffix appended to the dialog for one-off styling overrides. */
+  className?: string;
+}
+
+/**
+ * Thin wrapper around the native <dialog> element. We get focus trap,
+ * inert background, Esc-to-close, and accessible role/labelling for
+ * free — the only React-side glue is wiring the open prop to
+ * showModal()/close() and emitting onClose for both Esc and the X
+ * button so the caller can keep its own state in sync.
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  subtitle,
+  size = 'lg',
+  className,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  function handleNativeClose() {
+    // Native close fires when the user hits Esc or when we call close().
+    // Bouncing it back to onClose keeps the parent's state honest.
+    if (open) onClose();
+  }
+
+  function handleBackdropClick(event: React.MouseEvent<HTMLDialogElement>) {
+    // Clicks on the dialog element itself (vs. its content) hit the
+    // backdrop. Compare the target identity to the dialog node.
+    if (event.target === dialogRef.current) {
+      onClose();
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={`grn-modal grn-modal--${size} ${className ?? ''}`.trim()}
+      onClose={handleNativeClose}
+      onClick={handleBackdropClick}
+      aria-labelledby="grn-modal-title"
+    >
+      <header className="grn-modal__header">
+        <div className="grn-modal__title-block">
+          <h2 id="grn-modal-title" className="grn-modal__title">{title}</h2>
+          {subtitle ? <p className="grn-modal__subtitle">{subtitle}</p> : null}
+        </div>
+        <button
+          type="button"
+          className="grn-modal__close"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </header>
+      <div className="grn-modal__body">{children}</div>
+    </dialog>
+  );
+}

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -1,72 +1,21 @@
-import { useMemo, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Button, Card, Input, Panel, SectionHeading, Textarea } from '@olivias/ui';
-import {
-  createMyCrop,
-  getMe,
-  listCatalogCrops,
-  listMyBeds,
-  type UpsertGrowerCropRequest,
-} from '../services/api';
-import { CropPicker, type CropPickerSelection } from '../components/CropPlanner/CropPicker';
-import { BedSelector } from '../components/CropPlanner/BedSelector';
-import { visualForCrop } from '../components/CropPlanner/cropVisuals';
+import { useMemo } from 'react';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Panel, SectionHeading } from '@olivias/ui';
+import { CropForm } from '../components/CropPlanner/CropForm';
 import { PlantLoader } from '../components/branding/PlantLoader';
-import { createLogger } from '../utils/logging';
+import { getMe, listMyBeds } from '../services/api';
 
-const logger = createLogger('new-crop-page');
-
-interface PlantingDetails {
-  bedId: string | null;
-  plantingDate: string;
-  expectedHarvestDate: string;
-  plantCount: string;
-  spacingInches: string;
-  status: 'interested' | 'planning' | 'growing' | 'paused';
-}
-
-interface AdvancedDetails {
-  nickname: string;
-  defaultUnit: string;
-  notes: string;
-  visibility: 'private' | 'local' | 'public';
-  surplusEnabled: boolean;
-}
-
-const STATUS_OPTIONS: Array<{
-  id: PlantingDetails['status'];
-  label: string;
-  description: string;
-  emoji: string;
-}> = [
-  { id: 'interested', label: 'Interested', description: 'Just noting it down', emoji: '💭' },
-  { id: 'planning', label: 'Planning', description: 'I plan to plant this season', emoji: '📋' },
-  { id: 'growing', label: 'Growing', description: "It's in the ground right now", emoji: '🌱' },
-  { id: 'paused', label: 'Paused', description: 'Taking a break', emoji: '⏸️' },
-];
-
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function addDaysIso(base: string, days: number): string {
-  const d = new Date(`${base}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().slice(0, 10);
-}
-
-function daysBetween(a: string, b: string): number | null {
-  if (!a || !b) return null;
-  const start = new Date(`${a}T00:00:00Z`).getTime();
-  const end = new Date(`${b}T00:00:00Z`).getTime();
-  if (Number.isNaN(start) || Number.isNaN(end)) return null;
-  return Math.round((end - start) / (1000 * 60 * 60 * 24));
-}
-
+/**
+ * Standalone page wrapper around <CropForm/>. The same form is also
+ * embedded in a modal from the garden designer's bed inspector — that
+ * lives in components/GardenDesigner/AddCropModal.tsx and reuses the
+ * same component so the two surfaces never drift.
+ */
 export function NewCropPage() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const requestedBedId = searchParams.get('bedId');
 
   const { data: profile, isLoading: isLoadingProfile } = useQuery({
     queryKey: ['userProfile'],
@@ -74,58 +23,16 @@ export function NewCropPage() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: catalog = [], isLoading: isLoadingCatalog } = useQuery({
-    queryKey: ['catalogCrops'],
-    queryFn: listCatalogCrops,
-  });
-
-  const { data: beds = [], isLoading: isLoadingBeds } = useQuery({
+  const { data: beds = [] } = useQuery({
     queryKey: ['myBeds'],
     queryFn: listMyBeds,
-    enabled: profile?.userType === 'grower',
+    enabled: profile?.userType === 'grower' && requestedBedId !== null,
   });
 
-  const [selection, setSelection] = useState<CropPickerSelection | null>(null);
-  const [planting, setPlanting] = useState<PlantingDetails>({
-    bedId: null,
-    plantingDate: '',
-    expectedHarvestDate: '',
-    plantCount: '',
-    spacingInches: '',
-    status: 'planning',
-  });
-  const [advanced, setAdvanced] = useState<AdvancedDetails>({
-    nickname: '',
-    defaultUnit: '',
-    notes: '',
-    visibility: 'local',
-    surplusEnabled: false,
-  });
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  const visual = useMemo(
-    () => visualForCrop(selection?.cropName, selection?.category),
-    [selection]
+  const lockedBed = useMemo(
+    () => (requestedBedId ? beds.find((b) => b.id === requestedBedId) ?? null : null),
+    [beds, requestedBedId]
   );
-
-  const daysToHarvest = useMemo(
-    () => daysBetween(planting.plantingDate, planting.expectedHarvestDate),
-    [planting.plantingDate, planting.expectedHarvestDate]
-  );
-
-  const createMutation = useMutation({
-    mutationFn: createMyCrop,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myCrops'] });
-      logger.info('Created crop from new-crop page');
-      navigate('/crops', { replace: true });
-    },
-    onError: (err) => {
-      logger.error('Failed to create crop', err instanceof Error ? err : undefined);
-      setSubmitError(err instanceof Error ? err.message : 'Could not save your crop');
-    },
-  });
 
   if (isLoadingProfile) {
     return (
@@ -142,43 +49,6 @@ export function NewCropPage() {
     return <Navigate to="/" replace />;
   }
 
-  const canSubmit =
-    selection !== null &&
-    selection.cropName.trim().length > 0 &&
-    !createMutation.isPending;
-
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    setSubmitError(null);
-    if (!selection) {
-      setSubmitError('Pick a crop first.');
-      return;
-    }
-    const trimmedName = selection.cropName.trim();
-    if (!trimmedName) {
-      setSubmitError('Crop needs a name.');
-      return;
-    }
-
-    const payload: UpsertGrowerCropRequest = {
-      cropName: trimmedName,
-      canonicalId: selection.catalogCropId ?? undefined,
-      status: planting.status,
-      visibility: advanced.visibility,
-      surplusEnabled: advanced.surplusEnabled,
-      nickname: advanced.nickname.trim() || undefined,
-      defaultUnit: advanced.defaultUnit.trim() || undefined,
-      notes: advanced.notes.trim() || undefined,
-      bedId: planting.bedId,
-      plantingDate: planting.plantingDate || null,
-      expectedHarvestDate: planting.expectedHarvestDate || null,
-      plantCount: planting.plantCount ? Number(planting.plantCount) : null,
-      spacingInches: planting.spacingInches ? Number(planting.spacingInches) : null,
-    };
-
-    createMutation.mutate(payload);
-  };
-
   return (
     <section className="grn-section grn-new-crop">
       <SectionHeading
@@ -187,281 +57,12 @@ export function NewCropPage() {
         body="Tell us what's going in the ground — we'll tuck it into your garden plan."
       />
 
-      <form onSubmit={handleSubmit} className="grn-new-crop__form">
-        <Card className="grn-new-crop__hero" padding="6">
-          <div
-            className="grn-new-crop__hero-visual"
-            style={{ background: `linear-gradient(135deg, ${visual.accent}33, ${visual.accent}10)` }}
-            aria-hidden="true"
-          >
-            <span className="grn-new-crop__hero-emoji">{visual.emoji}</span>
-          </div>
-          <div className="grn-new-crop__hero-body">
-            <CropPicker
-              catalog={catalog}
-              isLoading={isLoadingCatalog}
-              value={selection}
-              onChange={setSelection}
-            />
-          </div>
-        </Card>
-
-        <Card padding="6">
-          <div className="grn-new-crop__section-head">
-            <span className="grn-new-crop__step">2</span>
-            <div>
-              <h2 className="grn-new-crop__section-title">Planting plan</h2>
-              <p className="grn-new-crop__section-sub">
-                Where it&apos;s going, when, and how many. Skip anything you don&apos;t know yet.
-              </p>
-            </div>
-          </div>
-
-          <fieldset className="grn-status-picker" aria-label="Planting status">
-            {STATUS_OPTIONS.map((option) => {
-              const isActive = planting.status === option.id;
-              return (
-                <label
-                  key={option.id}
-                  className={`grn-status-option ${isActive ? 'is-active' : ''}`.trim()}
-                >
-                  <input
-                    type="radio"
-                    name="planting-status"
-                    value={option.id}
-                    checked={isActive}
-                    onChange={() =>
-                      setPlanting((prev) => ({
-                        ...prev,
-                        status: option.id,
-                        // When the gardener says "it's growing now", default planting
-                        // date to today so the harvest progress bar starts ticking.
-                        plantingDate:
-                          option.id === 'growing' && !prev.plantingDate
-                            ? todayIso()
-                            : prev.plantingDate,
-                      }))
-                    }
-                  />
-                  <span className="grn-status-option__emoji" aria-hidden="true">
-                    {option.emoji}
-                  </span>
-                  <span className="grn-status-option__text">
-                    <strong>{option.label}</strong>
-                    <span>{option.description}</span>
-                  </span>
-                </label>
-              );
-            })}
-          </fieldset>
-
-          <BedSelector
-            beds={beds}
-            isLoading={isLoadingBeds}
-            value={planting.bedId}
-            onChange={(bedId) => setPlanting((prev) => ({ ...prev, bedId }))}
-          />
-
-          <div className="grn-new-crop__row">
-            <Input
-              label="Planting date"
-              type="text"
-              placeholder="YYYY-MM-DD"
-              value={planting.plantingDate}
-              onChange={(event) =>
-                setPlanting((prev) => ({ ...prev, plantingDate: event.target.value }))
-              }
-            />
-            <Input
-              label="Expected first harvest"
-              type="text"
-              placeholder="YYYY-MM-DD"
-              value={planting.expectedHarvestDate}
-              onChange={(event) =>
-                setPlanting((prev) => ({ ...prev, expectedHarvestDate: event.target.value }))
-              }
-            />
-          </div>
-
-          <div className="grn-quick-pick" role="group" aria-label="Quick harvest estimates">
-            <span className="grn-quick-pick__label">Typical harvest window:</span>
-            {[60, 75, 90, 120].map((days) => (
-              <button
-                key={days}
-                type="button"
-                className="grn-quick-pick__chip"
-                onClick={() => {
-                  const start = planting.plantingDate || todayIso();
-                  setPlanting((prev) => ({
-                    ...prev,
-                    plantingDate: prev.plantingDate || start,
-                    expectedHarvestDate: addDaysIso(start, days),
-                  }));
-                }}
-                disabled={!!daysToHarvest && daysToHarvest === days}
-              >
-                {days} days
-              </button>
-            ))}
-          </div>
-
-          {daysToHarvest !== null ? (
-            <p className="grn-new-crop__harvest-hint">
-              {daysToHarvest >= 0
-                ? `🌾 About ${daysToHarvest} day${daysToHarvest === 1 ? '' : 's'} until first harvest`
-                : `⚠️ Harvest date is before planting date — double-check the dates above.`}
-            </p>
-          ) : null}
-
-          <div className="grn-new-crop__row">
-            <Input
-              label="Number of plants"
-              type="number"
-              min={1}
-              placeholder="e.g. 6"
-              value={planting.plantCount}
-              onChange={(event) =>
-                setPlanting((prev) => ({ ...prev, plantCount: event.target.value }))
-              }
-            />
-            <Input
-              label="Spacing (inches)"
-              type="number"
-              min={0}
-              placeholder="e.g. 18"
-              value={planting.spacingInches}
-              onChange={(event) =>
-                setPlanting((prev) => ({ ...prev, spacingInches: event.target.value }))
-              }
-            />
-          </div>
-        </Card>
-
-        <Card padding="6">
-          <button
-            type="button"
-            className="grn-disclosure"
-            aria-expanded={showAdvanced}
-            onClick={() => setShowAdvanced((prev) => !prev)}
-          >
-            <span className="grn-disclosure__chevron" aria-hidden="true">
-              {showAdvanced ? '▾' : '▸'}
-            </span>
-            <span>
-              <strong>Notes &amp; sharing</strong>
-              <span className="grn-disclosure__hint">
-                {' '}
-                — nickname, units, and whether to share surplus with the community.
-              </span>
-            </span>
-          </button>
-
-          {showAdvanced ? (
-            <div className="grn-new-crop__advanced">
-              <div className="grn-new-crop__row">
-                <Input
-                  label="Nickname"
-                  placeholder="e.g. Big Boy, Sweet 100s"
-                  value={advanced.nickname}
-                  onChange={(event) =>
-                    setAdvanced((prev) => ({ ...prev, nickname: event.target.value }))
-                  }
-                />
-                <Input
-                  label="Default harvest unit"
-                  placeholder="lb, bunch, each"
-                  value={advanced.defaultUnit}
-                  onChange={(event) =>
-                    setAdvanced((prev) => ({ ...prev, defaultUnit: event.target.value }))
-                  }
-                />
-              </div>
-              <Textarea
-                label="Notes"
-                placeholder="Anything you want to remember — varieties tried, soil amendments, etc."
-                rows={3}
-                value={advanced.notes}
-                onChange={(event) =>
-                  setAdvanced((prev) => ({ ...prev, notes: event.target.value }))
-                }
-              />
-
-              <div className="grn-share-toggle">
-                <label className="grn-share-toggle__row">
-                  <input
-                    type="checkbox"
-                    checked={advanced.surplusEnabled}
-                    onChange={(event) =>
-                      setAdvanced((prev) => ({
-                        ...prev,
-                        surplusEnabled: event.target.checked,
-                      }))
-                    }
-                  />
-                  <span>
-                    <strong>Share surplus with neighbors</strong>
-                    <span>
-                      When you have extra, you can list it for nearby gatherers without retyping crop info.
-                    </span>
-                  </span>
-                </label>
-
-                {advanced.surplusEnabled ? (
-                  <fieldset className="grn-share-toggle__visibility">
-                    <legend>Who can see this crop in your garden?</legend>
-                    {(
-                      [
-                        { id: 'private', label: 'Just me', emoji: '🔒' },
-                        { id: 'local', label: 'Nearby community', emoji: '🤝' },
-                        { id: 'public', label: 'Anyone on GRN', emoji: '🌍' },
-                      ] as const
-                    ).map((option) => (
-                      <label
-                        key={option.id}
-                        className={`grn-share-toggle__option ${
-                          advanced.visibility === option.id ? 'is-active' : ''
-                        }`.trim()}
-                      >
-                        <input
-                          type="radio"
-                          name="visibility"
-                          value={option.id}
-                          checked={advanced.visibility === option.id}
-                          onChange={() =>
-                            setAdvanced((prev) => ({ ...prev, visibility: option.id }))
-                          }
-                        />
-                        <span aria-hidden="true">{option.emoji}</span>
-                        <span>{option.label}</span>
-                      </label>
-                    ))}
-                  </fieldset>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-        </Card>
-
-        {submitError ? (
-          <p className="grn-new-crop__submit-error" role="alert">
-            {submitError}
-          </p>
-        ) : null}
-
-        <div className="grn-new-crop__actions">
-          <Button
-            type="button"
-            variant="ghost"
-            size="md"
-            onClick={() => navigate('/crops')}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" size="md" disabled={!canSubmit}>
-            {createMutation.isPending ? 'Planting…' : 'Add to my garden'}
-          </Button>
-        </div>
-      </form>
+      <CropForm
+        lockedBed={lockedBed}
+        initialBedId={requestedBedId}
+        onCancel={() => navigate('/crops')}
+        onSuccess={() => navigate('/crops', { replace: true })}
+      />
     </section>
   );
 }

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -2099,15 +2099,26 @@ body {
 }
 
 .grn-designer-inspector__add-crop {
+  font: inherit;
   font-size: 0.85rem;
   color: var(--og-color-moss);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
   text-decoration: none;
   font-weight: 500;
 }
 
-.grn-designer-inspector__add-crop:hover,
+.grn-designer-inspector__add-crop:hover:not(:disabled),
 .grn-designer-inspector__add-crop:focus-visible {
   text-decoration: underline;
+  outline: none;
+}
+
+.grn-designer-inspector__add-crop:disabled {
+  color: rgba(79, 56, 37, 0.4);
+  cursor: not-allowed;
 }
 
 .grn-designer-inspector__empty {
@@ -2189,4 +2200,104 @@ body {
 
 .grn-page-status__error {
   color: #8b1f1a;
+}
+
+/* ==========================================================================
+   Modal (native <dialog>)
+   ========================================================================== */
+
+.grn-modal {
+  border: none;
+  padding: 0;
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+  color: var(--og-color-ink);
+  box-shadow: 0 24px 60px rgba(38, 23, 15, 0.28);
+  width: min(92vw, 720px);
+  max-height: min(88vh, 880px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.grn-modal--md {
+  width: min(88vw, 480px);
+}
+
+.grn-modal::backdrop {
+  background: rgba(38, 23, 15, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.grn-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(91, 58, 28, 0.1);
+}
+
+.grn-modal__title-block {
+  min-width: 0;
+}
+
+.grn-modal__title {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.15rem;
+  color: var(--og-color-soil);
+}
+
+.grn-modal__subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.7);
+}
+
+.grn-modal__close {
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 58, 28, 0.18);
+  background: transparent;
+  color: var(--og-color-soil);
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.grn-modal__close:hover,
+.grn-modal__close:focus-visible {
+  background: rgba(91, 58, 28, 0.08);
+  outline: none;
+}
+
+.grn-modal__body {
+  padding: 1rem 1.25rem 1.25rem;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* The CropForm uses its own card-stack layout; rein in the outer
+   gap so the form sits naturally inside the modal's body padding. */
+.grn-modal__body .grn-new-crop__form {
+  gap: 1rem;
+}
+
+/* ==========================================================================
+   Locked bed indicator (shown in CropForm when bed selector is hidden)
+   ========================================================================== */
+
+.grn-new-crop__locked-bed {
+  margin: 0.85rem 0 0;
+  padding: 0.55rem 0.85rem;
+  border-radius: var(--og-radius-sm);
+  background: rgba(91, 140, 74, 0.1);
+  color: var(--og-color-moss);
+  font-size: 0.9rem;
+}
+
+.grn-new-crop__locked-bed strong {
+  color: var(--og-color-soil);
 }


### PR DESCRIPTION
## Summary

The garden designer's "+ Add crop" link used to navigate away to `/crops/new`, which lost the user's place on the canvas. Now it opens the same form in a modal so the bed context stays visible.

- **Extracts `CropForm`** out of `NewCropPage` so it's reusable. The form takes `onSuccess` + `onCancel` callbacks (caller decides what "done" means) and an optional `lockedBed` prop. When `lockedBed` is set, the bed selector is replaced with a small "Adding to **<bed name>**" indicator and the bed-list query is skipped entirely.
- **`NewCropPage`** is now a thin wrapper that reads `?bedId=` from the URL, resolves the bed via `listMyBeds`, and feeds it to the form. **Bonus fix:** the existing `/crops/new?bedId=…` links from elsewhere now actually pre-select the bed — they didn't before.
- **New `Modal` primitive** backed by the native `<dialog>` element: focus trap, Esc-to-close, accessible labelling, inert background, backdrop-click-to-close — all for free.
- **New `AddCropModal`** mounts `CropForm` inside the modal with `lockedBed` and closes on success. The new crop chip appears on the bed immediately because `CropForm` already invalidates the `myCrops` query.
- **`BedInspector`** swaps the `Link` for a button that opens the modal, styled the same.

## Out of scope (deliberate)

The **My garden page's** "Add Crop" button still navigates to `/crops/new`. Modal-ising it makes sense in a follow-up if you want consistency, but full-page makes more sense in "manage my crops" mode than in "drop a quick crop on this bed" mode, so leaving it.

## Test plan

- [ ] After deploy: open the designer, select a bed, click "+ Add crop" — modal opens with title "Add a crop to **<bed name>**" and the bed selector is hidden, replaced by a green "Adding to <bed name>" line
- [ ] Submit the form — modal closes, the new crop emoji appears as a chip inside the bed on the canvas
- [ ] Esc and backdrop-click both close the modal
- [ ] Visit `/crops/new?bedId=<some-bed>` directly in the URL — the bed should now be pre-selected (was a latent bug)
- [ ] Visit `/crops/new` with no query param — works as before, full bed selector visible

## Gates

`tsc --noEmit`, `eslint .`, `vite build`, perf budget (944 KB total — main bundle unchanged at 200 KB; designer chunk grew ~2 KB), 236 vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)