### PR TITLE
Add /transparency page for Google for Nonprofits eligibility

### DIFF
--- a/apps/web/scripts/seo-data.mjs
+++ b/apps/web/scripts/seo-data.mjs
@@ -18,6 +18,15 @@ export const siteUrl = (process.env.VITE_SITE_URL ?? 'https://oliviasgarden.org'
 export const instagramUrl = 'https://instagram.com/oliviasgardentx';
 export const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
 export const contactEmail = 'allen@oliviasgarden.org';
+export const ein = '33-3101032';
+export const irsDeterminationDate = 'March 5, 2025';
+export const mailingAddress = {
+  streetAddress: '1820 Meadow Ranch Rd',
+  addressLocality: 'McKinney',
+  addressRegion: 'TX',
+  postalCode: '75071',
+  addressCountry: 'US',
+};
 export const defaultImage = '/images/home/og-image.png';
 export const defaultImageAlt = "Olivia's Garden Foundation social sharing image.";
 export const logoImage = '/images/icons/logo.svg';
@@ -38,21 +47,26 @@ export const organizationJsonLd = {
   url: siteUrl,
   logo: `${siteUrl}${logoImage}`,
   email: contactEmail,
+  taxID: ein,
   foundingDate: '2025',
   foundingLocation: {
     '@type': 'Place',
     address: {
       '@type': 'PostalAddress',
-      addressLocality: 'McKinney',
-      addressRegion: 'TX',
-      addressCountry: 'US',
+      streetAddress: mailingAddress.streetAddress,
+      addressLocality: mailingAddress.addressLocality,
+      addressRegion: mailingAddress.addressRegion,
+      postalCode: mailingAddress.postalCode,
+      addressCountry: mailingAddress.addressCountry,
     },
   },
   address: {
     '@type': 'PostalAddress',
-    addressLocality: 'McKinney',
-    addressRegion: 'TX',
-    addressCountry: 'US',
+    streetAddress: mailingAddress.streetAddress,
+    addressLocality: mailingAddress.addressLocality,
+    addressRegion: mailingAddress.addressRegion,
+    postalCode: mailingAddress.postalCode,
+    addressCountry: mailingAddress.addressCountry,
   },
   areaServed: {
     '@type': 'Country',
@@ -346,6 +360,8 @@ export const seoRoutes = [
       </p>
       <ul>
         <li>Email: <a href="mailto:${contactEmail}">${contactEmail}</a></li>
+        <li>Mailing address: ${mailingAddress.streetAddress}, ${mailingAddress.addressLocality}, ${mailingAddress.addressRegion} ${mailingAddress.postalCode}</li>
+        <li>Legal name: Olivia's Garden Foundation &mdash; EIN ${ein}</li>
         <li>Instagram: <a href="${instagramUrl}">@oliviasgardentx</a> &mdash; day-to-day work, harvests, animals.</li>
         <li>Facebook: <a href="${facebookUrl}">Olivia's Garden Foundation on Facebook</a> &mdash; events and community posts.</li>
       </ul>
@@ -447,6 +463,75 @@ export const seoRoutes = [
         donation date, donation amount, and the email used for the donation. We respond within
         5 business days. If a donation is refunded, the refunded amount is no longer a completed
         charitable contribution and any related tax deduction should be reversed or excluded.
+      </p>
+    `,
+  },
+  {
+    path: '/transparency',
+    title: 'Transparency and organization information',
+    description:
+      "Olivia's Garden Foundation organization details: legal name, EIN, mailing address, IRS 501(c)(3) determination, leadership, and financial transparency.",
+    seoImage: defaultImage,
+    prerender: true,
+    sitemap: { changefreq: 'monthly', priority: 0.5 },
+    bodyFallback: `
+      <h1>Transparency</h1>
+      <p>
+        Olivia's Garden Foundation publishes the public information about the organization here:
+        legal status, leadership, mailing address, financial situation, and where to find our
+        public filings.
+      </p>
+      <h2>Organization details</h2>
+      <ul>
+        <li>Legal name: Olivia's Garden Foundation</li>
+        <li>EIN: ${ein}</li>
+        <li>Tax status: 501(c)(3) public charity, recognized by the United States Internal Revenue Service</li>
+        <li>IRS determination date: ${irsDeterminationDate}</li>
+        <li>Year founded: 2025</li>
+        <li>State of incorporation: Texas</li>
+        <li>Mailing address: ${mailingAddress.streetAddress}, ${mailingAddress.addressLocality}, ${mailingAddress.addressRegion} ${mailingAddress.postalCode}, USA</li>
+      </ul>
+      <h2>Leadership</h2>
+      <p>
+        Olivia's Garden Foundation is run by the Helton family of McKinney, Texas: Allen Helton
+        (co-founder, president), Mallory Helton (co-founder), and Isabella Helton (family
+        contributor). The foundation has no paid staff.
+      </p>
+      <h2>Mission and programs</h2>
+      <p>
+        The foundation teaches individuals and families how to grow food, care for animals,
+        preserve what they produce, and build practical self-sufficiency. Programs include The
+        Okra Project (free seeds and a public garden map), hands-on workshops, the Good Roots
+        Network online platform, and community volunteer workdays.
+      </p>
+      <h2>Non-discrimination policy</h2>
+      <p>
+        Olivia's Garden Foundation does not discriminate on the basis of race, color, ethnic or
+        national origin, ancestry, gender, gender identity or expression, sexual orientation, age,
+        disability, religion, marital status, military or veteran status, or any other category
+        protected by applicable law in the administration of our programs, services, volunteer
+        opportunities, or employment. This applies to seed program participants, workshop
+        attendees, volunteers, donors, partners, and anyone else who interacts with the foundation.
+      </p>
+      <h2>Financial information</h2>
+      <p>
+        Olivia's Garden Foundation was founded in 2025 and received IRS 501(c)(3) recognition on
+        ${irsDeterminationDate}. Because we are a new organization, we do not yet have a published
+        annual report or a filed Form 990. Our first IRS filing, covering our initial reporting
+        period, will be made in 2026, and a summary will be posted on this page once filed. We
+        expect to file Form 990-N (e-Postcard) at our current scale.
+      </p>
+      <p>
+        Donations fund seeds and garden materials, lumber and hardware for raised beds and
+        animal enclosures, feed and care for the animals, workshop supplies, seed-program
+        shipping, and the software and hosting costs of the foundation's online tools. The
+        foundation has no paid staff, no office lease, and no fundraising contractors.
+      </p>
+      <h2>Public records and filings</h2>
+      <p>
+        Our 501(c)(3) status can be independently verified through the IRS Tax Exempt
+        Organization Search at <a href="https://apps.irs.gov/app/eos/">apps.irs.gov/app/eos</a>
+        using EIN ${ein}. We also maintain a public profile on Candid.
       </p>
     `,
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import { useRouteSeo } from './site/seo';
 import { LoginPage } from './site/pages/LoginPage';
 import { NotFoundPage } from './site/pages/NotFoundPage';
 import { RefundPolicyPage } from './site/pages/RefundPolicyPage';
+import { TransparencyPage } from './site/pages/TransparencyPage';
 import { readRedirectTargetFromSearch } from './auth/redirect';
 import {
   AboutPage,
@@ -421,6 +422,7 @@ function App() {
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
           <Route path="/terms" element={<TermsOfServicePage />} />
           <Route path="/refunds" element={<RefundPolicyPage />} />
+          <Route path="/transparency" element={<TransparencyPage />} />
           <Route path="/data" element={<DataDeletionPage onNavigate={navigate} />} />
           <Route
             path="/good-roots"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1139,20 +1139,20 @@ html {
   padding: 0.1rem 0;
 }
 
-.about-candid-seal {
+.candid-seal {
   display: flex;
   justify-content: center;
   padding: 0.25rem 0 0.5rem;
 }
 
-.about-candid-seal__link {
+.candid-seal__link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   max-width: min(100%, 18rem);
 }
 
-.about-candid-seal__link img {
+.candid-seal__link img {
   display: block;
   width: 100%;
   height: auto;

--- a/apps/web/src/site/organization.ts
+++ b/apps/web/src/site/organization.ts
@@ -4,4 +4,13 @@ export const foundationOrganization = {
   ein: '33-3101032',
   contactEmail: 'allen@oliviasgarden.org',
   logoImage: '/images/icons/logo.svg',
+  mailingAddress: {
+    line1: '1820 Meadow Ranch Rd',
+    city: 'McKinney',
+    region: 'TX',
+    postalCode: '75071',
+    country: 'USA',
+  },
+  foundedYear: 2025,
+  irsDeterminationDate: 'March 5, 2025',
 } as const;

--- a/apps/web/src/site/pages/TransparencyPage.tsx
+++ b/apps/web/src/site/pages/TransparencyPage.tsx
@@ -1,0 +1,220 @@
+import { LegalDocument, LegalSection, LegalTableOfContents } from '../chrome';
+import { foundationOrganization } from '../organization';
+import { candidProfileUrl, candidSealImageUrl } from '../routes';
+
+const CONTACT_EMAIL = foundationOrganization.contactEmail;
+
+const TRANSPARENCY_SECTIONS = [
+  { id: 'organization', title: 'Organization details' },
+  { id: 'leadership', title: 'Leadership' },
+  { id: 'mission-and-programs', title: 'Mission and programs' },
+  { id: 'non-discrimination', title: 'Non-discrimination policy' },
+  { id: 'financial-information', title: 'Financial information' },
+  { id: 'public-records', title: 'Public records and filings' },
+  { id: 'contact', title: 'Contact' },
+];
+
+export function TransparencyPage() {
+  const { legalName, ein, mailingAddress, foundedYear, irsDeterminationDate } = foundationOrganization;
+  const formattedAddress = `${mailingAddress.line1}, ${mailingAddress.city}, ${mailingAddress.region} ${mailingAddress.postalCode}`;
+
+  return (
+    <LegalDocument
+      title="Transparency"
+      eyebrow="About the organization"
+      effectiveDate="May 11, 2026"
+      intro={(
+        <p>
+          This page consolidates the public information about Olivia&apos;s Garden Foundation:
+          our legal status, leadership, mailing address, financial situation, and where to
+          find our public filings. We are a young organization and we want supporters,
+          partners, and regulators to be able to see exactly where we stand.
+        </p>
+      )}
+    >
+      <LegalTableOfContents items={TRANSPARENCY_SECTIONS} />
+
+      <LegalSection id="organization" number={1} title="Organization details">
+        <p>
+          <strong>Legal name:</strong> {legalName}
+          <br />
+          <strong>EIN (Employer Identification Number):</strong> {ein}
+          <br />
+          <strong>Tax status:</strong> 501(c)(3) public charity, recognized by the United
+          States Internal Revenue Service.
+          <br />
+          <strong>IRS determination date:</strong> {irsDeterminationDate}
+          <br />
+          <strong>Year founded:</strong> {foundedYear}
+          <br />
+          <strong>State of incorporation:</strong> Texas
+          <br />
+          <strong>Mailing address:</strong>
+          <br />
+          <span itemProp="address" itemScope itemType="https://schema.org/PostalAddress">
+            <span itemProp="streetAddress">{mailingAddress.line1}</span>
+            <br />
+            <span itemProp="addressLocality">{mailingAddress.city}</span>
+            ,{' '}
+            <span itemProp="addressRegion">{mailingAddress.region}</span>{' '}
+            <span itemProp="postalCode">{mailingAddress.postalCode}</span>
+            <br />
+            <span itemProp="addressCountry">{mailingAddress.country}</span>
+          </span>
+        </p>
+        <p>
+          Donations to Olivia&apos;s Garden Foundation are tax-deductible to the extent
+          allowed by United States law.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="leadership" number={2} title="Leadership">
+        <p>
+          Olivia&apos;s Garden Foundation is run by the Helton family of McKinney, Texas:
+        </p>
+        <ul className="site-list">
+          <li>
+            <strong>Allen Helton</strong> &mdash; co-founder and president. Designs and
+            builds the gardens, runs the technology platform, and leads day-to-day
+            operations.
+          </li>
+          <li>
+            <strong>Mallory Helton</strong> &mdash; co-founder. Leads workshops,
+            community programs, and animal care on the property.
+          </li>
+          <li>
+            <strong>Isabella Helton</strong> &mdash; family contributor. Helps with
+            workdays and community events.
+          </li>
+        </ul>
+        <p>
+          The foundation has no paid staff. All program work is performed by the founders
+          and volunteers.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="mission-and-programs" number={3} title="Mission and programs">
+        <p>
+          Our mission is to teach individuals and families how to grow food, care for
+          animals, preserve what they produce, and build practical self-sufficiency. The
+          foundation operates a working garden and small homestead in McKinney, Texas in
+          memory of our daughter Olivia.
+        </p>
+        <p>Current programs include:</p>
+        <ul className="site-list">
+          <li>
+            <strong>The Okra Project</strong> &mdash; a free seed program and public map
+            of community growers.
+          </li>
+          <li>
+            <strong>Hands-on workshops</strong> &mdash; in-person sessions on garden
+            preparation, animal care, food preservation, and related practical skills.
+          </li>
+          <li>
+            <strong>The Good Roots Network</strong> &mdash; an online platform that
+            connects home growers with neighbors and organizations who need fresh food.
+          </li>
+          <li>
+            <strong>Community workdays</strong> &mdash; regular volunteer days on the
+            property tied to seasonal garden and animal care work.
+          </li>
+        </ul>
+      </LegalSection>
+
+      <LegalSection id="non-discrimination" number={4} title="Non-discrimination policy">
+        <p>
+          Olivia&apos;s Garden Foundation is committed to serving everyone in our
+          community. We do not discriminate on the basis of race, color, ethnic or
+          national origin, ancestry, gender, gender identity or expression, sexual
+          orientation, age, disability, religion, marital status, military or veteran
+          status, or any other category protected by applicable law in the administration
+          of our programs, services, volunteer opportunities, or employment.
+        </p>
+        <p>
+          This commitment applies to seed program participants, workshop attendees,
+          volunteers, donors, partners, and anyone else who interacts with the foundation.
+          Concerns about how this policy is being applied can be sent to{' '}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> and will be reviewed
+          directly by foundation leadership.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="financial-information" number={5} title="Financial information">
+        <p>
+          Olivia&apos;s Garden Foundation was founded in {foundedYear} and received IRS
+          501(c)(3) recognition on {irsDeterminationDate}. Because we are a new
+          organization, we do not yet have a published annual report or a filed IRS Form
+          990. Our first IRS filing, covering our initial reporting period, will be made
+          in 2026, and a summary will be posted on this page once filed.
+        </p>
+        <p>
+          We operate at a small scale, well below the IRS thresholds for a full Form 990,
+          and we expect to file Form 990-N (e-Postcard) for our first reporting period.
+          Once our annual receipts grow past those thresholds, we will move to Form 990-EZ
+          or full Form 990 as required.
+        </p>
+        <p>
+          In plain language, the money that comes in is used for:
+        </p>
+        <ul className="site-list">
+          <li>Seeds, plants, soil, and garden materials</li>
+          <li>Lumber, fencing, and hardware for raised beds, animal enclosures, and on-site infrastructure</li>
+          <li>Feed, bedding, and veterinary care for chickens, turkeys, geese, goats, bees, and guineas</li>
+          <li>Supplies and materials for workshops</li>
+          <li>Shipping costs for the free okra seed program</li>
+          <li>Software, hosting, and operational costs for the Good Roots Network platform and the foundation website</li>
+        </ul>
+        <p>
+          We have no paid staff, no office lease, and no fundraising contractors. The
+          founders cover incidental overhead personally rather than from donated funds
+          where practical.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="public-records" number={6} title="Public records and filings">
+        <p>
+          Olivia&apos;s Garden Foundation maintains a public profile on Candid (formerly
+          GuideStar), which surfaces our IRS determination data and any future Form 990
+          filings:
+        </p>
+        <p>
+          <a href={candidProfileUrl} target="_blank" rel="noreferrer">
+            View our Candid profile
+          </a>
+        </p>
+        <p>
+          Our 501(c)(3) status can also be independently verified through the IRS Tax
+          Exempt Organization Search at{' '}
+          <a
+            href="https://apps.irs.gov/app/eos/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            apps.irs.gov/app/eos
+          </a>{' '}
+          using EIN {ein}.
+        </p>
+        <div className="candid-seal">
+          <a
+            className="candid-seal__link"
+            aria-label="View Olivia's Garden Foundation on Candid"
+            href={candidProfileUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <img alt="" src={candidSealImageUrl} loading="lazy" />
+          </a>
+        </div>
+      </LegalSection>
+
+      <LegalSection id="contact" number={7} title="Contact">
+        <p>
+          Questions about the organization, requests for additional information, or press
+          inquiries can be sent to{' '}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>, or by mail to{' '}
+          {formattedAddress}.
+        </p>
+      </LegalSection>
+    </LegalDocument>
+  );
+}

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -13,7 +13,7 @@ import {
 } from '../chrome';
 import { foundationOrganization } from '../organization';
 import { buildResponsiveBackgroundImage, ResponsiveImage } from '../responsive-images';
-import { candidProfileUrl, candidSealImageUrl, facebookUrl, goodRootsNetworkUrl, instagramUrl, webApiBase } from '../routes';
+import { facebookUrl, goodRootsNetworkUrl, instagramUrl, webApiBase } from '../routes';
 
 const CONTACT_EMAIL = foundationOrganization.contactEmail;
 
@@ -328,17 +328,6 @@ export function AboutPage() {
         </p>
       </section>
 
-      <section className="about-candid-seal" aria-label="Candid nonprofit transparency profile">
-        <a
-          className="about-candid-seal__link"
-          aria-label="View Olivia's Garden Foundation on Candid"
-          href={candidProfileUrl}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <img alt="" src={candidSealImageUrl} loading="lazy" />
-        </a>
-      </section>
     </div>
   );
 }
@@ -1633,6 +1622,11 @@ export function ContactPage() {
             Legal name: {foundationOrganization.legalName}
             <br />
             EIN: {foundationOrganization.ein}
+            <br />
+            Mailing address: {foundationOrganization.mailingAddress.line1},{' '}
+            {foundationOrganization.mailingAddress.city},{' '}
+            {foundationOrganization.mailingAddress.region}{' '}
+            {foundationOrganization.mailingAddress.postalCode}
           </p>
           <ul className="site-list contact-card__list">
             <li>

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -163,6 +163,16 @@ export const routes: AppRoute[] = [
     allowIndex: true,
     prerender: true,
   },
+  {
+    path: '/transparency',
+    label: 'Transparency',
+    showInLegalFooter: true,
+    title: 'Transparency and organization information',
+    description: "Olivia's Garden Foundation organization details: legal name, EIN, mailing address, IRS 501(c)(3) determination, leadership, and financial transparency.",
+    seoImage: socialShareImage,
+    allowIndex: true,
+    prerender: true,
+  },
 ];
 
 export const notFoundRoute: AppRoute = {


### PR DESCRIPTION
## Summary

- Adds a new `/transparency` page that consolidates legal name, EIN, IRS 501(c)(3) determination date (March 5, 2025), founding year, state of incorporation, full mailing address, leadership, mission/programs summary, non-discrimination policy, year-one financial posture, and public-records links (Candid + IRS EOS).
- Surfaces the mailing address on the Contact page next to the EIN, and centralizes address/founding/IRS fields on `foundationOrganization`.
- Moves the Candid (GuideStar) seal from About to Transparency, where it belongs alongside the rest of the org-verification info.
- Strengthens prerender SEO so a non-JS reviewer bot sees everything on first byte: matching `/transparency` entry in `seo-data.mjs` with a noscript body fallback containing the EIN, address, IRS data, and non-discrimination policy in plain HTML, and the organization JSON-LD now includes `taxID` and a full `PostalAddress`.

## Why

Google for Nonprofits rejected `oliviasgarden.org` citing missing physical address, missing financial reports, and missing charity ID. EIN was already in the footer but easy to miss, and the address and financial posture weren't anywhere on the site. The non-discrimination statement (a separate Google for Nonprofits requirement) was also missing.

The financial section is written honestly for a first-year nonprofit: no 990 filed yet, first IRS filing coming in 2026, expected to file Form 990-N at current scale, and a plain-language breakdown of how donated funds are used.

## What a reviewer should know

- `/transparency` uses the existing `LegalDocument`/`LegalSection` shell so it visually matches Privacy/Terms/Refunds.
- The route is registered with `showInLegalFooter: true` and `prerender: true`, and the `check:prerender-drift` build step confirms `routes.ts` and `seo-data.mjs` agree.
- The `.about-candid-seal*` CSS classes are renamed to `.candid-seal*` since they're no longer About-specific. The seal block was removed from `AboutPage` and `candidProfileUrl` / `candidSealImageUrl` were dropped from `content-pages.tsx` imports.
- Two unrelated line-ending changes to vendor README files were intentionally left out of this PR.

## Test plan

- [x] `npm run build` in `apps/web` passes (tsc + vite + prerender + sitemap)
- [x] `check:prerender-drift` reports `routes.ts` and `seo-data.mjs` agree (14 prerendered, 13 sitemap-eligible)
- [x] `dist/transparency/index.html` contains the EIN, full mailing address, IRS determination date, non-discrimination policy, and Candid links in the noscript fallback
- [x] Organization JSON-LD on every prerendered page now includes `taxID` and full `PostalAddress`
- [ ] Manual smoke after deploy: `/transparency` loads, footer link appears next to Privacy/Terms/Refunds, mailing address is visible on `/contact`, seal renders on `/transparency` and is gone from `/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)