### PR TITLE
Fix duplicated 'Good Roots Network' entry in signed-in mobile menu

### DIFF
--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -78,50 +78,70 @@ export function SiteHeader({
   const avatarLabel = authSession
     ? authSession.user.name ?? authSession.user.email ?? 'Signed-in account'
     : 'Go to login page';
-  const headerNavItems = [
-    ...navRoutes.map((route) => ({
-      id: route.path,
-      label: route.label,
-      href: route.path,
-      active: pathname === route.path,
-      accent: route.path === '/donate',
-      onSelect: () => onNavigate(route.path),
-    })),
-    {
-      id: authSession ? 'profile' : 'login',
-      label: authSession ? 'Profile' : 'Log in',
-      href: authSession ? '/profile' : '/login',
-      active: authSession ? pathname === '/profile' : pathname === '/login',
-      mobileOnly: true,
-      onSelect: () => onNavigate(authSession ? '/profile' : '/login'),
-    },
-    ...(authSession
-      ? [
-          {
-            id: 'okra-submissions',
-            label: 'My okra submissions',
-            href: '/okra/submissions',
-            active: pathname === '/okra/submissions',
-            mobileOnly: true,
-            onSelect: () => onNavigate('/okra/submissions'),
-          },
-          {
-            id: 'grn',
-            label: 'Good Roots Network',
-            href: buildCrossAppUrl(goodRootsNetworkUrl, authSession),
-            mobileOnly: true,
-          },
-          ...(authSession.user.isAdmin
-            ? [{
-                id: 'admin',
-                label: 'Admin',
-                href: buildCrossAppUrl(adminUrl, authSession),
-                mobileOnly: true,
-              }]
-            : []),
-        ]
-      : []),
-  ];
+  const marketingNavItems = navRoutes.map((route) => ({
+    id: route.path,
+    label: route.label,
+    href: route.path,
+    active: pathname === route.path,
+    accent: route.path === '/donate',
+    onSelect: () => onNavigate(route.path),
+  }));
+
+  const accountMobileItems = authSession
+    ? [
+        {
+          id: 'profile',
+          label: 'Profile',
+          href: '/profile',
+          active: pathname === '/profile',
+          mobileOnly: true,
+          divider: true,
+          onSelect: () => onNavigate('/profile'),
+        },
+        {
+          id: 'okra-submissions',
+          label: 'My okra submissions',
+          href: '/okra/submissions',
+          active: pathname === '/okra/submissions',
+          mobileOnly: true,
+          onSelect: () => onNavigate('/okra/submissions'),
+        },
+        {
+          id: 'grn-app',
+          label: 'Good Roots Network',
+          href: buildCrossAppUrl(goodRootsNetworkUrl, authSession),
+          mobileOnly: true,
+          sectionLabel: 'Apps',
+        },
+        ...(authSession.user.isAdmin
+          ? [{
+              id: 'admin',
+              label: 'Admin',
+              href: buildCrossAppUrl(adminUrl, authSession),
+              mobileOnly: true,
+            }]
+          : []),
+        ...(onLogout
+          ? [{
+              id: 'logout',
+              label: 'Log out',
+              mobileOnly: true,
+              divider: true,
+              onSelect: onLogout,
+            }]
+          : []),
+      ]
+    : [{
+        id: 'login',
+        label: 'Log in',
+        href: '/login',
+        active: pathname === '/login',
+        mobileOnly: true,
+        divider: true,
+        onSelect: () => onNavigate('/login'),
+      }];
+
+  const headerNavItems = [...marketingNavItems, ...accountMobileItems];
 
   return (
     <>

--- a/packages/ui/src/components/SiteHeader.tsx
+++ b/packages/ui/src/components/SiteHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
 
 export interface SiteHeaderNavItem {
   id: string;
@@ -8,6 +8,10 @@ export interface SiteHeaderNavItem {
   active?: boolean;
   accent?: boolean;
   mobileOnly?: boolean;
+  /** Render a divider line before this item. Only visible in the mobile drawer. */
+  divider?: boolean;
+  /** Render an uppercase section label before this item. Only visible in the mobile drawer. */
+  sectionLabel?: string;
 }
 
 export interface SiteHeaderProps {
@@ -130,36 +134,43 @@ export function SiteHeader({
               className={`og-site-header__nav ${menuOpen ? 'is-open' : ''}`.trim()}
               aria-label="Primary"
             >
-              {navItems.map((item) => (
-                item.href ? (
-                  <a
-                    key={item.id}
-                    href={item.href}
-                    className={`og-site-header__link ${item.active ? 'is-active' : ''} ${item.accent ? 'og-site-header__link--accent' : ''} ${item.mobileOnly ? 'og-site-header__link--mobile-only' : ''}`.trim()}
-                    onClick={(event) => {
-                      setMenuOpen(false);
-                      if (item.onSelect) {
-                        event.preventDefault();
-                        item.onSelect();
-                      }
-                    }}
-                  >
-                    {item.label}
-                  </a>
-                ) : (
-                  <button
-                    key={item.id}
-                    type="button"
-                    className={`og-site-header__link ${item.active ? 'is-active' : ''} ${item.accent ? 'og-site-header__link--accent' : ''} ${item.mobileOnly ? 'og-site-header__link--mobile-only' : ''}`.trim()}
-                    onClick={() => {
-                      setMenuOpen(false);
-                      item.onSelect?.();
-                    }}
-                  >
-                    {item.label}
-                  </button>
-                )
-              ))}
+              {navItems.map((item) => {
+                const linkClass = `og-site-header__link ${item.active ? 'is-active' : ''} ${item.accent ? 'og-site-header__link--accent' : ''} ${item.mobileOnly ? 'og-site-header__link--mobile-only' : ''}`.trim();
+                return (
+                  <Fragment key={item.id}>
+                    {item.divider ? <div className="og-site-header__divider" role="separator" aria-hidden="true" /> : null}
+                    {item.sectionLabel ? (
+                      <div className="og-site-header__section-label" role="presentation">{item.sectionLabel}</div>
+                    ) : null}
+                    {item.href ? (
+                      <a
+                        href={item.href}
+                        className={linkClass}
+                        onClick={(event) => {
+                          setMenuOpen(false);
+                          if (item.onSelect) {
+                            event.preventDefault();
+                            item.onSelect();
+                          }
+                        }}
+                      >
+                        {item.label}
+                      </a>
+                    ) : (
+                      <button
+                        type="button"
+                        className={linkClass}
+                        onClick={() => {
+                          setMenuOpen(false);
+                          item.onSelect?.();
+                        }}
+                      >
+                        {item.label}
+                      </button>
+                    )}
+                  </Fragment>
+                );
+              })}
             </nav>
           ) : null}
         </div>

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -141,6 +141,20 @@ body {
   display: inline-flex;
 }
 
+.og-site-header__divider {
+  height: 1px;
+  margin: 0.35rem 0.4rem;
+  background: rgba(79, 56, 37, 0.12);
+}
+
+.og-site-header__section-label {
+  padding: 0.5rem 0.85rem 0.15rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
 .og-site-header__link {
   border: 0;
   border-radius: var(--og-radius-pill);
@@ -1030,7 +1044,9 @@ body {
     order: 2;
   }
 
-  .og-site-header__link--mobile-only {
+  .og-site-header__link--mobile-only,
+  .og-site-header__divider,
+  .og-site-header__section-label {
     display: none;
   }
 


### PR DESCRIPTION
## Summary

- The mobile drawer showed **Good Roots Network** twice when signed in — once as the marketing landing-page nav link and once as the cross-app launcher — with no visual distinction between them.
- Added optional `divider` and `sectionLabel` props to the shared `SiteHeader` nav item type so the mobile drawer can mirror the structure of the desktop avatar dropdown (Profile → personal links → divider → **Apps** header → app launchers → divider → Log out).
- The two `Good Roots Network` entries now read clearly as distinct: one in the marketing nav at the top, the other under the **Apps** section header alongside Admin.
- Side benefit: `Log out` is now reachable on mobile. Previously the avatar dropdown (which holds the logout button) was hidden below the 800px breakpoint, so signed-in mobile users had no in-menu way to log out.

## What changed

- [packages/ui/src/components/SiteHeader.tsx](packages/ui/src/components/SiteHeader.tsx) — added `divider` and `sectionLabel` to `SiteHeaderNavItem`. Rendered inside the drawer above each item; hidden on desktop where the drawer becomes a flex row.
- [packages/ui/src/styles.css](packages/ui/src/styles.css) — styled `og-site-header__divider` and `og-site-header__section-label` to match the existing avatar-menu styling; hidden at the ≥800px breakpoint alongside `--mobile-only` links.
- [apps/web/src/site/chrome.tsx](apps/web/src/site/chrome.tsx) — restructured the signed-in mobile menu items: divider before Profile, `Apps` section label before the cross-app GRN launcher, and a new `Log out` entry with a divider at the bottom.

## What reviewers should know

- Desktop behavior is unchanged. The new section label / divider elements have `display: none` at ≥800px, matching how `--mobile-only` links are already hidden.
- The new props are additive and optional, so the other apps that consume `SiteHeader` from `@olivias/ui` (grn, admin, store) compile and render unchanged. Typechecks pass across web/ui/grn/admin/store.
- The two GRN links genuinely point to different destinations — `/good-roots` for the marketing page on the foundation site, and the cross-app session URL for the GRN app — so the duplication wasn't a bug to remove, just a visual structuring problem.

## Test plan

- [ ] Sign in on a mobile-width browser, open the menu, and confirm: Profile / okra submissions appear above an `APPS` section header, GRN-app launcher and Admin (if admin) appear under it, and `Log out` is at the bottom with a divider above it.
- [ ] Tap each item and confirm: marketing `Good Roots Network` navigates to `/good-roots`, the launcher under `APPS` opens the GRN app with a session hash, `Log out` signs out.
- [ ] Sign out and confirm the mobile menu shows just the marketing nav plus a divider and `Log in`.
- [ ] On desktop, confirm the header still renders as a horizontal nav with no stray dividers or section labels, and the avatar dropdown is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)