### PR TITLE
GRN: surface grow-near-you recommendations to growers

### DIFF
--- a/apps/grn/src/components/CropPlanner/CropForm.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.tsx
@@ -199,6 +199,7 @@ export function CropForm({
         isLoading={isLoadingCatalog || growerSignals.isLoading}
         onSelect={setSelection}
         selectedCatalogCropId={selection?.catalogCropId ?? null}
+        growingCropIds={growerSignals.growingCatalogCropIds}
       />
       <Card className="grn-new-crop__hero" padding="6">
         <div
@@ -217,6 +218,7 @@ export function CropForm({
             value={selection}
             onChange={setSelection}
             scarceCropIds={growerSignals.scarceCropIds}
+            growingCropIds={growerSignals.growingCatalogCropIds}
           />
         </div>
       </Card>

--- a/apps/grn/src/components/CropPlanner/CropForm.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.tsx
@@ -13,6 +13,8 @@ import { CropPicker, type CropPickerSelection } from './CropPicker';
 import { visualForCrop } from './cropVisuals';
 import { CropIcon } from './cropIcons';
 import { createLogger } from '../../utils/logging';
+import { useGrowerCropSignals } from '../../hooks/useGrowerCropSignals';
+import { NeededNearbyStrip } from '../Recommendations/NeededNearbyStrip';
 
 const logger = createLogger('crop-form');
 
@@ -108,6 +110,8 @@ export function CropForm({
     enabled: lockedBed === null,
   });
 
+  const growerSignals = useGrowerCropSignals();
+
   const [selection, setSelection] = useState<CropPickerSelection | null>(null);
   const [planting, setPlanting] = useState<PlantingDetails>({
     bedId: lockedBed?.id ?? initialBedId,
@@ -189,6 +193,13 @@ export function CropForm({
 
   return (
     <form onSubmit={handleSubmit} className="grn-new-crop__form">
+      <NeededNearbyStrip
+        topScarce={growerSignals.topScarce}
+        catalog={catalog}
+        isLoading={isLoadingCatalog || growerSignals.isLoading}
+        onSelect={setSelection}
+        selectedCatalogCropId={selection?.catalogCropId ?? null}
+      />
       <Card className="grn-new-crop__hero" padding="6">
         <div
           className="grn-new-crop__hero-visual"
@@ -205,6 +216,7 @@ export function CropForm({
             isLoading={isLoadingCatalog}
             value={selection}
             onChange={setSelection}
+            scarceCropIds={growerSignals.scarceCropIds}
           />
         </div>
       </Card>

--- a/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { CropPicker } from './CropPicker';
+import { CropPicker, type CropPickerSelection } from './CropPicker';
 import type { CatalogCrop } from '../../types/listing';
 
 const baseCatalog: CatalogCrop[] = [
@@ -105,6 +106,46 @@ describe('CropPicker with grower scarcity signals', () => {
 
     expect(await screen.findByRole('listbox')).toBeInTheDocument();
     expect(screen.queryByTestId('needed-nearby-badge')).not.toBeInTheDocument();
+  });
+
+  it('syncs the input text when the parent sets the selection externally', async () => {
+    const tomato = baseCatalog[0];
+
+    function Harness() {
+      const [value, setValue] = React.useState<CropPickerSelection | null>(null);
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              setValue({
+                catalogCropId: tomato.id,
+                cropName: tomato.commonName,
+                category: tomato.category,
+              })
+            }
+          >
+            choose-apple
+          </button>
+          <CropPicker
+            catalog={baseCatalog}
+            isLoading={false}
+            value={value}
+            onChange={setValue}
+          />
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('');
+
+    await user.click(screen.getByRole('button', { name: 'choose-apple' }));
+
+    expect(input.value).toBe(tomato.commonName);
   });
 
   it('badges crops the grower already has and ranks them below fresh scarce options', async () => {

--- a/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CropPicker } from './CropPicker';
+import type { CatalogCrop } from '../../types/listing';
+
+const baseCatalog: CatalogCrop[] = [
+  {
+    id: 'crop-apple',
+    slug: 'apple',
+    commonName: 'Apple',
+    scientificName: null,
+    category: 'fruit',
+    description: null,
+  },
+  {
+    id: 'crop-basil',
+    slug: 'basil',
+    commonName: 'Basil',
+    scientificName: null,
+    category: 'herb',
+    description: null,
+  },
+  {
+    id: 'crop-zucchini',
+    slug: 'zucchini',
+    commonName: 'Zucchini',
+    scientificName: null,
+    category: 'vegetable',
+    description: null,
+  },
+];
+
+describe('CropPicker with grower scarcity signals', () => {
+  it('floats scarce crops to the top when no query is active', async () => {
+    const user = userEvent.setup();
+    render(
+      <CropPicker
+        catalog={baseCatalog}
+        isLoading={false}
+        value={null}
+        onChange={() => {}}
+        scarceCropIds={new Set(['crop-zucchini'])}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+
+    const listbox = await screen.findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Zucchini');
+    expect(within(options[0]).getByTestId('needed-nearby-badge')).toBeInTheDocument();
+  });
+
+  it('badges a scarce crop even when it stays in alphabetical position', async () => {
+    const user = userEvent.setup();
+    render(
+      <CropPicker
+        catalog={baseCatalog}
+        isLoading={false}
+        value={null}
+        onChange={() => {}}
+        scarceCropIds={new Set(['crop-basil'])}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+
+    const listbox = await screen.findByRole('listbox');
+    const basilOption = within(listbox).getByText('Basil').closest('li');
+    expect(basilOption).not.toBeNull();
+    expect(within(basilOption as HTMLElement).getByTestId('needed-nearby-badge')).toBeInTheDocument();
+  });
+
+  it('still prioritizes query prefix matches over scarcity highlighting', async () => {
+    const user = userEvent.setup();
+    render(
+      <CropPicker
+        catalog={baseCatalog}
+        isLoading={false}
+        value={null}
+        onChange={() => {}}
+        scarceCropIds={new Set(['crop-zucchini'])}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.type(input, 'ap');
+
+    const listbox = await screen.findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Apple');
+  });
+
+  it('renders without scarcity props (back-compat with non-grower contexts)', async () => {
+    const user = userEvent.setup();
+    render(
+      <CropPicker catalog={baseCatalog} isLoading={false} value={null} onChange={() => {}} />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    expect(screen.queryByTestId('needed-nearby-badge')).not.toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.test.tsx
@@ -106,4 +106,36 @@ describe('CropPicker with grower scarcity signals', () => {
     expect(await screen.findByRole('listbox')).toBeInTheDocument();
     expect(screen.queryByTestId('needed-nearby-badge')).not.toBeInTheDocument();
   });
+
+  it('badges crops the grower already has and ranks them below fresh scarce options', async () => {
+    const user = userEvent.setup();
+    render(
+      <CropPicker
+        catalog={baseCatalog}
+        isLoading={false}
+        value={null}
+        onChange={() => {}}
+        scarceCropIds={new Set(['crop-zucchini', 'crop-apple'])}
+        growingCropIds={new Set(['crop-zucchini'])}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+
+    const listbox = await screen.findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
+    // Fresh scarce (Apple) above already-growing scarce (Zucchini)
+    expect(options[0]).toHaveTextContent('Apple');
+    expect(options[1]).toHaveTextContent('Zucchini');
+
+    const zucchiniOption = within(listbox).getByText('Zucchini').closest('li');
+    expect(zucchiniOption).not.toBeNull();
+    expect(
+      within(zucchiniOption as HTMLElement).getByTestId('already-growing-badge')
+    ).toBeInTheDocument();
+    expect(
+      within(zucchiniOption as HTMLElement).getByTestId('needed-nearby-badge')
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/grn/src/components/CropPlanner/CropPicker.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.tsx
@@ -23,6 +23,13 @@ interface CropPickerProps {
    * nearby" badge so growers can see them at the decision moment.
    */
   scarceCropIds?: Set<string>;
+  /**
+   * Catalog crop IDs the viewer already has in their garden. When
+   * provided, these options carry an "Already growing" badge so the
+   * grower can tell at a glance whether a suggestion would be a new
+   * addition or a duplicate of something they already track.
+   */
+  growingCropIds?: Set<string>;
 }
 
 const MAX_VISIBLE_RESULTS = 8;
@@ -45,6 +52,7 @@ export function CropPicker({
   onChange,
   compact,
   scarceCropIds,
+  growingCropIds,
 }: CropPickerProps) {
   const [query, setQuery] = useState(value?.cropName ?? '');
   const [activeCategory, setActiveCategory] = useState<string>('all');
@@ -88,17 +96,25 @@ export function CropPicker({
         return a.commonName.localeCompare(b.commonName);
       });
     } else if (scarceCropIds && scarceCropIds.size > 0) {
-      // No active query: float locally scarce crops to the top so growers
-      // see what neighbors are asking for at the decision moment.
+      // No active query: float locally scarce crops the grower does NOT
+      // already have to the very top, then other scarce crops, then the
+      // rest. Already-growing scarce crops still appear above ordinary
+      // catalog entries but below fresh opportunities.
+      const rank = (id: string): number => {
+        const isScarce = scarceCropIds.has(id);
+        const isGrowing = growingCropIds?.has(id) ?? false;
+        if (isScarce && !isGrowing) return 0;
+        if (isScarce && isGrowing) return 1;
+        return 2;
+      };
       filtered.sort((a, b) => {
-        const aScarce = scarceCropIds.has(a.id) ? 0 : 1;
-        const bScarce = scarceCropIds.has(b.id) ? 0 : 1;
-        if (aScarce !== bScarce) return aScarce - bScarce;
+        const diff = rank(a.id) - rank(b.id);
+        if (diff !== 0) return diff;
         return a.commonName.localeCompare(b.commonName);
       });
     }
     return filtered.slice(0, MAX_VISIBLE_RESULTS);
-  }, [catalog, activeCategory, lowerQuery, scarceCropIds]);
+  }, [catalog, activeCategory, lowerQuery, scarceCropIds, growingCropIds]);
 
   const exactMatch = useMemo(() => {
     if (!trimmedQuery) return null;
@@ -284,6 +300,7 @@ export function CropPicker({
             const visual = visualForCrop(crop.commonName, crop.category);
             const isHighlighted = index === highlightIndex;
             const isScarce = scarceCropIds?.has(crop.id) ?? false;
+            const isAlreadyGrowing = growingCropIds?.has(crop.id) ?? false;
             return (
               <li
                 key={crop.id}
@@ -313,6 +330,14 @@ export function CropPicker({
                         data-testid="needed-nearby-badge"
                       >
                         Needed nearby
+                      </span>
+                    ) : null}
+                    {isAlreadyGrowing ? (
+                      <span
+                        className="grn-crop-picker__pill grn-crop-picker__pill--growing"
+                        data-testid="already-growing-badge"
+                      >
+                        Already growing
                       </span>
                     ) : null}
                   </span>

--- a/apps/grn/src/components/CropPlanner/CropPicker.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.tsx
@@ -16,6 +16,13 @@ interface CropPickerProps {
   onChange: (selection: CropPickerSelection | null) => void;
   /** When true, render a more compact variant (no category chips) */
   compact?: boolean;
+  /**
+   * Catalog crop IDs that local searchers are asking for and growers
+   * are not yet supplying. When provided, these crops are floated to
+   * the top of the list when no query is active and get a "Needed
+   * nearby" badge so growers can see them at the decision moment.
+   */
+  scarceCropIds?: Set<string>;
 }
 
 const MAX_VISIBLE_RESULTS = 8;
@@ -31,7 +38,14 @@ function categoryMatches(filter: string, category: string | null | undefined): b
   return normalized === filter || normalized.startsWith(`${filter}`) || normalized.includes(filter);
 }
 
-export function CropPicker({ catalog, isLoading, value, onChange, compact }: CropPickerProps) {
+export function CropPicker({
+  catalog,
+  isLoading,
+  value,
+  onChange,
+  compact,
+  scarceCropIds,
+}: CropPickerProps) {
   const [query, setQuery] = useState(value?.cropName ?? '');
   const [activeCategory, setActiveCategory] = useState<string>('all');
   const [isOpen, setIsOpen] = useState(false);
@@ -73,9 +87,18 @@ export function CropPicker({ catalog, isLoading, value, onChange, compact }: Cro
         if (aStarts !== bStarts) return aStarts - bStarts;
         return a.commonName.localeCompare(b.commonName);
       });
+    } else if (scarceCropIds && scarceCropIds.size > 0) {
+      // No active query: float locally scarce crops to the top so growers
+      // see what neighbors are asking for at the decision moment.
+      filtered.sort((a, b) => {
+        const aScarce = scarceCropIds.has(a.id) ? 0 : 1;
+        const bScarce = scarceCropIds.has(b.id) ? 0 : 1;
+        if (aScarce !== bScarce) return aScarce - bScarce;
+        return a.commonName.localeCompare(b.commonName);
+      });
     }
     return filtered.slice(0, MAX_VISIBLE_RESULTS);
-  }, [catalog, activeCategory, lowerQuery]);
+  }, [catalog, activeCategory, lowerQuery, scarceCropIds]);
 
   const exactMatch = useMemo(() => {
     if (!trimmedQuery) return null;
@@ -260,6 +283,7 @@ export function CropPicker({ catalog, isLoading, value, onChange, compact }: Cro
           {matches.map((crop, index) => {
             const visual = visualForCrop(crop.commonName, crop.category);
             const isHighlighted = index === highlightIndex;
+            const isScarce = scarceCropIds?.has(crop.id) ?? false;
             return (
               <li
                 key={crop.id}
@@ -281,7 +305,17 @@ export function CropPicker({ catalog, isLoading, value, onChange, compact }: Cro
                   <CropIcon iconKey={visual.iconKey} color={visual.accent} size="1.3rem" />
                 </span>
                 <span className="grn-crop-picker__option-text">
-                  <span className="grn-crop-picker__option-name">{crop.commonName}</span>
+                  <span className="grn-crop-picker__option-name">
+                    {crop.commonName}
+                    {isScarce ? (
+                      <span
+                        className="grn-crop-picker__pill grn-crop-picker__pill--scarce"
+                        data-testid="needed-nearby-badge"
+                      >
+                        Needed nearby
+                      </span>
+                    ) : null}
+                  </span>
                   <span className="grn-crop-picker__option-meta">
                     {crop.category ? <span>{crop.category}</span> : null}
                     {crop.scientificName ? <em>{crop.scientificName}</em> : null}

--- a/apps/grn/src/components/CropPlanner/CropPicker.tsx
+++ b/apps/grn/src/components/CropPlanner/CropPicker.tsx
@@ -74,6 +74,23 @@ export function CropPicker({
     return () => document.removeEventListener('mousedown', handler);
   }, [isOpen]);
 
+  // Sync the visible input when the selection is set externally — e.g.
+  // when a grower taps a "Needed nearby" chip and the parent calls
+  // onChange with a new selection. Uses the React-recommended
+  // "adjust state during render" pattern so we run before the next
+  // paint without scheduling an effect. value=null is intentionally
+  // ignored so typing that clears the selection doesn't wipe the input
+  // mid-edit.
+  const [lastSyncedCropName, setLastSyncedCropName] = useState<string | null>(
+    value?.cropName ?? null
+  );
+  if (value && value.cropName !== lastSyncedCropName) {
+    setLastSyncedCropName(value.cropName);
+    if (value.cropName !== query) {
+      setQuery(value.cropName);
+    }
+  }
+
   const trimmedQuery = query.trim();
   const lowerQuery = trimmedQuery.toLowerCase();
 

--- a/apps/grn/src/components/Recommendations/NeededNearbyStrip.test.tsx
+++ b/apps/grn/src/components/Recommendations/NeededNearbyStrip.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NeededNearbyStrip } from './NeededNearbyStrip';
+import type { CatalogCrop } from '../../types/listing';
+import type { ScarceCropEntry } from '../../hooks/useGrowerCropSignals';
+
+const catalog: CatalogCrop[] = [
+  {
+    id: 'crop-1',
+    slug: 'tomato',
+    commonName: 'Tomato',
+    scientificName: null,
+    category: 'fruit',
+    description: null,
+  },
+  {
+    id: 'crop-2',
+    slug: 'kale',
+    commonName: 'Kale',
+    scientificName: null,
+    category: 'leafy',
+    description: null,
+  },
+];
+
+const topScarce: ScarceCropEntry[] = [
+  { cropId: 'crop-1', scarcityScore: 0.92, requestCount: 8, listingCount: 2 },
+  { cropId: 'crop-2', scarcityScore: 0.61, requestCount: 4, listingCount: 1 },
+];
+
+describe('NeededNearbyStrip', () => {
+  it('renders nothing while loading so it does not flash', () => {
+    const { container } = render(
+      <NeededNearbyStrip
+        topScarce={topScarce}
+        catalog={catalog}
+        isLoading
+        onSelect={() => {}}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when there are no scarce crops to show', () => {
+    const { container } = render(
+      <NeededNearbyStrip topScarce={[]} catalog={catalog} isLoading={false} onSelect={() => {}} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when scarce crops are not in the catalog', () => {
+    const { container } = render(
+      <NeededNearbyStrip
+        topScarce={[{ cropId: 'missing', scarcityScore: 0.9, requestCount: 3, listingCount: 0 }]}
+        catalog={catalog}
+        isLoading={false}
+        onSelect={() => {}}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders chips for each scarce crop with request counts', () => {
+    render(
+      <NeededNearbyStrip
+        topScarce={topScarce}
+        catalog={catalog}
+        isLoading={false}
+        onSelect={() => {}}
+      />
+    );
+
+    const strip = screen.getByTestId('needed-nearby-strip');
+    expect(strip).toHaveTextContent(/needed nearby/i);
+    expect(screen.getByTestId('needed-nearby-chip-tomato')).toHaveTextContent('Tomato');
+    expect(screen.getByTestId('needed-nearby-chip-tomato')).toHaveTextContent('8 requests');
+    expect(screen.getByTestId('needed-nearby-chip-kale')).toHaveTextContent('4 requests');
+  });
+
+  it('calls onSelect with a CropPickerSelection when a chip is tapped', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <NeededNearbyStrip
+        topScarce={topScarce}
+        catalog={catalog}
+        isLoading={false}
+        onSelect={onSelect}
+      />
+    );
+
+    await user.click(screen.getByTestId('needed-nearby-chip-tomato'));
+
+    expect(onSelect).toHaveBeenCalledWith({
+      catalogCropId: 'crop-1',
+      cropName: 'Tomato',
+      category: 'fruit',
+    });
+  });
+
+  it('reflects the currently selected catalog crop on its chip', () => {
+    render(
+      <NeededNearbyStrip
+        topScarce={topScarce}
+        catalog={catalog}
+        isLoading={false}
+        onSelect={() => {}}
+        selectedCatalogCropId="crop-2"
+      />
+    );
+
+    expect(screen.getByTestId('needed-nearby-chip-kale')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('needed-nearby-chip-tomato')).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/apps/grn/src/components/Recommendations/NeededNearbyStrip.test.tsx
+++ b/apps/grn/src/components/Recommendations/NeededNearbyStrip.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NeededNearbyStrip } from './NeededNearbyStrip';
 import type { CatalogCrop } from '../../types/listing';
@@ -116,5 +116,27 @@ describe('NeededNearbyStrip', () => {
 
     expect(screen.getByTestId('needed-nearby-chip-kale')).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByTestId('needed-nearby-chip-tomato')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('flags already-growing crops and pushes them after fresh opportunities', () => {
+    render(
+      <NeededNearbyStrip
+        topScarce={topScarce}
+        catalog={catalog}
+        isLoading={false}
+        onSelect={() => {}}
+        growingCropIds={new Set(['crop-1'])}
+      />
+    );
+
+    const tomatoChip = screen.getByTestId('needed-nearby-chip-tomato');
+    expect(within(tomatoChip).getByTestId('already-growing-flag')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('needed-nearby-chip-kale')).queryByTestId('already-growing-flag')
+    ).not.toBeInTheDocument();
+
+    const chips = screen.getAllByRole('button');
+    expect(chips[0]).toBe(screen.getByTestId('needed-nearby-chip-kale'));
+    expect(chips[1]).toBe(tomatoChip);
   });
 });

--- a/apps/grn/src/components/Recommendations/NeededNearbyStrip.tsx
+++ b/apps/grn/src/components/Recommendations/NeededNearbyStrip.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react';
+import type { CatalogCrop } from '../../types/listing';
+import type { CropPickerSelection } from '../CropPlanner/CropPicker';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { CropIcon } from '../CropPlanner/cropIcons';
+import type { ScarceCropEntry } from '../../hooks/useGrowerCropSignals';
+
+interface NeededNearbyStripProps {
+  topScarce: ScarceCropEntry[];
+  catalog: CatalogCrop[];
+  isLoading: boolean;
+  onSelect: (selection: CropPickerSelection) => void;
+  selectedCatalogCropId?: string | null;
+}
+
+interface ResolvedScarceCrop extends ScarceCropEntry {
+  crop: CatalogCrop;
+}
+
+/**
+ * Compact chip strip that highlights the crops nearby searchers are
+ * asking for. Tapping a chip prefills the CropPicker so a grower can
+ * commit to that crop in one move. Renders nothing when there is
+ * nothing to recommend, so it stays invisible in cold-start regions.
+ */
+export function NeededNearbyStrip({
+  topScarce,
+  catalog,
+  isLoading,
+  onSelect,
+  selectedCatalogCropId,
+}: NeededNearbyStripProps) {
+  const resolved = useMemo<ResolvedScarceCrop[]>(() => {
+    if (catalog.length === 0) return [];
+    const byId = new Map(catalog.map((crop) => [crop.id, crop]));
+    return topScarce
+      .map((entry) => {
+        const crop = byId.get(entry.cropId);
+        return crop ? { ...entry, crop } : null;
+      })
+      .filter((entry): entry is ResolvedScarceCrop => entry !== null);
+  }, [topScarce, catalog]);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (resolved.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grn-needed-nearby" data-testid="needed-nearby-strip">
+      <div className="grn-needed-nearby__header">
+        <span className="grn-needed-nearby__eyebrow">Needed nearby</span>
+        <p className="grn-needed-nearby__hint">
+          Local searchers are asking for these. Tap one to start adding it.
+        </p>
+      </div>
+      <ul className="grn-needed-nearby__chips" role="list">
+        {resolved.map((entry) => {
+          const visual = visualForCrop(entry.crop.commonName, entry.crop.category);
+          const isSelected = selectedCatalogCropId === entry.crop.id;
+          return (
+            <li key={entry.cropId}>
+              <button
+                type="button"
+                className={`grn-needed-nearby__chip ${isSelected ? 'is-selected' : ''}`.trim()}
+                aria-pressed={isSelected}
+                data-testid={`needed-nearby-chip-${entry.crop.slug}`}
+                onClick={() =>
+                  onSelect({
+                    catalogCropId: entry.crop.id,
+                    cropName: entry.crop.commonName,
+                    category: entry.crop.category,
+                  })
+                }
+              >
+                <span
+                  className="grn-needed-nearby__chip-emoji"
+                  aria-hidden="true"
+                  style={{ background: `${visual.accent}1f` }}
+                >
+                  <CropIcon iconKey={visual.iconKey} color={visual.accent} size="1.1rem" />
+                </span>
+                <span className="grn-needed-nearby__chip-text">
+                  <span className="grn-needed-nearby__chip-name">{entry.crop.commonName}</span>
+                  <span className="grn-needed-nearby__chip-meta">
+                    {entry.requestCount} request{entry.requestCount === 1 ? '' : 's'}
+                  </span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default NeededNearbyStrip;

--- a/apps/grn/src/components/Recommendations/NeededNearbyStrip.tsx
+++ b/apps/grn/src/components/Recommendations/NeededNearbyStrip.tsx
@@ -11,10 +11,18 @@ interface NeededNearbyStripProps {
   isLoading: boolean;
   onSelect: (selection: CropPickerSelection) => void;
   selectedCatalogCropId?: string | null;
+  /**
+   * Catalog crop IDs the grower already has in their garden. These
+   * still appear (because neighbors may still want more), but are
+   * sorted after new opportunities and stamped with "Already growing"
+   * so the chip doesn't read as a fresh suggestion.
+   */
+  growingCropIds?: Set<string>;
 }
 
 interface ResolvedScarceCrop extends ScarceCropEntry {
   crop: CatalogCrop;
+  alreadyGrowing: boolean;
 }
 
 /**
@@ -29,17 +37,32 @@ export function NeededNearbyStrip({
   isLoading,
   onSelect,
   selectedCatalogCropId,
+  growingCropIds,
 }: NeededNearbyStripProps) {
   const resolved = useMemo<ResolvedScarceCrop[]>(() => {
     if (catalog.length === 0) return [];
     const byId = new Map(catalog.map((crop) => [crop.id, crop]));
-    return topScarce
+    const list = topScarce
       .map((entry) => {
         const crop = byId.get(entry.cropId);
-        return crop ? { ...entry, crop } : null;
+        if (!crop) return null;
+        return {
+          ...entry,
+          crop,
+          alreadyGrowing: growingCropIds?.has(entry.cropId) ?? false,
+        };
       })
       .filter((entry): entry is ResolvedScarceCrop => entry !== null);
-  }, [topScarce, catalog]);
+    // Surface fresh opportunities first; keep already-growing chips visible
+    // so growers know neighbors still want more, but de-prioritized.
+    list.sort((left, right) => {
+      if (left.alreadyGrowing !== right.alreadyGrowing) {
+        return left.alreadyGrowing ? 1 : -1;
+      }
+      return right.scarcityScore - left.scarcityScore;
+    });
+    return list;
+  }, [topScarce, catalog, growingCropIds]);
 
   if (isLoading) {
     return null;
@@ -65,7 +88,7 @@ export function NeededNearbyStrip({
             <li key={entry.cropId}>
               <button
                 type="button"
-                className={`grn-needed-nearby__chip ${isSelected ? 'is-selected' : ''}`.trim()}
+                className={`grn-needed-nearby__chip ${isSelected ? 'is-selected' : ''} ${entry.alreadyGrowing ? 'is-already-growing' : ''}`.trim()}
                 aria-pressed={isSelected}
                 data-testid={`needed-nearby-chip-${entry.crop.slug}`}
                 onClick={() =>
@@ -84,7 +107,17 @@ export function NeededNearbyStrip({
                   <CropIcon iconKey={visual.iconKey} color={visual.accent} size="1.1rem" />
                 </span>
                 <span className="grn-needed-nearby__chip-text">
-                  <span className="grn-needed-nearby__chip-name">{entry.crop.commonName}</span>
+                  <span className="grn-needed-nearby__chip-name">
+                    {entry.crop.commonName}
+                    {entry.alreadyGrowing ? (
+                      <span
+                        className="grn-needed-nearby__chip-flag"
+                        data-testid="already-growing-flag"
+                      >
+                        Already growing
+                      </span>
+                    ) : null}
+                  </span>
                   <span className="grn-needed-nearby__chip-meta">
                     {entry.requestCount} request{entry.requestCount === 1 ? '' : 's'}
                   </span>

--- a/apps/grn/src/components/Recommendations/RecommendationsPanel.test.tsx
+++ b/apps/grn/src/components/Recommendations/RecommendationsPanel.test.tsx
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecommendationsPanel } from './RecommendationsPanel';
+import {
+  createCheckoutSession,
+  getDerivedFeed,
+  getEntitlements,
+  getWeeklyGrowPlan,
+  listCatalogCrops,
+} from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  createCheckoutSession: vi.fn(),
+  getDerivedFeed: vi.fn(),
+  getEntitlements: vi.fn(),
+  getWeeklyGrowPlan: vi.fn(),
+  listCatalogCrops: vi.fn(),
+}));
+
+const mockCreateCheckoutSession = vi.mocked(createCheckoutSession);
+const mockGetDerivedFeed = vi.mocked(getDerivedFeed);
+const mockGetEntitlements = vi.mocked(getEntitlements);
+const mockGetWeeklyGrowPlan = vi.mocked(getWeeklyGrowPlan);
+const mockListCatalogCrops = vi.mocked(listCatalogCrops);
+
+function setOnlineStatus(isOnline: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value: isOnline,
+  });
+}
+
+function renderPanel(overrides?: { growerGeoKey?: string | null }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const growerGeoKey = overrides && 'growerGeoKey' in overrides ? overrides.growerGeoKey : '9v6kn';
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecommendationsPanel viewerUserId="grower-1" growerGeoKey={growerGeoKey} />
+    </QueryClientProvider>
+  );
+}
+
+describe('RecommendationsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    setOnlineStatus(true);
+
+    mockListCatalogCrops.mockResolvedValue([
+      {
+        id: 'crop-1',
+        slug: 'tomato',
+        commonName: 'Tomato',
+        scientificName: null,
+        category: 'fruit',
+        description: null,
+      },
+      {
+        id: 'crop-2',
+        slug: 'kale',
+        commonName: 'Kale',
+        scientificName: null,
+        category: 'leafy',
+        description: null,
+      },
+    ]);
+
+    mockGetDerivedFeed.mockResolvedValue({
+      items: [],
+      signals: [
+        {
+          geoBoundaryKey: '9v6k',
+          cropId: 'crop-1',
+          windowDays: 7,
+          listingCount: 2,
+          requestCount: 8,
+          supplyQuantity: '20',
+          demandQuantity: '80',
+          scarcityScore: 0.92,
+          abundanceScore: 0.18,
+          computedAt: '2026-02-20T10:00:00.000Z',
+          expiresAt: '2026-02-20T16:00:00.000Z',
+        },
+        {
+          geoBoundaryKey: '9v6k',
+          cropId: 'crop-2',
+          windowDays: 7,
+          listingCount: 12,
+          requestCount: 3,
+          supplyQuantity: '160',
+          demandQuantity: '20',
+          scarcityScore: 0.1,
+          abundanceScore: 0.94,
+          computedAt: '2026-02-20T10:00:00.000Z',
+          expiresAt: '2026-02-20T16:00:00.000Z',
+        },
+      ],
+      freshness: {
+        asOf: '2026-02-20T10:00:00.000Z',
+        isStale: false,
+        staleFallbackUsed: false,
+        staleReason: null,
+      },
+      aiSummary: null,
+      growerGuidance: {
+        guidanceText: 'Consider planting more tomatoes — local demand exceeds supply.',
+        explanation: {
+          season: 'spring',
+          strategy: 'increase-resilience',
+          windowDays: 7,
+          sourceSignalCount: 2,
+          strongestScarcitySignal: null,
+          strongestAbundanceSignal: null,
+        },
+      },
+      limit: 1,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    mockGetEntitlements.mockResolvedValue({
+      tier: 'pro',
+      entitlementsVersion: 'v1',
+      entitlements: ['ai.feed_insights.read'],
+      policy: { aiIsProOnly: true, freeRemindersDeterministicOnly: true },
+    });
+
+    mockGetWeeklyGrowPlan.mockResolvedValue({
+      modelId: 'amazon.nova-lite-v1:0',
+      modelVersion: 'v1',
+      structuredJson: true,
+      geoKey: '9v6kn',
+      windowDays: 7,
+      recommendations: [
+        {
+          recommendation: 'Plant a scarcity-priority crop like tomatoes this week.',
+          confidence: 0.82,
+          rationale: ['Top scarcity signal: 0.92 for tomatoes'],
+        },
+      ],
+    });
+
+    mockCreateCheckoutSession.mockResolvedValue({
+      checkoutUrl: 'https://checkout.stripe.test/session_123',
+      checkoutSessionId: 'cs_test_123',
+    });
+  });
+
+  it('prompts to set location when grower has no geo key', () => {
+    renderPanel({ growerGeoKey: null });
+
+    expect(
+      screen.getByRole('heading', { name: /set your location to see recommendations/i })
+    ).toBeInTheDocument();
+    expect(mockGetDerivedFeed).not.toHaveBeenCalled();
+  });
+
+  it('renders deterministic guidance and ranked crop signals', async () => {
+    renderPanel();
+
+    const guidance = await screen.findByTestId('grower-guidance-card');
+    expect(
+      within(guidance).getByText(/consider planting more tomatoes/i)
+    ).toBeInTheDocument();
+
+    const snapshot = await screen.findByTestId('grower-signal-snapshot');
+    const scarceList = within(snapshot).getByTestId('grower-scarce-list');
+    const abundantList = within(snapshot).getByTestId('grower-abundant-list');
+    expect(within(scarceList).getByText('Tomato')).toBeInTheDocument();
+    expect(within(scarceList).getByText(/scarcity 92%/i)).toBeInTheDocument();
+    expect(within(abundantList).getByText('Kale')).toBeInTheDocument();
+    expect(within(abundantList).getByText(/abundance 94%/i)).toBeInTheDocument();
+  });
+
+  it('shows the AI grow plan when the Pro entitlement is present', async () => {
+    renderPanel();
+
+    const planCard = await screen.findByTestId('weekly-grow-plan-card');
+    expect(
+      within(planCard).getByText(/plant a scarcity-priority crop/i)
+    ).toBeInTheDocument();
+    expect(within(planCard).getByText(/confidence 82%/i)).toBeInTheDocument();
+    expect(within(planCard).getByText(/ai-assisted/i)).toBeInTheDocument();
+  });
+
+  it('hides the AI plan and shows an upgrade CTA when the user is not Pro', async () => {
+    mockGetEntitlements.mockResolvedValueOnce({
+      tier: 'free',
+      entitlementsVersion: 'v1',
+      entitlements: [],
+      policy: { aiIsProOnly: true, freeRemindersDeterministicOnly: true },
+    });
+
+    renderPanel();
+
+    expect(
+      await screen.findByText(/ai grow plans are a pro feature/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unlock pro ai/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetWeeklyGrowPlan).not.toHaveBeenCalled();
+    });
+    expect(await screen.findByTestId('grower-guidance-card')).toBeInTheDocument();
+  });
+
+  it('lets a Pro user opt out of AI insights and skips fetching the weekly plan', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(await screen.findByTestId('weekly-grow-plan-card')).toBeInTheDocument();
+
+    const toggle = screen.getByRole('checkbox', { name: /show ai grow plan/i });
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('weekly-grow-plan-card')).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/ai grow plans are off for this account on this device/i)
+    ).toBeInTheDocument();
+  });
+
+  it('refetches signals when the user changes the window', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await screen.findByTestId('grower-signal-snapshot');
+
+    await waitFor(() => {
+      expect(mockGetDerivedFeed).toHaveBeenCalledWith(
+        expect.objectContaining({ geoKey: '9v6kn', windowDays: 7 })
+      );
+    });
+
+    const windowSelect = screen.getByRole('combobox', { name: /window/i });
+    await user.selectOptions(windowSelect, '30');
+
+    await waitFor(() => {
+      expect(mockGetDerivedFeed).toHaveBeenCalledWith(
+        expect.objectContaining({ geoKey: '9v6kn', windowDays: 30 })
+      );
+    });
+  });
+
+  it('shows an empty state when no crop signals are available', async () => {
+    mockGetDerivedFeed.mockResolvedValueOnce({
+      items: [],
+      signals: [],
+      freshness: {
+        asOf: '2026-02-20T10:00:00.000Z',
+        isStale: false,
+        staleFallbackUsed: false,
+        staleReason: null,
+      },
+      aiSummary: null,
+      growerGuidance: null,
+      limit: 1,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText(/no local signals yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/Recommendations/RecommendationsPanel.test.tsx
+++ b/apps/grn/src/components/Recommendations/RecommendationsPanel.test.tsx
@@ -128,7 +128,7 @@ describe('RecommendationsPanel', () => {
     mockGetEntitlements.mockResolvedValue({
       tier: 'pro',
       entitlementsVersion: 'v1',
-      entitlements: ['ai.feed_insights.read'],
+      entitlements: ['ai.copilot.weekly_grow_plan'],
       policy: { aiIsProOnly: true, freeRemindersDeterministicOnly: true },
     });
 
@@ -188,6 +188,25 @@ describe('RecommendationsPanel', () => {
     ).toBeInTheDocument();
     expect(within(planCard).getByText(/confidence 82%/i)).toBeInTheDocument();
     expect(within(planCard).getByText(/ai-assisted/i)).toBeInTheDocument();
+  });
+
+  it('keeps the weekly plan locked when the user only has the feed-insights entitlement', async () => {
+    mockGetEntitlements.mockResolvedValueOnce({
+      tier: 'supporter',
+      entitlementsVersion: 'v1',
+      entitlements: ['ai.feed_insights.read'],
+      policy: { aiIsProOnly: true, freeRemindersDeterministicOnly: true },
+    });
+
+    renderPanel();
+
+    expect(
+      await screen.findByText(/ai grow plans are a pro feature/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unlock pro ai/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetWeeklyGrowPlan).not.toHaveBeenCalled();
+    });
   });
 
   it('hides the AI plan and shows an upgrade CTA when the user is not Pro', async () => {

--- a/apps/grn/src/components/Recommendations/RecommendationsPanel.tsx
+++ b/apps/grn/src/components/Recommendations/RecommendationsPanel.tsx
@@ -105,9 +105,13 @@ export function RecommendationsPanel({
     retry: 1,
   });
 
-  const hasProAiInsights =
-    entitlementsQuery.data?.entitlements?.includes('ai.feed_insights.read') ?? false;
-  const aiInsightsActive = hasProAiInsights && !aiInsightsOptOut;
+  // Match the entitlement the backend handler requires
+  // (services/grn-api/src/api/handlers/ai_copilot.rs). Gating on
+  // ai.feed_insights.read would show the UI for tiers that have the
+  // summary entitlement but not the copilot one, then 403 on call.
+  const hasWeeklyPlanAccess =
+    entitlementsQuery.data?.entitlements?.includes('ai.copilot.weekly_grow_plan') ?? false;
+  const weeklyPlanActive = hasWeeklyPlanAccess && !aiInsightsOptOut;
 
   const derivedFeedQuery = useQuery({
     queryKey: ['growerDerivedFeed', growerGeoKey, windowDays],
@@ -125,7 +129,7 @@ export function RecommendationsPanel({
   const weeklyPlanQuery = useQuery({
     queryKey: ['growerWeeklyPlan', growerGeoKey, windowDays],
     queryFn: () => getWeeklyGrowPlan(growerGeoKey ?? '', windowDays),
-    enabled: Boolean(growerGeoKey) && !isOffline && aiInsightsActive,
+    enabled: Boolean(growerGeoKey) && !isOffline && weeklyPlanActive,
     staleTime: 60 * 1000,
   });
 
@@ -336,7 +340,7 @@ export function RecommendationsPanel({
             </p>
           </div>
 
-          {hasProAiInsights ? (
+          {hasWeeklyPlanAccess ? (
             <label className="inline-flex items-center gap-2 text-sm text-neutral-700">
               <input
                 type="checkbox"
@@ -357,7 +361,7 @@ export function RecommendationsPanel({
           )}
         </div>
 
-        {!hasProAiInsights && (
+        {!hasWeeklyPlanAccess && (
           <p
             className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700"
             role="status"
@@ -366,7 +370,7 @@ export function RecommendationsPanel({
           </p>
         )}
 
-        {hasProAiInsights && aiInsightsOptOut && (
+        {hasWeeklyPlanAccess && aiInsightsOptOut && (
           <p
             className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700"
             role="status"
@@ -375,11 +379,11 @@ export function RecommendationsPanel({
           </p>
         )}
 
-        {aiInsightsActive && weeklyPlanQuery.isLoading && (
+        {weeklyPlanActive && weeklyPlanQuery.isLoading && (
           <p className="text-sm text-neutral-600" role="status">Loading AI grow plan...</p>
         )}
 
-        {aiInsightsActive && weeklyPlanQuery.isError && (
+        {weeklyPlanActive && weeklyPlanQuery.isError && (
           <p
             className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800"
             role="status"
@@ -388,7 +392,7 @@ export function RecommendationsPanel({
           </p>
         )}
 
-        {aiInsightsActive && weeklyPlanQuery.data?.recommendations?.length ? (
+        {weeklyPlanActive && weeklyPlanQuery.data?.recommendations?.length ? (
           <div
             className="rounded-base border border-primary-300 bg-white px-3 py-3"
             data-testid="weekly-grow-plan-card"

--- a/apps/grn/src/components/Recommendations/RecommendationsPanel.tsx
+++ b/apps/grn/src/components/Recommendations/RecommendationsPanel.tsx
@@ -1,0 +1,423 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Card } from '@olivias/ui';
+import {
+  createCheckoutSession,
+  getDerivedFeed,
+  getEntitlements,
+  getWeeklyGrowPlan,
+  listCatalogCrops,
+} from '../../services/api';
+import type { DerivedFeedSignal } from '../../types/feed';
+import { createLogger } from '../../utils/logging';
+
+const logger = createLogger('grower-recommendations');
+const AI_OPT_OUT_KEY_PREFIX = 'ai-insights-opt-out';
+
+type WindowDays = 7 | 14 | 30;
+
+const WINDOW_OPTIONS: { value: WindowDays; label: string }[] = [
+  { value: 7, label: 'Last 7 days' },
+  { value: 14, label: 'Last 14 days' },
+  { value: 30, label: 'Last 30 days' },
+];
+
+export interface RecommendationsPanelProps {
+  viewerUserId?: string;
+  growerGeoKey?: string | null;
+  defaultWindowDays?: WindowDays;
+}
+
+function loadAiOptOutPreference(viewerUserId?: string): boolean {
+  try {
+    const storageKey = `${AI_OPT_OUT_KEY_PREFIX}:${viewerUserId ?? 'anonymous'}`;
+    return window.localStorage.getItem(storageKey) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return '0%';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDateTime(value: string): string {
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+function rankSignals(
+  signals: DerivedFeedSignal[],
+  key: 'scarcityScore' | 'abundanceScore'
+): DerivedFeedSignal[] {
+  return [...signals].sort((left, right) => right[key] - left[key]).slice(0, 5);
+}
+
+export function RecommendationsPanel({
+  viewerUserId,
+  growerGeoKey,
+  defaultWindowDays = 7,
+}: RecommendationsPanelProps) {
+  const [isOffline, setIsOffline] = useState<boolean>(() => !navigator.onLine);
+  const [windowDays, setWindowDays] = useState<WindowDays>(defaultWindowDays);
+  const [aiInsightsOptOut, setAiInsightsOptOut] = useState<boolean>(() =>
+    loadAiOptOutPreference(viewerUserId)
+  );
+  const [isStartingUpgrade, setIsStartingUpgrade] = useState(false);
+
+  useEffect(() => {
+    const goOffline = () => setIsOffline(true);
+    const goOnline = () => setIsOffline(false);
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online', goOnline);
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online', goOnline);
+    };
+  }, []);
+
+  useEffect(() => {
+    setAiInsightsOptOut(loadAiOptOutPreference(viewerUserId));
+  }, [viewerUserId]);
+
+  useEffect(() => {
+    try {
+      const storageKey = `${AI_OPT_OUT_KEY_PREFIX}:${viewerUserId ?? 'anonymous'}`;
+      window.localStorage.setItem(storageKey, String(aiInsightsOptOut));
+    } catch {
+      // Ignore localStorage failures in restricted environments.
+    }
+  }, [aiInsightsOptOut, viewerUserId]);
+
+  const cropsQuery = useQuery({
+    queryKey: ['catalogCrops'],
+    queryFn: listCatalogCrops,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const entitlementsQuery = useQuery({
+    queryKey: ['meEntitlements'],
+    queryFn: getEntitlements,
+    staleTime: 60 * 1000,
+    retry: 1,
+  });
+
+  const hasProAiInsights =
+    entitlementsQuery.data?.entitlements?.includes('ai.feed_insights.read') ?? false;
+  const aiInsightsActive = hasProAiInsights && !aiInsightsOptOut;
+
+  const derivedFeedQuery = useQuery({
+    queryKey: ['growerDerivedFeed', growerGeoKey, windowDays],
+    queryFn: () =>
+      getDerivedFeed({
+        geoKey: growerGeoKey ?? '',
+        windowDays,
+        limit: 1,
+        offset: 0,
+      }),
+    enabled: Boolean(growerGeoKey) && !isOffline,
+    staleTime: 60 * 1000,
+  });
+
+  const weeklyPlanQuery = useQuery({
+    queryKey: ['growerWeeklyPlan', growerGeoKey, windowDays],
+    queryFn: () => getWeeklyGrowPlan(growerGeoKey ?? '', windowDays),
+    enabled: Boolean(growerGeoKey) && !isOffline && aiInsightsActive,
+    staleTime: 60 * 1000,
+  });
+
+  const cropNameById = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const crop of cropsQuery.data ?? []) {
+      byId.set(crop.id, crop.commonName);
+    }
+    return byId;
+  }, [cropsQuery.data]);
+
+  const cropSignals = useMemo(
+    () => (derivedFeedQuery.data?.signals ?? []).filter((signal) => Boolean(signal.cropId)),
+    [derivedFeedQuery.data?.signals]
+  );
+
+  const scarceSignals = useMemo(() => rankSignals(cropSignals, 'scarcityScore'), [cropSignals]);
+  const abundantSignals = useMemo(
+    () => rankSignals(cropSignals, 'abundanceScore'),
+    [cropSignals]
+  );
+  const guidance = derivedFeedQuery.data?.growerGuidance ?? null;
+  const freshness = derivedFeedQuery.data?.freshness ?? null;
+
+  const labelForSignal = (signal: DerivedFeedSignal): string => {
+    if (!signal.cropId) return 'Mixed crops';
+    return cropNameById.get(signal.cropId) ?? 'Local crop';
+  };
+
+  const handleStartUpgrade = async () => {
+    try {
+      setIsStartingUpgrade(true);
+      const origin = window.location.origin;
+      const session = await createCheckoutSession({
+        successUrl: `${origin}/?upgrade=success`,
+        cancelUrl: `${origin}/?upgrade=cancelled`,
+      });
+      window.location.assign(session.checkoutUrl);
+    } catch (error) {
+      logger.error(
+        `Failed to start pro upgrade checkout: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    } finally {
+      setIsStartingUpgrade(false);
+    }
+  };
+
+  if (!growerGeoKey) {
+    return (
+      <Card className="space-y-3" padding="6">
+        <h3 className="text-lg font-semibold text-neutral-900">Set your location to see recommendations</h3>
+        <p className="text-sm text-neutral-700">
+          We use the geohash you set in onboarding to find what neighbors are growing and what's missing nearby. Add your home location in your profile to unlock grow recommendations.
+        </p>
+      </Card>
+    );
+  }
+
+  const isLoading = derivedFeedQuery.isLoading || cropsQuery.isLoading;
+  const hasNoSignals = !isLoading && !derivedFeedQuery.isError && cropSignals.length === 0;
+
+  return (
+    <div className="space-y-4">
+      <Card className="space-y-4" padding="6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold text-neutral-900">What to grow nearby</h3>
+            <p className="text-sm text-neutral-600">
+              Recommendations look at what neighbors are growing and what local searchers are asking for, then highlight gaps you could fill.
+            </p>
+          </div>
+
+          <label className="flex flex-col gap-1 text-sm text-neutral-700 sm:w-48">
+            <span className="font-medium" id="grow-window-label">Window</span>
+            <select
+              aria-labelledby="grow-window-label"
+              value={windowDays}
+              onChange={(event) => {
+                const next = Number(event.target.value) as WindowDays;
+                if (WINDOW_OPTIONS.some((option) => option.value === next)) {
+                  setWindowDays(next);
+                }
+              }}
+              className="w-full rounded-base border-2 border-neutral-300 bg-white px-3 py-2 text-base text-neutral-800"
+            >
+              {WINDOW_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {isOffline && (
+          <p
+            className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800"
+            role="status"
+          >
+            You are offline. Recommendations will refresh when you reconnect.
+          </p>
+        )}
+
+        {derivedFeedQuery.isError && !isOffline && (
+          <p
+            className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error"
+            role="alert"
+          >
+            We couldn't load local signals right now. Try again in a moment.
+          </p>
+        )}
+
+        {isLoading && !isOffline && (
+          <p className="text-sm text-neutral-600" role="status">Loading local signals...</p>
+        )}
+
+        {hasNoSignals && (
+          <p className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-3 text-sm text-neutral-700">
+            No local signals yet for this window. As more neighbors list surplus or post requests near your geohash, recommendations will appear here.
+          </p>
+        )}
+
+        {guidance && (
+          <div
+            className="rounded-base border border-primary-200 bg-primary-50 px-3 py-3"
+            data-testid="grower-guidance-card"
+          >
+            <h4 className="text-base font-semibold text-neutral-900">Local guidance</h4>
+            <p className="mt-1 text-sm text-neutral-800">{guidance.guidanceText}</p>
+            <p className="mt-2 text-xs text-neutral-600">
+              Strategy: {guidance.explanation.strategy} · Season: {guidance.explanation.season} · Based on {guidance.explanation.sourceSignalCount} local signal{guidance.explanation.sourceSignalCount === 1 ? '' : 's'}
+            </p>
+          </div>
+        )}
+
+        {(scarceSignals.length > 0 || abundantSignals.length > 0) && (
+          <div
+            className="rounded-base border border-neutral-200 bg-white px-3 py-3"
+            data-testid="grower-signal-snapshot"
+          >
+            <h4 className="text-sm font-semibold text-neutral-900">Crop signals near you</h4>
+            <p className="mt-1 text-xs text-neutral-600">
+              Scarce crops are in high demand and short supply locally. Abundant crops are already well covered.
+            </p>
+
+            <div className="mt-3 grid gap-3 md:grid-cols-2">
+              <div data-testid="grower-scarce-list">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-warning">Consider planting</p>
+                {scarceSignals.length === 0 ? (
+                  <p className="text-sm text-neutral-600">No crops stand out as scarce yet.</p>
+                ) : (
+                  <ul className="space-y-1 text-sm text-neutral-800">
+                    {scarceSignals.map((signal) => (
+                      <li
+                        key={`scarce-${signal.geoBoundaryKey}-${signal.cropId ?? 'all'}`}
+                        className="flex items-center justify-between gap-3"
+                      >
+                        <span>{labelForSignal(signal)}</span>
+                        <span className="text-xs text-neutral-600">
+                          scarcity {formatPercent(signal.scarcityScore)} · {signal.requestCount} request{signal.requestCount === 1 ? '' : 's'}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div data-testid="grower-abundant-list">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-success">Already covered</p>
+                {abundantSignals.length === 0 ? (
+                  <p className="text-sm text-neutral-600">No crops stand out as abundant yet.</p>
+                ) : (
+                  <ul className="space-y-1 text-sm text-neutral-800">
+                    {abundantSignals.map((signal) => (
+                      <li
+                        key={`abundant-${signal.geoBoundaryKey}-${signal.cropId ?? 'all'}`}
+                        className="flex items-center justify-between gap-3"
+                      >
+                        <span>{labelForSignal(signal)}</span>
+                        <span className="text-xs text-neutral-600">
+                          abundance {formatPercent(signal.abundanceScore)} · {signal.listingCount} listing{signal.listingCount === 1 ? '' : 's'}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {freshness && (
+          <p className="text-xs text-neutral-500">
+            Signals as of {formatDateTime(freshness.asOf)}
+            {freshness.isStale ? ' · using cached data while fresh signals catch up' : ''}
+          </p>
+        )}
+      </Card>
+
+      <Card className="space-y-4" padding="6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <h4 className="text-base font-semibold text-neutral-900">AI grow plan</h4>
+            <p className="text-sm text-neutral-600">
+              Optional weekly plan that turns nearby signals into specific suggestions. Labeled as AI-assisted and easy to turn off.
+            </p>
+          </div>
+
+          {hasProAiInsights ? (
+            <label className="inline-flex items-center gap-2 text-sm text-neutral-700">
+              <input
+                type="checkbox"
+                checked={!aiInsightsOptOut}
+                onChange={(event) => setAiInsightsOptOut(!event.target.checked)}
+                aria-label="Show AI grow plan"
+              />
+              Show AI plan
+            </label>
+          ) : (
+            <Button
+              onClick={() => void handleStartUpgrade()}
+              variant="primary"
+              disabled={isStartingUpgrade}
+            >
+              {isStartingUpgrade ? 'Opening checkout...' : 'Unlock Pro AI'}
+            </Button>
+          )}
+        </div>
+
+        {!hasProAiInsights && (
+          <p
+            className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700"
+            role="status"
+          >
+            AI grow plans are a Pro feature. The scarce/abundant signals above are always free.
+          </p>
+        )}
+
+        {hasProAiInsights && aiInsightsOptOut && (
+          <p
+            className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700"
+            role="status"
+          >
+            AI grow plans are off for this account on this device.
+          </p>
+        )}
+
+        {aiInsightsActive && weeklyPlanQuery.isLoading && (
+          <p className="text-sm text-neutral-600" role="status">Loading AI grow plan...</p>
+        )}
+
+        {aiInsightsActive && weeklyPlanQuery.isError && (
+          <p
+            className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800"
+            role="status"
+          >
+            AI grow plan is temporarily unavailable. The free signals above remain accurate.
+          </p>
+        )}
+
+        {aiInsightsActive && weeklyPlanQuery.data?.recommendations?.length ? (
+          <div
+            className="rounded-base border border-primary-300 bg-white px-3 py-3"
+            data-testid="weekly-grow-plan-card"
+          >
+            <div className="mb-2 inline-flex items-center rounded-full border border-primary-300 bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700">
+              AI-assisted
+            </div>
+            <ul className="space-y-2">
+              {weeklyPlanQuery.data.recommendations.map((rec, index) => (
+                <li
+                  key={`weekly-grow-plan-${index}`}
+                  className="rounded-md border border-neutral-200 px-3 py-2"
+                >
+                  <p className="text-sm text-neutral-900">{rec.recommendation}</p>
+                  <p className="mt-1 text-xs text-neutral-600">
+                    Confidence {formatPercent(rec.confidence)}
+                    {rec.rationale[0] ? ` · ${rec.rationale[0]}` : ''}
+                  </p>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 text-xs text-neutral-500">
+              Model: {weeklyPlanQuery.data.modelId} · Window: {weeklyPlanQuery.data.windowDays} days
+            </p>
+          </div>
+        ) : null}
+      </Card>
+    </div>
+  );
+}
+
+export default RecommendationsPanel;

--- a/apps/grn/src/hooks/useGrowerCropSignals.ts
+++ b/apps/grn/src/hooks/useGrowerCropSignals.ts
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getDerivedFeed, getMe } from '../services/api';
+import type { DerivedFeedSignal } from '../types/feed';
+
+const TOP_SCARCE_LIMIT = 4;
+const MIN_SCARCITY_TO_HIGHLIGHT = 0.5;
+
+export interface ScarceCropEntry {
+  cropId: string;
+  scarcityScore: number;
+  requestCount: number;
+  listingCount: number;
+}
+
+export interface GrowerCropSignals {
+  geoKey: string | null;
+  scarcityByCropId: Map<string, number>;
+  scarceCropIds: Set<string>;
+  topScarce: ScarceCropEntry[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useGrowerCropSignals(): GrowerCropSignals {
+  const profileQuery = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getMe,
+    staleTime: 5 * 60 * 1000,
+    retry: 2,
+  });
+
+  const geoKey =
+    profileQuery.data?.userType === 'grower'
+      ? profileQuery.data.growerProfile?.geoKey ?? null
+      : null;
+
+  const feedQuery = useQuery({
+    queryKey: ['growerDerivedFeed', geoKey, 7],
+    queryFn: () =>
+      getDerivedFeed({ geoKey: geoKey ?? '', windowDays: 7, limit: 1, offset: 0 }),
+    enabled: Boolean(geoKey),
+    staleTime: 60 * 1000,
+  });
+
+  const cropSignals = useMemo<DerivedFeedSignal[]>(
+    () => (feedQuery.data?.signals ?? []).filter((signal) => Boolean(signal.cropId)),
+    [feedQuery.data?.signals]
+  );
+
+  const topScarce = useMemo<ScarceCropEntry[]>(() => {
+    const ranked = [...cropSignals]
+      .filter((signal) => signal.scarcityScore >= MIN_SCARCITY_TO_HIGHLIGHT)
+      .sort((left, right) => right.scarcityScore - left.scarcityScore)
+      .slice(0, TOP_SCARCE_LIMIT);
+
+    return ranked
+      .map((signal) =>
+        signal.cropId
+          ? {
+              cropId: signal.cropId,
+              scarcityScore: signal.scarcityScore,
+              requestCount: signal.requestCount,
+              listingCount: signal.listingCount,
+            }
+          : null
+      )
+      .filter((entry): entry is ScarceCropEntry => entry !== null);
+  }, [cropSignals]);
+
+  const scarcityByCropId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const signal of cropSignals) {
+      if (!signal.cropId) continue;
+      const existing = map.get(signal.cropId);
+      if (existing === undefined || signal.scarcityScore > existing) {
+        map.set(signal.cropId, signal.scarcityScore);
+      }
+    }
+    return map;
+  }, [cropSignals]);
+
+  const scarceCropIds = useMemo(
+    () => new Set(topScarce.map((entry) => entry.cropId)),
+    [topScarce]
+  );
+
+  return {
+    geoKey,
+    scarcityByCropId,
+    scarceCropIds,
+    topScarce,
+    isLoading: profileQuery.isLoading || feedQuery.isLoading,
+    isError: feedQuery.isError,
+  };
+}

--- a/apps/grn/src/hooks/useGrowerCropSignals.ts
+++ b/apps/grn/src/hooks/useGrowerCropSignals.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getDerivedFeed, getMe } from '../services/api';
+import { getDerivedFeed, getMe, listMyCrops } from '../services/api';
 import type { DerivedFeedSignal } from '../types/feed';
 
 const TOP_SCARCE_LIMIT = 4;
@@ -18,6 +18,7 @@ export interface GrowerCropSignals {
   scarcityByCropId: Map<string, number>;
   scarceCropIds: Set<string>;
   topScarce: ScarceCropEntry[];
+  growingCatalogCropIds: Set<string>;
   isLoading: boolean;
   isError: boolean;
 }
@@ -30,16 +31,21 @@ export function useGrowerCropSignals(): GrowerCropSignals {
     retry: 2,
   });
 
-  const geoKey =
-    profileQuery.data?.userType === 'grower'
-      ? profileQuery.data.growerProfile?.geoKey ?? null
-      : null;
+  const isGrower = profileQuery.data?.userType === 'grower';
+  const geoKey = isGrower ? profileQuery.data?.growerProfile?.geoKey ?? null : null;
 
   const feedQuery = useQuery({
     queryKey: ['growerDerivedFeed', geoKey, 7],
     queryFn: () =>
       getDerivedFeed({ geoKey: geoKey ?? '', windowDays: 7, limit: 1, offset: 0 }),
     enabled: Boolean(geoKey),
+    staleTime: 60 * 1000,
+  });
+
+  const myCropsQuery = useQuery({
+    queryKey: ['myCrops'],
+    queryFn: listMyCrops,
+    enabled: isGrower,
     staleTime: 60 * 1000,
   });
 
@@ -85,11 +91,22 @@ export function useGrowerCropSignals(): GrowerCropSignals {
     [topScarce]
   );
 
+  const growingCatalogCropIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const crop of myCropsQuery.data ?? []) {
+      if (crop.canonicalId) {
+        ids.add(crop.canonicalId);
+      }
+    }
+    return ids;
+  }, [myCropsQuery.data]);
+
   return {
     geoKey,
     scarcityByCropId,
     scarceCropIds,
     topScarce,
+    growingCatalogCropIds,
     isLoading: profileQuery.isLoading || feedQuery.isLoading,
     isError: feedQuery.isError,
   };

--- a/apps/grn/src/pages/RecommendationsPage.tsx
+++ b/apps/grn/src/pages/RecommendationsPage.tsx
@@ -1,0 +1,47 @@
+import { Navigate } from 'react-router-dom';
+import { Panel, SectionHeading } from '@olivias/ui';
+import { useQuery } from '@tanstack/react-query';
+import { getMe } from '../services/api';
+import { RecommendationsPanel } from '../components/Recommendations/RecommendationsPanel';
+import { PlantLoader } from '../components/branding/PlantLoader';
+
+export function RecommendationsPage() {
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getMe,
+    staleTime: 5 * 60 * 1000,
+    retry: 2,
+  });
+
+  if (isLoading) {
+    return (
+      <section className="grn-section">
+        <SectionHeading eyebrow="Grower tools" title="Recommendations" />
+        <Panel className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Loading…</p>
+        </Panel>
+      </section>
+    );
+  }
+
+  if (!profile || profile.userType !== 'grower') {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <section className="grn-section">
+      <SectionHeading
+        eyebrow="Grower tools"
+        title="Recommendations"
+        body="See what's scarce, what's already covered, and what to plant next based on neighbors near you."
+      />
+      <RecommendationsPanel
+        viewerUserId={profile.id}
+        growerGeoKey={profile.growerProfile?.geoKey ?? null}
+      />
+    </section>
+  );
+}
+
+export default RecommendationsPage;

--- a/apps/grn/src/shell/AppShell.tsx
+++ b/apps/grn/src/shell/AppShell.tsx
@@ -54,6 +54,19 @@ const growerNavItems: NavItem[] = [
     ),
   },
   {
+    id: 'recommendations',
+    path: '/recommendations',
+    label: 'Recommendations',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 2a1 1 0 0 1 .9.56l2.18 4.42 4.88.71a1 1 0 0 1 .55 1.71l-3.53 3.44.83 4.86a1 1 0 0 1-1.45 1.05L12 16.77l-4.36 2.29A1 1 0 0 1 6.19 18l.83-4.86L3.49 9.7a1 1 0 0 1 .55-1.71l4.88-.71L11.1 2.56A1 1 0 0 1 12 2Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+  },
+  {
     id: 'garden',
     path: '/garden',
     label: 'Designer',

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -11,6 +11,9 @@ const DashboardPage = lazy(() =>
 const CropsPage = lazy(() =>
   import('../pages/CropsPage').then((m) => ({ default: m.CropsPage }))
 );
+const RecommendationsPage = lazy(() =>
+  import('../pages/RecommendationsPage').then((m) => ({ default: m.RecommendationsPage }))
+);
 const NewCropPage = lazy(() =>
   import('../pages/NewCropPage').then((m) => ({ default: m.NewCropPage }))
 );
@@ -57,6 +60,7 @@ export function AuthenticatedRoot() {
               <Route path="/" element={<DashboardPage />} />
               <Route path="/crops" element={<CropsPage />} />
               <Route path="/crops/new" element={<NewCropPage />} />
+              <Route path="/recommendations" element={<RecommendationsPage />} />
               <Route path="/garden" element={<GardenDesignerPage />} />
               <Route path="/listings" element={<ListingsPage />} />
               <Route path="/requests" element={<RequestsPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -852,6 +852,100 @@ body {
   color: #8a5c1d;
 }
 
+.grn-crop-picker__pill--scarce {
+  margin-inline-start: 0.5rem;
+  background: rgba(216, 80, 41, 0.16);
+  color: #8a3517;
+}
+
+.grn-needed-nearby {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--og-radius-md);
+  border: 1px solid rgba(216, 80, 41, 0.28);
+  background: linear-gradient(135deg, rgba(216, 80, 41, 0.08), rgba(216, 167, 65, 0.08));
+}
+
+.grn-needed-nearby__header {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.grn-needed-nearby__eyebrow {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a3517;
+}
+
+.grn-needed-nearby__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--og-color-soil);
+}
+
+.grn-needed-nearby__chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.grn-needed-nearby__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 0.7rem 0.4rem 0.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 56, 37, 0.18);
+  background: var(--og-color-paper);
+  color: var(--og-color-ink);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.grn-needed-nearby__chip:hover,
+.grn-needed-nearby__chip:focus-visible {
+  border-color: var(--og-color-moss);
+  box-shadow: 0 6px 16px rgba(38, 23, 15, 0.12);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.grn-needed-nearby__chip.is-selected {
+  border-color: var(--og-color-moss);
+  box-shadow: 0 0 0 2px rgba(66, 107, 63, 0.25);
+}
+
+.grn-needed-nearby__chip-emoji {
+  display: inline-grid;
+  place-items: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 999px;
+}
+
+.grn-needed-nearby__chip-text {
+  display: grid;
+  text-align: start;
+}
+
+.grn-needed-nearby__chip-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.1;
+}
+
+.grn-needed-nearby__chip-meta {
+  font-size: 0.75rem;
+  color: var(--og-color-soil);
+}
+
 .grn-crop-picker__listbox {
   list-style: none;
   margin: 0.35rem 0 0;

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -858,6 +858,12 @@ body {
   color: #8a3517;
 }
 
+.grn-crop-picker__pill--growing {
+  margin-inline-start: 0.5rem;
+  background: rgba(66, 107, 63, 0.16);
+  color: var(--og-color-moss);
+}
+
 .grn-needed-nearby {
   display: grid;
   gap: 0.75rem;
@@ -920,6 +926,23 @@ body {
 .grn-needed-nearby__chip.is-selected {
   border-color: var(--og-color-moss);
   box-shadow: 0 0 0 2px rgba(66, 107, 63, 0.25);
+}
+
+.grn-needed-nearby__chip.is-already-growing {
+  background: rgba(66, 107, 63, 0.06);
+}
+
+.grn-needed-nearby__chip-flag {
+  display: inline-flex;
+  align-items: center;
+  margin-inline-start: 0.4rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(66, 107, 63, 0.16);
+  color: var(--og-color-moss);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .grn-needed-nearby__chip-emoji {


### PR DESCRIPTION
Adds a dedicated Recommendations page in the grower nav that wires the
existing /feed/derived signals + deterministic grower guidance and the
Pro-gated /ai/copilot/weekly-plan into a grower-facing view. The
underlying APIs already existed but were only surfaced inside the
gatherer's request panel.