### PR TITLE
GRN: close pro-tier gating gaps in entitlement test matrix

### DIFF
--- a/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Free - GET Agent Tasks.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Free - GET Agent Tasks.request.yaml
@@ -1,0 +1,26 @@
+$kind: http-request
+name: 'Free - GET /agent-tasks → 403'
+description: |-
+  Verifies that a free-tier token is rejected with 403 feature_locked
+  when listing pro agent tasks.
+method: GET
+url: '{{baseUrl}}/agent-tasks'
+order: 2500
+headers:
+  - key: Authorization
+    value: 'Bearer {{freeAuthToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 403", function () {
+          pm.response.to.have.status(403);
+      });
+
+      pm.test("Response contains feature_locked error with correct entitlement fields", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("error", "feature_locked");
+          pm.expect(body).to.have.property("entitlementKey").that.is.a("string");
+          pm.expect(body).to.have.property("requiredTier", "pro");
+          pm.expect(body).to.have.property("upgradeHintKey").that.is.a("string");
+      });

--- a/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Free - GET Feed Derived AI Summary.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Free - GET Feed Derived AI Summary.request.yaml
@@ -1,0 +1,36 @@
+$kind: http-request
+name: 'Free - GET /feed/derived → aiSummary is null'
+description: |-
+  Verifies that a free-tier token can read the derived feed (200) but
+  the LLM-backed aiSummary field is null because the user lacks the
+  ai.feed_insights.read entitlement.
+method: GET
+url: '{{baseUrl}}/feed/derived'
+order: 5500
+headers:
+  - key: Authorization
+    value: 'Bearer {{freeAuthToken}}'
+queryParams:
+  - key: geoKey
+    value: '9v6kn7'
+  - key: windowDays
+    value: '7'
+  - key: limit
+    value: '5'
+  - key: offset
+    value: '0'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Free tier never receives an aiSummary", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("items");
+          pm.expect(body).to.have.property("signals");
+          pm.expect(body).to.have.property("aiSummary");
+          pm.expect(body.aiSummary, "free tier must not receive AI-generated summary").to.equal(null);
+      });

--- a/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Premium - GET Agent Tasks.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Premium - GET Agent Tasks.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+name: 'Premium - GET /agent-tasks → non-403'
+description: |-
+  Verifies that a pro-tier token is NOT rejected with 403
+  when listing agent tasks.
+method: GET
+url: '{{baseUrl}}/agent-tasks'
+order: 7500
+headers:
+  - key: Authorization
+    value: 'Bearer {{premiumAuthToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is not 403", function () {
+          pm.expect(pm.response.code).to.not.equal(403);
+      });

--- a/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Premium - GET Feed Derived AI Summary.request.yaml
+++ b/postman/collections/Good Roots Network API - Utility Tests/Entitlement Matrix/Premium - GET Feed Derived AI Summary.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+name: 'Premium - GET /feed/derived → aiSummary shape when present'
+description: |-
+  Verifies that a pro-tier token reads the derived feed (200). The
+  aiSummary field is allowed to be null (no signal data / guardrails
+  blocked), but when present it must match the AI summary contract,
+  proving the LLM gating opens for pro callers.
+method: GET
+url: '{{baseUrl}}/feed/derived'
+order: 10500
+headers:
+  - key: Authorization
+    value: 'Bearer {{premiumAuthToken}}'
+queryParams:
+  - key: geoKey
+    value: '9v6kn7'
+  - key: windowDays
+    value: '7'
+  - key: limit
+    value: '5'
+  - key: offset
+    value: '0'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Pro tier receives aiSummary field (null or valid shape)", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("aiSummary");
+
+          if (body.aiSummary !== null) {
+              pm.expect(body.aiSummary).to.have.property("summaryText").that.is.a("string");
+              pm.expect(body.aiSummary).to.have.property("modelId").that.is.a("string");
+              pm.expect(body.aiSummary).to.have.property("modelVersion").that.is.a("string");
+              pm.expect(body.aiSummary).to.have.property("generatedAt").that.is.a("string");
+              pm.expect(body.aiSummary).to.have.property("expiresAt").that.is.a("string");
+              pm.expect(body.aiSummary).to.have.property("fromCache").that.is.a("boolean");
+          }
+      });

--- a/services/grn-api/src/api/middleware/entitlements.rs
+++ b/services/grn-api/src/api/middleware/entitlements.rs
@@ -274,4 +274,45 @@ mod tests {
         assert_eq!(response.required_tier, "pro");
         assert_eq!(response.upgrade_hint_key, "upgrade.pro");
     }
+
+    // Lock down LLM-touching entitlements at the config level so a future
+    // edit cannot accidentally hand them to the free tier. Every handler
+    // that invokes an LLM (or schedules one) must key off one of these.
+    const LLM_BACKED_ENTITLEMENTS: &[&str] = &[
+        "ai.copilot.weekly_grow_plan",
+        "ai.feed_insights.read",
+        "agent.tasks.automation",
+    ];
+
+    #[test]
+    fn llm_entitlements_are_denied_to_free_tier() {
+        let Some(config) = config_or_skip() else {
+            return;
+        };
+
+        for key in LLM_BACKED_ENTITLEMENTS {
+            let lookup = tier_has_entitlement(config, "free", key);
+            assert!(lookup.is_ok(), "entitlement lookup failed for {key}");
+            assert!(
+                !lookup.unwrap_or(true),
+                "free tier must not be granted LLM-backed entitlement {key}",
+            );
+        }
+    }
+
+    #[test]
+    fn llm_entitlements_are_granted_to_pro_tier() {
+        let Some(config) = config_or_skip() else {
+            return;
+        };
+
+        for key in LLM_BACKED_ENTITLEMENTS {
+            let lookup = tier_has_entitlement(config, "pro", key);
+            assert!(lookup.is_ok(), "entitlement lookup failed for {key}");
+            assert!(
+                lookup.unwrap_or(false),
+                "pro tier must be granted LLM-backed entitlement {key}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
Audit confirms every LLM-touching grn-api endpoint is already entitlement-
gated (ai_copilot, feed AI summary, agent_tasks, pro analytics). Add the
missing coverage so the gating cannot regress unnoticed:

- Postman entitlement matrix: free/pro GET /agent-tasks (the POST/PUT pair
  was covered but list was not) and free/pro GET /feed/derived asserting
  aiSummary is null for free callers and shape-valid for pro callers.
- Rust unit tests: loop over every LLM-backed entitlement key
  (ai.copilot.weekly_grow_plan, ai.feed_insights.read,
  agent.tasks.automation) so a config change that grants any of them to
  free fails fast.

https://claude.ai/code/session_01RmGYmBoprXEFf3yra1aNPe