### PR TITLE
GRN: Garden Pyramid planner with database-backed crop tiers

### DIFF
--- a/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PYRAMID_TIERS,
+  bucketCropsByTier,
+  classifyCropToTier,
+  tierMeta,
+  type PyramidTier,
+} from './gardenPyramid';
+
+describe('classifyCropToTier', () => {
+  it('places calorie staples in the Foundation layer', () => {
+    expect(classifyCropToTier('Potato')).toBe(1);
+    expect(classifyCropToTier('Sweet potato')).toBe(1);
+    expect(classifyCropToTier('Yukon Gold potatoes')).toBe(1);
+    expect(classifyCropToTier('Garlic')).toBe(1);
+    expect(classifyCropToTier('Yellow onion')).toBe(1);
+  });
+
+  it('places everyday vegetables in the Workhorse layer', () => {
+    expect(classifyCropToTier('Tomato')).toBe(2);
+    expect(classifyCropToTier('Bell pepper')).toBe(2);
+    expect(classifyCropToTier('Cucumber')).toBe(2);
+    expect(classifyCropToTier('Carrot')).toBe(2);
+    expect(classifyCropToTier('Zucchini')).toBe(2);
+  });
+
+  it('places fast greens in the Fresh layer', () => {
+    expect(classifyCropToTier('Lettuce')).toBe(3);
+    expect(classifyCropToTier('Spinach')).toBe(3);
+    expect(classifyCropToTier('Kale')).toBe(3);
+    expect(classifyCropToTier('Radish')).toBe(3);
+    expect(classifyCropToTier('Bok choy')).toBe(3);
+  });
+
+  it('places herbs in the Flavor layer', () => {
+    expect(classifyCropToTier('Cilantro')).toBe(4);
+    expect(classifyCropToTier('Dill')).toBe(4);
+    expect(classifyCropToTier('Flat-leaf parsley')).toBe(4);
+    expect(classifyCropToTier('Fennel')).toBe(4);
+    expect(classifyCropToTier('Basil')).toBe(4);
+  });
+
+  it('places berries and treats in the Joy layer', () => {
+    expect(classifyCropToTier('Strawberry')).toBe(5);
+    expect(classifyCropToTier('Blueberries')).toBe(5);
+    expect(classifyCropToTier('Raspberry')).toBe(5);
+    expect(classifyCropToTier('Concord grapes')).toBe(5);
+    expect(classifyCropToTier('Watermelon')).toBe(5);
+  });
+
+  describe('ambiguous names resolve to the most likely layer', () => {
+    it('treats winter squash as Foundation but summer squash/zucchini as Workhorse', () => {
+      expect(classifyCropToTier('Butternut squash')).toBe(1);
+      expect(classifyCropToTier('Winter squash')).toBe(1);
+      expect(classifyCropToTier('Squash')).toBe(1); // bare name → winter staple
+      expect(classifyCropToTier('Summer squash')).toBe(2);
+      expect(classifyCropToTier('Yellow squash')).toBe(2);
+    });
+
+    it('treats dry beans as Foundation but fresh/plain beans as Workhorse', () => {
+      expect(classifyCropToTier('Dry beans')).toBe(1);
+      expect(classifyCropToTier('Kidney bean')).toBe(1);
+      expect(classifyCropToTier('Green beans')).toBe(2);
+      expect(classifyCropToTier('Beans')).toBe(2); // bare name → fresh
+    });
+
+    it('separates storage onions from scallions/green onions', () => {
+      expect(classifyCropToTier('Onion')).toBe(1);
+      expect(classifyCropToTier('Green onion')).toBe(3);
+      expect(classifyCropToTier('Scallions')).toBe(3);
+    });
+  });
+
+  it('falls back to category when the name does not match', () => {
+    expect(classifyCropToTier('Some mystery plant', 'herb')).toBe(4);
+    expect(classifyCropToTier('Unknown thing', 'berry')).toBe(5);
+    expect(classifyCropToTier('Unknown veg', 'vegetable')).toBe(2);
+    expect(classifyCropToTier('Mystery grain', 'grain')).toBe(1);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(classifyCropToTier('Quux')).toBeNull();
+    expect(classifyCropToTier(null, null)).toBeNull();
+    expect(classifyCropToTier('Quux', 'unknown-category')).toBeNull();
+  });
+});
+
+describe('PYRAMID_TIERS', () => {
+  it('defines exactly five tiers ordered Foundation → Joy', () => {
+    expect(PYRAMID_TIERS).toHaveLength(5);
+    expect(PYRAMID_TIERS.map((t) => t.level)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('exposes metadata for each level via tierMeta', () => {
+    ([1, 2, 3, 4, 5] as PyramidTier[]).forEach((level) => {
+      const meta = tierMeta(level);
+      expect(meta.level).toBe(level);
+      expect(meta.name).toBeTruthy();
+      expect(meta.suggestions.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('bucketCropsByTier', () => {
+  it('groups crops into their layers and collects the unplaceable ones', () => {
+    const crops = [
+      { cropName: 'Potato' },
+      { cropName: 'Tomato' },
+      { cropName: 'Lettuce' },
+      { cropName: 'Basil' },
+      { cropName: 'Strawberry' },
+      { cropName: 'Mystery plant' },
+    ];
+
+    const { tiers, unsorted } = bucketCropsByTier(crops);
+
+    expect(tiers[1].map((c) => c.cropName)).toEqual(['Potato']);
+    expect(tiers[2].map((c) => c.cropName)).toEqual(['Tomato']);
+    expect(tiers[3].map((c) => c.cropName)).toEqual(['Lettuce']);
+    expect(tiers[4].map((c) => c.cropName)).toEqual(['Basil']);
+    expect(tiers[5].map((c) => c.cropName)).toEqual(['Strawberry']);
+    expect(unsorted.map((c) => c.cropName)).toEqual(['Mystery plant']);
+  });
+
+  it('returns empty buckets for an empty input', () => {
+    const { tiers, unsorted } = bucketCropsByTier([]);
+    expect(unsorted).toEqual([]);
+    ([1, 2, 3, 4, 5] as PyramidTier[]).forEach((level) => {
+      expect(tiers[level]).toEqual([]);
+    });
+  });
+});

--- a/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
@@ -3,6 +3,8 @@ import {
   PYRAMID_TIERS,
   bucketCropsByTier,
   classifyCropToTier,
+  evaluatePlan,
+  resolveCropTier,
   tierMeta,
   type PyramidTier,
 } from './gardenPyramid';
@@ -128,5 +130,67 @@ describe('bucketCropsByTier', () => {
     ([1, 2, 3, 4, 5] as PyramidTier[]).forEach((level) => {
       expect(tiers[level]).toEqual([]);
     });
+  });
+
+  it('prefers the catalog pyramidTier over the name-based fallback', () => {
+    // Name says "Tomato" (Workhorse) but the catalog tier wins.
+    const { tiers } = bucketCropsByTier([
+      { cropName: 'Tomato', pyramidTier: 5 },
+      { cropName: 'Totally made up plant', pyramidTier: 1 },
+    ]);
+    expect(tiers[5].map((c) => c.cropName)).toEqual(['Tomato']);
+    expect(tiers[1].map((c) => c.cropName)).toEqual(['Totally made up plant']);
+  });
+
+  it('ignores an out-of-range pyramidTier and falls back to the name', () => {
+    expect(resolveCropTier({ cropName: 'Tomato', pyramidTier: 9 })).toBe(2);
+    expect(resolveCropTier({ cropName: 'Tomato', pyramidTier: 0 })).toBe(2);
+    expect(resolveCropTier({ cropName: 'Tomato', pyramidTier: null })).toBe(2);
+    expect(resolveCropTier({ cropName: 'Tomato' })).toBe(2);
+  });
+});
+
+describe('evaluatePlan', () => {
+  const counts = (c: Partial<Record<PyramidTier, number>>): Record<PyramidTier, number> => ({
+    1: c[1] ?? 0,
+    2: c[2] ?? 0,
+    3: c[3] ?? 0,
+    4: c[4] ?? 0,
+    5: c[5] ?? 0,
+  });
+
+  it('scores an empty plan as zero with an Empty plot label', () => {
+    const result = evaluatePlan(counts({}));
+    expect(result.score).toBe(0);
+    expect(result.label).toBe('Empty plot');
+    expect(result.coveredCount).toBe(0);
+    expect(result.nextFocusTier).toBe(1);
+  });
+
+  it('gives a higher score to a foundation-first plan than a top-heavy one', () => {
+    const foundationFirst = evaluatePlan(counts({ 1: 3, 2: 2, 3: 1 }));
+    const topHeavy = evaluatePlan(counts({ 3: 1, 4: 2, 5: 3 }));
+    expect(foundationFirst.score).toBeGreaterThan(topHeavy.score);
+    expect(foundationFirst.topHeavy).toBe(false);
+    expect(topHeavy.topHeavy).toBe(true);
+  });
+
+  it('awards a full, well-shaped pyramid the top band', () => {
+    const result = evaluatePlan(counts({ 1: 5, 2: 4, 3: 3, 4: 2, 5: 1 }));
+    expect(result.score).toBe(100);
+    expect(result.label).toBe('Thriving garden');
+    expect(result.coveredCount).toBe(5);
+    expect(result.nextFocusTier).toBeNull();
+  });
+
+  it('points to the lowest empty layer as the next focus', () => {
+    const result = evaluatePlan(counts({ 1: 2, 3: 1 }));
+    expect(result.nextFocusTier).toBe(2);
+  });
+
+  it('keeps the score within 0–100', () => {
+    const result = evaluatePlan(counts({ 1: 1, 2: 1, 3: 1, 4: 1, 5: 1 }));
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
   });
 });

--- a/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.test.ts
@@ -62,6 +62,8 @@ describe('classifyCropToTier', () => {
     it('treats dry beans as Foundation but fresh/plain beans as Workhorse', () => {
       expect(classifyCropToTier('Dry beans')).toBe(1);
       expect(classifyCropToTier('Kidney bean')).toBe(1);
+      expect(classifyCropToTier('Fava bean')).toBe(1);
+      expect(classifyCropToTier('Edamame')).toBe(1);
       expect(classifyCropToTier('Green beans')).toBe(2);
       expect(classifyCropToTier('Beans')).toBe(2); // bare name → fresh
     });

--- a/apps/grn/src/components/CropPlanner/gardenPyramid.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.ts
@@ -254,17 +254,37 @@ export function classifyCropToTier(
   return null;
 }
 
+function asPyramidTier(value: number | null | undefined): PyramidTier | null {
+  if (value == null) return null;
+  if (Number.isInteger(value) && value >= 1 && value <= 5) {
+    return value as PyramidTier;
+  }
+  return null;
+}
+
+/**
+ * Resolve the pyramid layer for a single crop. The authoritative source is the
+ * `pyramidTier` carried from the catalog; only when that is absent (e.g. a
+ * free-text crop with no catalog link) do we fall back to classifying the name.
+ */
+export function resolveCropTier(crop: {
+  cropName: string;
+  pyramidTier?: number | null;
+}): PyramidTier | null {
+  return asPyramidTier(crop.pyramidTier) ?? classifyCropToTier(crop.cropName, null);
+}
+
 /**
  * Bucket a list of crops into pyramid layers. Returns a record keyed by tier
  * level plus an `unsorted` list for crops that couldn't be placed.
  */
-export function bucketCropsByTier<T extends { cropName: string }>(
+export function bucketCropsByTier<T extends { cropName: string; pyramidTier?: number | null }>(
   crops: readonly T[]
 ): { tiers: Record<PyramidTier, T[]>; unsorted: T[] } {
   const tiers: Record<PyramidTier, T[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
   const unsorted: T[] = [];
   for (const crop of crops) {
-    const tier = classifyCropToTier(crop.cropName, null);
+    const tier = resolveCropTier(crop);
     if (tier === null) {
       unsorted.push(crop);
     } else {
@@ -272,4 +292,100 @@ export function bucketCropsByTier<T extends { cropName: string }>(
     }
   }
   return { tiers, unsorted };
+}
+
+// ---------------------------------------------------------------------------
+// Plan evaluation
+// ---------------------------------------------------------------------------
+
+const ALL_TIERS: readonly PyramidTier[] = [1, 2, 3, 4, 5];
+
+// Lower layers carry more weight: a strong plan is built from the Foundation
+// up. Weights sum to 1 so full coverage maps to a coverage score of 1.
+const TIER_WEIGHTS: Record<PyramidTier, number> = {
+  1: 0.3,
+  2: 0.25,
+  3: 0.2,
+  4: 0.15,
+  5: 0.1,
+};
+
+export interface PlanEvaluation {
+  /** 0–100 overall plan health. */
+  score: number;
+  /** Friendly label for the score band. */
+  label: string;
+  /** Number of layers with at least one crop. */
+  coveredCount: number;
+  /** Lowest layer still empty (the recommended place to grow next), or null. */
+  nextFocusTier: PyramidTier | null;
+  /** True when an upper layer holds more crops than a layer beneath it. */
+  topHeavy: boolean;
+}
+
+function scoreLabel(score: number): string {
+  if (score <= 0) return 'Empty plot';
+  if (score < 25) return 'Seedling plan';
+  if (score < 50) return 'Taking root';
+  if (score < 75) return 'Well-rooted';
+  return 'Thriving garden';
+}
+
+/**
+ * Evaluate how well a garden is planned using the pyramid philosophy:
+ * reward covering the lower (foundational) layers, and reward a true pyramid
+ * shape where each layer is no smaller than the one above it.
+ */
+export function evaluatePlan(counts: Record<PyramidTier, number>): PlanEvaluation {
+  const total = ALL_TIERS.reduce((sum, t) => sum + (counts[t] || 0), 0);
+  const coveredCount = ALL_TIERS.filter((t) => (counts[t] || 0) > 0).length;
+  const nextFocusTier = ALL_TIERS.find((t) => (counts[t] || 0) === 0) ?? null;
+
+  if (total === 0) {
+    return { score: 0, label: scoreLabel(0), coveredCount: 0, nextFocusTier: 1, topHeavy: false };
+  }
+
+  // Coverage: weighted credit for each layer that has at least one crop.
+  const coverage = ALL_TIERS.reduce(
+    (sum, t) => sum + ((counts[t] || 0) > 0 ? TIER_WEIGHTS[t] : 0),
+    0
+  );
+
+  // Shape: a violation is an upper layer holding more crops than the layer
+  // directly beneath it (a top-heavy plan). Four adjacent pairs in total.
+  let violations = 0;
+  for (let t = 1 as PyramidTier; t < 5; t = (t + 1) as PyramidTier) {
+    const lower = counts[t] || 0;
+    const upper = counts[(t + 1) as PyramidTier] || 0;
+    if (upper > lower) violations += 1;
+  }
+  const shape = 1 - violations / 4;
+
+  const score = Math.round(100 * (0.7 * coverage + 0.3 * shape));
+
+  return {
+    score,
+    label: scoreLabel(score),
+    coveredCount,
+    nextFocusTier,
+    topHeavy: violations > 0,
+  };
+}
+
+/**
+ * Short, actionable guidance derived from an evaluation: what to grow next, or
+ * a nudge to rebalance a top-heavy plan.
+ */
+export function planGuidance(evaluation: PlanEvaluation): string {
+  if (evaluation.score === 0) {
+    return 'Start at the Foundation — add a staple crop like potatoes or onions.';
+  }
+  if (evaluation.nextFocusTier !== null) {
+    const meta = tierMeta(evaluation.nextFocusTier);
+    return `Next up: add a ${meta.name} crop — ${meta.tagline.toLowerCase()}.`;
+  }
+  if (evaluation.topHeavy) {
+    return 'Your plan is a little top-heavy. Add more to the lower layers to balance the pyramid.';
+  }
+  return 'Every layer is covered and well balanced — a beautifully planned garden!';
 }

--- a/apps/grn/src/components/CropPlanner/gardenPyramid.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.ts
@@ -140,7 +140,7 @@ const nameRules: ReadonlyArray<{ match: RegExp; tier: PyramidTier }> = [
   { match: /winter squash|butternut|acorn squash|spaghetti squash|kabocha|delicata|hubbard/i, tier: 1 },
   { match: /\bpumpkin\b/i, tier: 1 },
   { match: /dry bean|dried bean|kidney bean|pinto|black bean|navy bean|cannellini|cowpea|black[- ]?eyed pea/i, tier: 1 },
-  { match: /lentil|chickpea|garbanzo|soybean|soy bean/i, tier: 1 },
+  { match: /lentil|chickpea|garbanzo|soybean|soy bean|edamame|fava bean|broad bean/i, tier: 1 },
   { match: /\bgarlic\b/i, tier: 1 },
   { match: /\bshallot/i, tier: 1 },
 
@@ -153,7 +153,7 @@ const nameRules: ReadonlyArray<{ match: RegExp; tier: PyramidTier }> = [
   // --- Workhorse: everyday vegetables ---
   { match: /summer squash|yellow squash|pattypan|crookneck|zucchini|courgette/i, tier: 2 },
   { match: /\bsquash\b|\bgourd\b/i, tier: 1 }, // bare "squash" defaults to winter squash
-  { match: /green bean|snap bean|string bean|pole bean|bush bean|wax bean|fava|lima|fresh bean/i, tier: 2 },
+  { match: /green bean|snap bean|string bean|pole bean|bush bean|wax bean|lima|fresh bean/i, tier: 2 },
   { match: /\bbean(s)?\b/i, tier: 2 }, // bare "beans" defaults to fresh
   { match: /tomato/i, tier: 2 },
   { match: /pepper|capsicum|chili|chile|jalape|cayenne|habanero|serrano|poblano/i, tier: 2 },

--- a/apps/grn/src/components/CropPlanner/gardenPyramid.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.ts
@@ -1,0 +1,275 @@
+// The Garden Pyramid: a 5-level way to plan a garden, biggest layer to
+// smallest, inspired by the "feed-yourself first" framing growers find
+// intuitive. Each layer builds on the one below it:
+//
+//   1. Foundation — staples you can live on (calories + storage)
+//   2. Workhorse  — where the garden starts replacing the grocery store
+//   3. Fresh      — grab-and-go greens you eat straight from the bed
+//   4. Flavor     — herbs that make everything taste better
+//   5. Joy        — berries, treats, and experiments
+//
+// `classifyCropToTier` auto-sorts a crop name into one of these layers using
+// the same ordered-regex approach as `cropVisuals.ts`: the most specific
+// patterns win, and ambiguous crops (e.g. plain "beans" or "squash") fall back
+// to the layer most growers mean by default. Anything we can't place returns
+// `null` so the UI can surface it as an experiment for the Joy tier.
+
+import type { CropIconKey } from './cropIconPaths';
+
+export type PyramidTier = 1 | 2 | 3 | 4 | 5;
+
+export interface PyramidSuggestion {
+  name: string;
+  iconKey: CropIconKey;
+}
+
+export interface PyramidTierMeta {
+  level: PyramidTier;
+  /** Stable key used for class names + test ids. */
+  key: string;
+  name: string;
+  /** One-line hook shown on the pyramid band. */
+  tagline: string;
+  /** Longer explanation shown in the tier detail panel. */
+  description: string;
+  /** Accent color for the band + cards (harmonizes with the GRN palette). */
+  accent: string;
+  /** Curated starter crops for growers who want to fill a gap in this layer. */
+  suggestions: PyramidSuggestion[];
+}
+
+// Ordered low → high so the array index doubles as "build from the bottom up".
+export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
+  {
+    level: 1,
+    key: 'foundation',
+    name: 'Foundation',
+    tagline: 'Staples you can feed yourself with',
+    description:
+      'Calorie-dense crops that store for months and form the base of a self-reliant garden. If you grow nothing else, grow these.',
+    accent: '#7a533c',
+    suggestions: [
+      { name: 'Potatoes', iconKey: 'potato' },
+      { name: 'Sweet potatoes', iconKey: 'sweetPotato' },
+      { name: 'Dry beans', iconKey: 'bean' },
+      { name: 'Winter squash', iconKey: 'squash' },
+      { name: 'Onions', iconKey: 'onion' },
+      { name: 'Garlic', iconKey: 'garlic' },
+    ],
+  },
+  {
+    level: 2,
+    key: 'workhorse',
+    name: 'Workhorse',
+    tagline: 'Where the garden replaces the grocery store',
+    description:
+      'High-yield, everyday vegetables that show up in most meals. These are the crops that start shrinking your grocery bill.',
+    accent: '#426b3f',
+    suggestions: [
+      { name: 'Tomatoes', iconKey: 'tomato' },
+      { name: 'Peppers', iconKey: 'pepper' },
+      { name: 'Zucchini', iconKey: 'zucchini' },
+      { name: 'Cabbage', iconKey: 'cabbage' },
+      { name: 'Cucumbers', iconKey: 'cucumber' },
+      { name: 'Carrots', iconKey: 'carrot' },
+    ],
+  },
+  {
+    level: 3,
+    key: 'fresh',
+    name: 'Fresh',
+    tagline: 'Grab-something-fresh-from-the-garden greens',
+    description:
+      'Fast-growing greens you pick minutes before eating. Quick wins that keep you visiting the garden all season.',
+    accent: '#6f8f5f',
+    suggestions: [
+      { name: 'Lettuce', iconKey: 'lettuce' },
+      { name: 'Spinach', iconKey: 'spinach' },
+      { name: 'Kale', iconKey: 'kale' },
+      { name: 'Radishes', iconKey: 'radish' },
+      { name: 'Scallions', iconKey: 'leek' },
+      { name: 'Bok choy', iconKey: 'cabbage' },
+    ],
+  },
+  {
+    level: 4,
+    key: 'flavor',
+    name: 'Flavor',
+    tagline: 'Herbs that make every meal sing',
+    description:
+      'A little space goes a long way. Fresh herbs add the flavor that turns homegrown produce into great cooking.',
+    accent: '#d8a741',
+    suggestions: [
+      { name: 'Cilantro', iconKey: 'cilantro' },
+      { name: 'Dill', iconKey: 'dill' },
+      { name: 'Parsley', iconKey: 'parsley' },
+      { name: 'Fennel', iconKey: 'fennel' },
+      { name: 'Basil', iconKey: 'basil' },
+    ],
+  },
+  {
+    level: 5,
+    key: 'joy',
+    name: 'Joy',
+    tagline: 'Berries, treats, and experiments',
+    description:
+      'The fun layer. Berries, novelties, and the crops you grow just because they make you happy. Pure upside once the rest is in place.',
+    accent: '#a3527e',
+    suggestions: [
+      { name: 'Strawberries', iconKey: 'strawberry' },
+      { name: 'Blueberries', iconKey: 'blueberry' },
+      { name: 'Raspberries', iconKey: 'raspberry' },
+      { name: 'Blackberries', iconKey: 'blackberry' },
+      { name: 'Grapes', iconKey: 'grape' },
+    ],
+  },
+] as const;
+
+export function tierMeta(level: PyramidTier): PyramidTierMeta {
+  // Levels are 1-indexed and the array is ordered, so this is always defined.
+  return PYRAMID_TIERS[level - 1];
+}
+
+// Ordered most-specific → least-specific. First match wins, so disambiguating
+// patterns (e.g. "winter squash", "green onion") must sit above the generic
+// fallbacks ("squash", "onion").
+const nameRules: ReadonlyArray<{ match: RegExp; tier: PyramidTier }> = [
+  // --- Foundation: storage staples & calories ---
+  { match: /sweet potato|\byam\b/i, tier: 1 },
+  { match: /\bpotato(es)?\b/i, tier: 1 },
+  { match: /winter squash|butternut|acorn squash|spaghetti squash|kabocha|delicata|hubbard/i, tier: 1 },
+  { match: /\bpumpkin\b/i, tier: 1 },
+  { match: /dry bean|dried bean|kidney bean|pinto|black bean|navy bean|cannellini|cowpea|black[- ]?eyed pea/i, tier: 1 },
+  { match: /lentil|chickpea|garbanzo|soybean|soy bean/i, tier: 1 },
+  { match: /\bgarlic\b/i, tier: 1 },
+  { match: /\bshallot/i, tier: 1 },
+
+  // --- Fresh: scallions/greens that share a name with foundation alliums ---
+  { match: /green onion|spring onion|scallion|bunching onion/i, tier: 3 },
+
+  // --- Foundation: storage onions (after the green-onion carve-out) ---
+  { match: /\bonion(s)?\b/i, tier: 1 },
+
+  // --- Workhorse: everyday vegetables ---
+  { match: /summer squash|yellow squash|pattypan|crookneck|zucchini|courgette/i, tier: 2 },
+  { match: /\bsquash\b|\bgourd\b/i, tier: 1 }, // bare "squash" defaults to winter squash
+  { match: /green bean|snap bean|string bean|pole bean|bush bean|wax bean|fava|lima|fresh bean/i, tier: 2 },
+  { match: /\bbean(s)?\b/i, tier: 2 }, // bare "beans" defaults to fresh
+  { match: /tomato/i, tier: 2 },
+  { match: /pepper|capsicum|chili|chile|jalape|cayenne|habanero|serrano|poblano/i, tier: 2 },
+  { match: /cucumber|gherkin/i, tier: 2 },
+  { match: /\bcabbage\b/i, tier: 2 },
+  { match: /\bcarrot/i, tier: 2 },
+  { match: /eggplant|aubergine/i, tier: 2 },
+  { match: /broccoli|cauliflower|brussels|kohlrabi/i, tier: 2 },
+  { match: /\bbeet|turnip|parsnip|rutabaga|celeriac/i, tier: 2 },
+  { match: /\bleek\b/i, tier: 2 },
+  { match: /\bcorn\b|maize/i, tier: 2 },
+  { match: /\bokra\b/i, tier: 2 },
+  { match: /\bcelery\b/i, tier: 2 },
+  { match: /\bpea(s)?\b/i, tier: 2 },
+
+  // --- Fresh: fast greens ---
+  { match: /lettuce|salad green|mesclun|mixed green/i, tier: 3 },
+  { match: /spinach/i, tier: 3 },
+  { match: /\bkale\b/i, tier: 3 },
+  { match: /radish/i, tier: 3 },
+  { match: /bok choy|pak choi|pac choi/i, tier: 3 },
+  { match: /arugula|rocket/i, tier: 3 },
+  { match: /chard/i, tier: 3 },
+  { match: /collard/i, tier: 3 },
+  { match: /mustard green|mizuna|tatsoi|cress|microgreen/i, tier: 3 },
+  { match: /endive|escarole|radicchio/i, tier: 3 },
+
+  // --- Flavor: herbs ---
+  { match: /cilantro|coriander/i, tier: 4 },
+  { match: /\bdill\b/i, tier: 4 },
+  { match: /parsley/i, tier: 4 },
+  { match: /\bfennel\b/i, tier: 4 },
+  { match: /basil/i, tier: 4 },
+  { match: /\bmint\b/i, tier: 4 },
+  { match: /rosemary/i, tier: 4 },
+  { match: /thyme/i, tier: 4 },
+  { match: /\bsage\b/i, tier: 4 },
+  { match: /oregano/i, tier: 4 },
+  { match: /chive/i, tier: 4 },
+  { match: /tarragon|marjoram|lemongrass|lemon balm|chamomile|lavender|bay leaf|savory/i, tier: 4 },
+
+  // --- Joy: berries, fruit, treats ---
+  { match: /strawberr/i, tier: 5 },
+  { match: /blueberr/i, tier: 5 },
+  { match: /raspberr/i, tier: 5 },
+  { match: /blackberr/i, tier: 5 },
+  { match: /goji|elderberr|gooseberr|currant|huckleberr|mulberr|cranberr/i, tier: 5 },
+  { match: /\bberry\b|berries/i, tier: 5 },
+  { match: /grape/i, tier: 5 },
+  { match: /watermelon|cantaloupe|honeydew|muskmelon|\bmelon\b/i, tier: 5 },
+  { match: /\bfig\b|apple|pear|peach|nectarine|\bplum\b|cherry|cherries|apricot|pomegranate|persimmon/i, tier: 5 },
+  { match: /lemon|lime|orange|mandarin|tangerine|citrus|grapefruit/i, tier: 5 },
+];
+
+const categoryRules: Record<string, PyramidTier> = {
+  herb: 4,
+  herbs: 4,
+  berry: 5,
+  berries: 5,
+  fruit: 5,
+  fruits: 5,
+  grain: 1,
+  grains: 1,
+  allium: 1,
+  alliums: 1,
+  legume: 1,
+  legumes: 1,
+  root: 2,
+  roots: 2,
+  brassica: 2,
+  brassicas: 2,
+  nightshade: 2,
+  nightshades: 2,
+  cucurbit: 2,
+  cucurbits: 2,
+  vegetable: 2,
+  vegetables: 2,
+};
+
+/**
+ * Sort a crop into a pyramid layer by name first, then category. Returns
+ * `null` when nothing matches so callers can treat it as an unplaced
+ * experiment rather than guessing.
+ */
+export function classifyCropToTier(
+  name?: string | null,
+  category?: string | null
+): PyramidTier | null {
+  if (name) {
+    for (const rule of nameRules) {
+      if (rule.match.test(name)) return rule.tier;
+    }
+  }
+  if (category) {
+    const key = category.trim().toLowerCase();
+    if (key in categoryRules) return categoryRules[key];
+  }
+  return null;
+}
+
+/**
+ * Bucket a list of crops into pyramid layers. Returns a record keyed by tier
+ * level plus an `unsorted` list for crops that couldn't be placed.
+ */
+export function bucketCropsByTier<T extends { cropName: string }>(
+  crops: readonly T[]
+): { tiers: Record<PyramidTier, T[]>; unsorted: T[] } {
+  const tiers: Record<PyramidTier, T[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
+  const unsorted: T[] = [];
+  for (const crop of crops) {
+    const tier = classifyCropToTier(crop.cropName, null);
+    if (tier === null) {
+      unsorted.push(crop);
+    } else {
+      tiers[tier].push(crop);
+    }
+  }
+  return { tiers, unsorted };
+}

--- a/apps/grn/src/components/Planner/GardenPyramid.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.tsx
@@ -1,8 +1,17 @@
 import { PYRAMID_TIERS, type PyramidTier } from '../CropPlanner/gardenPyramid';
+import { CropIcon } from '../CropPlanner/cropIcons';
+import type { CropIconKey } from '../CropPlanner/cropIconPaths';
+
+export interface PyramidCropVisual {
+  id: string;
+  label: string;
+  iconKey: CropIconKey;
+  accent: string;
+}
 
 interface GardenPyramidProps {
-  /** How many of the grower's crops sit in each layer. */
-  counts: Record<PyramidTier, number>;
+  /** The grower's crops in each layer, with the vector icon to render. */
+  cropsByTier: Record<PyramidTier, PyramidCropVisual[]>;
   /** Currently focused layer. */
   activeTier: PyramidTier;
   onSelectTier: (tier: PyramidTier) => void;
@@ -12,27 +21,34 @@ interface GardenPyramidProps {
 // the Foundation, narrowest at Joy. Indexed by level (1-5).
 const BAND_WIDTH: Record<PyramidTier, string> = {
   1: '100%',
-  2: '87%',
-  3: '74%',
-  4: '61%',
-  5: '48%',
+  2: '88%',
+  3: '76%',
+  4: '64%',
+  5: '52%',
 };
 
+// How many crop icons to show inline before collapsing into a "+N" pill.
+const MAX_VISIBLE_ICONS = 6;
+
 /**
- * The Garden Pyramid overview. Renders the five layers top (Joy) to bottom
- * (Foundation) as selectable bands, each showing how many of the grower's
- * crops live in that layer. Selecting a band focuses it in the detail panel.
+ * The Garden Pyramid hero. Renders the five layers top (Joy) to bottom
+ * (Foundation) as selectable bands. Each band shows the vector icons of the
+ * crops the grower has placed there; empty layers preview faded suggestion
+ * icons so the gardener can see what belongs.
  */
-export function GardenPyramid({ counts, activeTier, onSelectTier }: GardenPyramidProps) {
+export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenPyramidProps) {
   // Render narrowest (top) to widest (bottom): Joy → Foundation.
   const topDown = [...PYRAMID_TIERS].reverse();
 
   return (
     <div className="grn-pyramid" role="list" aria-label="Garden pyramid layers">
       {topDown.map((tier) => {
-        const count = counts[tier.level];
+        const crops = cropsByTier[tier.level] ?? [];
+        const count = crops.length;
         const covered = count > 0;
         const isActive = activeTier === tier.level;
+        const visible = crops.slice(0, MAX_VISIBLE_ICONS);
+        const overflow = count - visible.length;
 
         return (
           <button
@@ -58,10 +74,43 @@ export function GardenPyramid({ counts, activeTier, onSelectTier }: GardenPyrami
             <span className="grn-pyramid__level" aria-hidden="true">
               {tier.level}
             </span>
-            <span className="grn-pyramid__band-text">
-              <span className="grn-pyramid__band-name">{tier.name}</span>
-              <span className="grn-pyramid__band-tagline">{tier.tagline}</span>
+
+            <span className="grn-pyramid__band-main">
+              <span className="grn-pyramid__band-text">
+                <span className="grn-pyramid__band-name">{tier.name}</span>
+                <span className="grn-pyramid__band-tagline">{tier.tagline}</span>
+              </span>
+
+              <span className="grn-pyramid__crops" aria-hidden="true">
+                {covered ? (
+                  <>
+                    {visible.map((crop) => (
+                      <span
+                        key={crop.id}
+                        className="grn-pyramid__crop-icon"
+                        title={crop.label}
+                      >
+                        <CropIcon iconKey={crop.iconKey} color={crop.accent} size="1.5rem" />
+                      </span>
+                    ))}
+                    {overflow > 0 ? (
+                      <span className="grn-pyramid__crop-more">+{overflow}</span>
+                    ) : null}
+                  </>
+                ) : (
+                  tier.suggestions.slice(0, 4).map((suggestion) => (
+                    <span
+                      key={suggestion.name}
+                      className="grn-pyramid__crop-icon is-ghost"
+                      title={suggestion.name}
+                    >
+                      <CropIcon iconKey={suggestion.iconKey} size="1.4rem" />
+                    </span>
+                  ))
+                )}
+              </span>
             </span>
+
             <span
               className={`grn-pyramid__band-count ${covered ? 'is-covered' : 'is-empty'}`.trim()}
               data-testid={`pyramid-count-${tier.key}`}

--- a/apps/grn/src/components/Planner/GardenPyramid.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.tsx
@@ -1,0 +1,77 @@
+import { PYRAMID_TIERS, type PyramidTier } from '../CropPlanner/gardenPyramid';
+
+interface GardenPyramidProps {
+  /** How many of the grower's crops sit in each layer. */
+  counts: Record<PyramidTier, number>;
+  /** Currently focused layer. */
+  activeTier: PyramidTier;
+  onSelectTier: (tier: PyramidTier) => void;
+}
+
+// Stepped widths give the stacked bands a clear pyramid silhouette — widest at
+// the Foundation, narrowest at Joy. Indexed by level (1-5).
+const BAND_WIDTH: Record<PyramidTier, string> = {
+  1: '100%',
+  2: '87%',
+  3: '74%',
+  4: '61%',
+  5: '48%',
+};
+
+/**
+ * The Garden Pyramid overview. Renders the five layers top (Joy) to bottom
+ * (Foundation) as selectable bands, each showing how many of the grower's
+ * crops live in that layer. Selecting a band focuses it in the detail panel.
+ */
+export function GardenPyramid({ counts, activeTier, onSelectTier }: GardenPyramidProps) {
+  // Render narrowest (top) to widest (bottom): Joy → Foundation.
+  const topDown = [...PYRAMID_TIERS].reverse();
+
+  return (
+    <div className="grn-pyramid" role="list" aria-label="Garden pyramid layers">
+      {topDown.map((tier) => {
+        const count = counts[tier.level];
+        const covered = count > 0;
+        const isActive = activeTier === tier.level;
+
+        return (
+          <button
+            key={tier.key}
+            type="button"
+            role="listitem"
+            data-testid={`pyramid-band-${tier.key}`}
+            className={`grn-pyramid__band ${isActive ? 'is-active' : ''} ${
+              covered ? 'is-covered' : 'is-empty'
+            }`.trim()}
+            style={{
+              width: BAND_WIDTH[tier.level],
+              ['--tier-accent' as string]: tier.accent,
+            }}
+            aria-pressed={isActive}
+            aria-label={`Layer ${tier.level}, ${tier.name}: ${
+              covered
+                ? `${count} crop${count === 1 ? '' : 's'} planned`
+                : 'nothing here yet'
+            }`}
+            onClick={() => onSelectTier(tier.level)}
+          >
+            <span className="grn-pyramid__level" aria-hidden="true">
+              {tier.level}
+            </span>
+            <span className="grn-pyramid__band-text">
+              <span className="grn-pyramid__band-name">{tier.name}</span>
+              <span className="grn-pyramid__band-tagline">{tier.tagline}</span>
+            </span>
+            <span
+              className={`grn-pyramid__band-count ${covered ? 'is-covered' : 'is-empty'}`.trim()}
+              data-testid={`pyramid-count-${tier.key}`}
+              aria-hidden="true"
+            >
+              {covered ? count : '+'}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/grn/src/components/Planner/PlanScore.tsx
+++ b/apps/grn/src/components/Planner/PlanScore.tsx
@@ -1,0 +1,63 @@
+import type { PlanEvaluation } from '../CropPlanner/gardenPyramid';
+
+interface PlanScoreProps {
+  evaluation: PlanEvaluation;
+}
+
+function scoreColor(score: number): string {
+  if (score >= 75) return '#426b3f'; // moss
+  if (score >= 50) return '#6f8f5f'; // sage
+  if (score >= 25) return '#d8a741'; // gold
+  if (score > 0) return '#b06a3c'; // clay
+  return 'rgba(79, 56, 37, 0.3)';
+}
+
+const RADIUS = 52;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * Radial gauge that visualizes the 0–100 plan score plus its friendly label.
+ * The arc fills proportionally and is colored by score band.
+ */
+export function PlanScore({ evaluation }: PlanScoreProps) {
+  const { score, label } = evaluation;
+  const color = scoreColor(score);
+  const offset = CIRCUMFERENCE * (1 - Math.max(0, Math.min(100, score)) / 100);
+
+  return (
+    <div className="grn-plan-score" role="img" aria-label={`Plan score ${score} out of 100: ${label}`}>
+      <svg viewBox="0 0 120 120" className="grn-plan-score__dial" aria-hidden="true">
+        <circle
+          cx="60"
+          cy="60"
+          r={RADIUS}
+          fill="none"
+          stroke="rgba(79, 56, 37, 0.12)"
+          strokeWidth="10"
+        />
+        <circle
+          cx="60"
+          cy="60"
+          r={RADIUS}
+          fill="none"
+          stroke={color}
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={offset}
+          transform="rotate(-90 60 60)"
+          style={{ transition: 'stroke-dashoffset 500ms ease' }}
+        />
+        <text x="60" y="56" textAnchor="middle" className="grn-plan-score__value" fill={color}>
+          {score}
+        </text>
+        <text x="60" y="74" textAnchor="middle" className="grn-plan-score__max">
+          / 100
+        </text>
+      </svg>
+      <span className="grn-plan-score__label" style={{ color }}>
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { PlannerPage } from './PlannerPage';
+import { getMe, listMyCrops } from '../services/api';
+import type { GrowerCropItem } from '../types/listing';
+import type { UserProfile } from '../types/user';
+
+vi.mock('../services/api', () => ({
+  getMe: vi.fn(),
+  listMyCrops: vi.fn(),
+}));
+
+const mockGetMe = vi.mocked(getMe);
+const mockListMyCrops = vi.mocked(listMyCrops);
+
+const growerProfile = {
+  id: 'grower-1',
+  userType: 'grower',
+} as unknown as UserProfile;
+
+function crop(id: string, cropName: string): GrowerCropItem {
+  return {
+    id,
+    userId: 'grower-1',
+    canonicalId: null,
+    cropName,
+    varietyId: null,
+    status: 'growing',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: null,
+    bedName: null,
+    plantingDate: null,
+    expectedHarvestDate: null,
+    plantCount: null,
+    spacingInches: null,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PlannerPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('PlannerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMe.mockResolvedValue(growerProfile);
+    mockListMyCrops.mockResolvedValue([]);
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders the five pyramid layers', async () => {
+    renderPage();
+    expect(await screen.findByTestId('pyramid-band-foundation')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-workhorse')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-fresh')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-flavor')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-joy')).toBeInTheDocument();
+  });
+
+  it('counts the grower crops that fall into each layer', async () => {
+    mockListMyCrops.mockResolvedValue([
+      crop('c1', 'Potato'),
+      crop('c2', 'Tomato'),
+      crop('c3', 'Cucumber'),
+    ]);
+    renderPage();
+
+    // Foundation has 1 (potato), Workhorse has 2 (tomato, cucumber).
+    await waitFor(() =>
+      expect(screen.getByTestId('pyramid-count-foundation')).toHaveTextContent('1')
+    );
+    expect(screen.getByTestId('pyramid-count-workhorse')).toHaveTextContent('2');
+    // The Fresh layer has nothing, so it shows the "+" add affordance.
+    expect(screen.getByTestId('pyramid-count-fresh')).toHaveTextContent('+');
+
+    expect(screen.getByText(/of 5 layers started/i)).toHaveTextContent(
+      '2 of 5 layers started'
+    );
+  });
+
+  it('shows the selected layer detail and switches when another band is clicked', async () => {
+    mockListMyCrops.mockResolvedValue([crop('c1', 'Basil')]);
+    const user = userEvent.setup();
+    renderPage();
+
+    // Default focus is the Foundation layer.
+    const detail = await screen.findByRole('heading', { name: 'Foundation' });
+    expect(detail).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('pyramid-band-flavor'));
+
+    expect(await screen.findByRole('heading', { name: 'Flavor' })).toBeInTheDocument();
+    // The grower's basil should appear in the Flavor layer's crop list.
+    expect(screen.getByText('Basil')).toBeInTheDocument();
+  });
+
+  it('surfaces crops it cannot place in a "Not yet placed" section', async () => {
+    mockListMyCrops.mockResolvedValue([crop('c1', 'Dragonfruit cactus')]);
+    renderPage();
+
+    expect(await screen.findByText(/Not yet placed/i)).toBeInTheDocument();
+    expect(screen.getByText('Dragonfruit cactus')).toBeInTheDocument();
+  });
+
+  it('redirects non-growers home', async () => {
+    mockGetMe.mockResolvedValue({ id: 'g1', userType: 'gatherer' } as unknown as UserProfile);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.queryByTestId('pyramid-band-foundation')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -21,7 +21,7 @@ const growerProfile = {
   userType: 'grower',
 } as unknown as UserProfile;
 
-function crop(id: string, cropName: string): GrowerCropItem {
+function crop(id: string, cropName: string, pyramidTier?: number | null): GrowerCropItem {
   return {
     id,
     userId: 'grower-1',
@@ -40,6 +40,7 @@ function crop(id: string, cropName: string): GrowerCropItem {
     expectedHarvestDate: null,
     plantCount: null,
     spacingInches: null,
+    pyramidTier: pyramidTier ?? null,
     createdAt: '2026-01-01',
     updatedAt: '2026-01-01',
   };
@@ -104,6 +105,25 @@ describe('PlannerPage', () => {
 
     expect(screen.getByText(/of 5 layers started/i)).toHaveTextContent(
       '2 of 5 layers started'
+    );
+  });
+
+  it('sorts a crop by its catalog pyramidTier even when the name says otherwise', async () => {
+    // "Tomato" classifies to Workhorse by name, but the catalog tier (Joy) wins.
+    mockListMyCrops.mockResolvedValue([crop('c1', 'Tomato', 5)]);
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pyramid-count-joy')).toHaveTextContent('1')
+    );
+    expect(screen.getByTestId('pyramid-count-workhorse')).toHaveTextContent('+');
+  });
+
+  it('shows a plan score gauge', async () => {
+    mockListMyCrops.mockResolvedValue([crop('c1', 'Potato'), crop('c2', 'Tomato')]);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole('img', { name: /plan score \d+ out of 100/i })).toBeInTheDocument()
     );
   });
 

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -70,7 +70,7 @@ export function PlannerPage() {
   if (isLoadingProfile) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Grower tools" title="Garden pyramid" />
+        <SectionHeading title="Garden pyramid" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading your plan…</p>
@@ -88,9 +88,8 @@ export function PlannerPage() {
   return (
     <section className="grn-section grn-planner">
       <SectionHeading
-        eyebrow="Grower tools"
         title="Garden pyramid"
-        body="Plan your garden in five layers — biggest to smallest. Build from the Foundation up: staples first, then everyday workhorses, fresh greens, flavor, and finally the joy crops."
+        body="Your grower planner, organized in five layers — biggest to smallest. Build from the Foundation up: staples first, then everyday workhorses, fresh greens, flavor, and finally the joy crops."
       />
 
       <Card padding="6">

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -4,11 +4,14 @@ import { useQuery } from '@tanstack/react-query';
 import { Button, Card, Panel, SectionHeading } from '@olivias/ui';
 import { getMe, listMyCrops } from '../services/api';
 import { PlantLoader } from '../components/branding/PlantLoader';
-import { GardenPyramid } from '../components/Planner/GardenPyramid';
+import { GardenPyramid, type PyramidCropVisual } from '../components/Planner/GardenPyramid';
+import { PlanScore } from '../components/Planner/PlanScore';
 import { CropIcon } from '../components/CropPlanner/cropIcons';
 import { visualForCrop } from '../components/CropPlanner/cropVisuals';
 import {
   bucketCropsByTier,
+  evaluatePlan,
+  planGuidance,
   tierMeta,
   type PyramidTier,
 } from '../components/CropPlanner/gardenPyramid';
@@ -50,7 +53,19 @@ export function PlannerPage() {
     [tiers]
   );
 
-  const coveredCount = ALL_TIERS.filter((level) => counts[level] > 0).length;
+  const cropsByTier = useMemo(
+    () =>
+      ALL_TIERS.reduce(
+        (acc, level) => {
+          acc[level] = tiers[level].map(toCropVisual);
+          return acc;
+        },
+        {} as Record<PyramidTier, PyramidCropVisual[]>
+      ),
+    [tiers]
+  );
+
+  const evaluation = useMemo(() => evaluatePlan(counts), [counts]);
 
   if (isLoadingProfile) {
     return (
@@ -75,36 +90,35 @@ export function PlannerPage() {
       <SectionHeading
         eyebrow="Grower tools"
         title="Garden pyramid"
-        body="Plan your garden in five layers — biggest to smallest. Build from the Foundation up: staples first, then the everyday workhorses, fresh greens, flavor, and finally the joy crops."
+        body="Plan your garden in five layers — biggest to smallest. Build from the Foundation up: staples first, then everyday workhorses, fresh greens, flavor, and finally the joy crops."
       />
 
       <Card padding="6">
-        <div className="grn-planner__progress">
-          <div>
+        <div className="grn-planner__health">
+          <PlanScore evaluation={evaluation} />
+          <div className="grn-planner__health-body">
             <p className="grn-planner__progress-stat">
-              <strong>{coveredCount}</strong> of 5 layers started
+              <strong>{evaluation.coveredCount}</strong> of 5 layers started
             </p>
-            <p className="grn-planner__progress-hint">
-              {coveredCount === 0
-                ? 'Your pyramid is empty — start at the Foundation with a staple crop.'
-                : coveredCount === 5
-                  ? 'Every layer has a crop — a wonderfully balanced garden plan!'
-                  : 'Keep building. A strong garden grows from the bottom up.'}
-            </p>
-          </div>
-          <div className="grn-planner__progress-track" aria-hidden="true">
-            {ALL_TIERS.map((level) => (
-              <span
-                key={level}
-                className={`grn-planner__progress-pip ${counts[level] > 0 ? 'is-on' : ''}`.trim()}
-                style={{ background: counts[level] > 0 ? tierMeta(level).accent : undefined }}
-              />
-            ))}
+            <div className="grn-planner__progress-track" aria-hidden="true">
+              {ALL_TIERS.map((level) => (
+                <span
+                  key={level}
+                  className={`grn-planner__progress-pip ${counts[level] > 0 ? 'is-on' : ''}`.trim()}
+                  style={{ background: counts[level] > 0 ? tierMeta(level).accent : undefined }}
+                  title={`${tierMeta(level).name}: ${counts[level]} crop${counts[level] === 1 ? '' : 's'}`}
+                />
+              ))}
+            </div>
+            <p className="grn-planner__guidance">{planGuidance(evaluation)}</p>
           </div>
         </div>
+      </Card>
 
+      <Card padding="6">
+        <h3 className="grn-planner__pyramid-title">Your garden pyramid</h3>
         <GardenPyramid
-          counts={counts}
+          cropsByTier={cropsByTier}
           activeTier={activeTier}
           onSelectTier={setActiveTier}
         />
@@ -123,8 +137,8 @@ export function PlannerPage() {
           <div className="grn-planner__unsorted">
             <h3 className="grn-planner__detail-name">Not yet placed</h3>
             <p className="grn-planner__detail-desc">
-              We couldn&apos;t auto-sort these into a layer — they may be perfect
-              experiments for your Joy tier.
+              We couldn&apos;t sort these into a layer — they may be ornamentals or
+              experiments outside the food pyramid.
             </p>
             <ul className="grn-planner__crop-list">
               {unsorted.map((crop) => (
@@ -136,6 +150,16 @@ export function PlannerPage() {
       ) : null}
     </section>
   );
+}
+
+function toCropVisual(crop: GrowerCropItem): PyramidCropVisual {
+  const visual = visualForCrop(crop.cropName, null);
+  return {
+    id: crop.id,
+    label: crop.nickname || crop.cropName,
+    iconKey: visual.iconKey,
+    accent: visual.accent,
+  };
 }
 
 interface TierDetailProps {

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Card, Panel, SectionHeading } from '@olivias/ui';
+import { getMe, listMyCrops } from '../services/api';
+import { PlantLoader } from '../components/branding/PlantLoader';
+import { GardenPyramid } from '../components/Planner/GardenPyramid';
+import { CropIcon } from '../components/CropPlanner/cropIcons';
+import { visualForCrop } from '../components/CropPlanner/cropVisuals';
+import {
+  bucketCropsByTier,
+  tierMeta,
+  type PyramidTier,
+} from '../components/CropPlanner/gardenPyramid';
+import type { GrowerCropItem } from '../types/listing';
+
+const ALL_TIERS: PyramidTier[] = [1, 2, 3, 4, 5];
+
+export function PlannerPage() {
+  const navigate = useNavigate();
+  const [activeTier, setActiveTier] = useState<PyramidTier>(1);
+
+  const { data: profile, isLoading: isLoadingProfile } = useQuery({
+    queryKey: ['userProfile'],
+    queryFn: getMe,
+    staleTime: 5 * 60 * 1000,
+    retry: 2,
+  });
+
+  const { data: myCrops } = useQuery({
+    queryKey: ['myCrops'],
+    queryFn: listMyCrops,
+    enabled: profile?.userType === 'grower',
+  });
+
+  const { tiers, unsorted } = useMemo(
+    () => bucketCropsByTier(myCrops ?? []),
+    [myCrops]
+  );
+
+  const counts = useMemo(
+    () =>
+      ALL_TIERS.reduce(
+        (acc, level) => {
+          acc[level] = tiers[level].length;
+          return acc;
+        },
+        {} as Record<PyramidTier, number>
+      ),
+    [tiers]
+  );
+
+  const coveredCount = ALL_TIERS.filter((level) => counts[level] > 0).length;
+
+  if (isLoadingProfile) {
+    return (
+      <section className="grn-section">
+        <SectionHeading eyebrow="Grower tools" title="Garden pyramid" />
+        <Panel className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Loading your plan…</p>
+        </Panel>
+      </section>
+    );
+  }
+
+  if (!profile || profile.userType !== 'grower') {
+    return <Navigate to="/" replace />;
+  }
+
+  const activeCrops = tiers[activeTier];
+
+  return (
+    <section className="grn-section grn-planner">
+      <SectionHeading
+        eyebrow="Grower tools"
+        title="Garden pyramid"
+        body="Plan your garden in five layers — biggest to smallest. Build from the Foundation up: staples first, then the everyday workhorses, fresh greens, flavor, and finally the joy crops."
+      />
+
+      <Card padding="6">
+        <div className="grn-planner__progress">
+          <div>
+            <p className="grn-planner__progress-stat">
+              <strong>{coveredCount}</strong> of 5 layers started
+            </p>
+            <p className="grn-planner__progress-hint">
+              {coveredCount === 0
+                ? 'Your pyramid is empty — start at the Foundation with a staple crop.'
+                : coveredCount === 5
+                  ? 'Every layer has a crop — a wonderfully balanced garden plan!'
+                  : 'Keep building. A strong garden grows from the bottom up.'}
+            </p>
+          </div>
+          <div className="grn-planner__progress-track" aria-hidden="true">
+            {ALL_TIERS.map((level) => (
+              <span
+                key={level}
+                className={`grn-planner__progress-pip ${counts[level] > 0 ? 'is-on' : ''}`.trim()}
+                style={{ background: counts[level] > 0 ? tierMeta(level).accent : undefined }}
+              />
+            ))}
+          </div>
+        </div>
+
+        <GardenPyramid
+          counts={counts}
+          activeTier={activeTier}
+          onSelectTier={setActiveTier}
+        />
+      </Card>
+
+      <Card padding="6">
+        <TierDetail
+          tier={activeTier}
+          crops={activeCrops}
+          onAddCrop={() => navigate('/crops/new')}
+        />
+      </Card>
+
+      {unsorted.length > 0 ? (
+        <Card padding="6">
+          <div className="grn-planner__unsorted">
+            <h3 className="grn-planner__detail-name">Not yet placed</h3>
+            <p className="grn-planner__detail-desc">
+              We couldn&apos;t auto-sort these into a layer — they may be perfect
+              experiments for your Joy tier.
+            </p>
+            <ul className="grn-planner__crop-list">
+              {unsorted.map((crop) => (
+                <CropChip key={crop.id} crop={crop} />
+              ))}
+            </ul>
+          </div>
+        </Card>
+      ) : null}
+    </section>
+  );
+}
+
+interface TierDetailProps {
+  tier: PyramidTier;
+  crops: GrowerCropItem[];
+  onAddCrop: () => void;
+}
+
+function TierDetail({ tier, crops, onAddCrop }: TierDetailProps) {
+  const meta = tierMeta(tier);
+  const plantedNames = useMemo(
+    () => new Set(crops.map((c) => c.cropName.trim().toLowerCase())),
+    [crops]
+  );
+  const openSuggestions = meta.suggestions.filter(
+    (s) => !plantedNames.has(s.name.trim().toLowerCase())
+  );
+
+  return (
+    <div className="grn-planner__detail">
+      <header
+        className="grn-planner__detail-head"
+        style={{ ['--tier-accent' as string]: meta.accent }}
+      >
+        <span className="grn-planner__detail-level" aria-hidden="true">
+          {meta.level}
+        </span>
+        <div>
+          <h3 className="grn-planner__detail-name">{meta.name}</h3>
+          <p className="grn-planner__detail-tagline">{meta.tagline}</p>
+        </div>
+      </header>
+
+      <p className="grn-planner__detail-desc">{meta.description}</p>
+
+      <div className="grn-planner__detail-section">
+        <h4 className="grn-planner__detail-subhead">
+          In your garden ({crops.length})
+        </h4>
+        {crops.length > 0 ? (
+          <ul className="grn-planner__crop-list">
+            {crops.map((crop) => (
+              <CropChip key={crop.id} crop={crop} />
+            ))}
+          </ul>
+        ) : (
+          <p className="grn-planner__detail-empty">
+            Nothing in this layer yet.
+          </p>
+        )}
+      </div>
+
+      {openSuggestions.length > 0 ? (
+        <div className="grn-planner__detail-section">
+          <h4 className="grn-planner__detail-subhead">Ideas to fill this layer</h4>
+          <ul className="grn-planner__suggestions">
+            {openSuggestions.map((suggestion) => (
+              <li key={suggestion.name}>
+                <span className="grn-planner__suggestion" style={{ color: meta.accent }}>
+                  <CropIcon iconKey={suggestion.iconKey} color={meta.accent} size="1.1rem" />
+                  {suggestion.name}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="grn-planner__detail-actions">
+        <Button variant="primary" size="sm" onClick={onAddCrop}>
+          + Add a crop
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CropChip({ crop }: { crop: GrowerCropItem }) {
+  const visual = visualForCrop(crop.cropName, null);
+  return (
+    <li className="grn-planner__crop-chip" style={{ borderColor: `${visual.accent}55` }}>
+      <CropIcon iconKey={visual.iconKey} color={visual.accent} size="1.2rem" />
+      <span>{crop.nickname || crop.cropName}</span>
+    </li>
+  );
+}
+
+export default PlannerPage;

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -224,6 +224,7 @@ interface RawCatalogCrop {
   scientific_name: string | null;
   category: string | null;
   description: string | null;
+  pyramid_tier?: number | null;
 }
 
 interface RawCatalogVariety {
@@ -252,6 +253,7 @@ interface RawGrowerCropItem {
   expected_harvest_date: string | null;
   plant_count: number | null;
   spacing_inches: number | null;
+  pyramid_tier?: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -463,6 +465,7 @@ function mapCatalogCrop(raw: RawCatalogCrop): CatalogCrop {
     scientificName: raw.scientific_name,
     category: raw.category,
     description: raw.description,
+    pyramidTier: raw.pyramid_tier ?? null,
   };
 }
 
@@ -495,6 +498,7 @@ function mapGrowerCropItem(raw: RawGrowerCropItem): GrowerCropItem {
     expectedHarvestDate: raw.expected_harvest_date ?? null,
     plantCount: raw.plant_count ?? null,
     spacingInches: raw.spacing_inches ?? null,
+    pyramidTier: raw.pyramid_tier ?? null,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
   };

--- a/apps/grn/src/shell/AppShell.tsx
+++ b/apps/grn/src/shell/AppShell.tsx
@@ -54,6 +54,19 @@ const growerNavItems: NavItem[] = [
     ),
   },
   {
+    id: 'planner',
+    path: '/planner',
+    label: 'Planner',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 3 2 20h20L12 3Zm0 4.6 2.1 3.6H9.9L12 7.6ZM8.7 13.2h6.6l1.5 2.6H7.2l1.5-2.6ZM5.6 18.6 6.6 17h10.8l1 1.6H5.6Z"
+          fill="currentColor"
+        />
+      </svg>
+    ),
+  },
+  {
     id: 'recommendations',
     path: '/recommendations',
     label: 'Recommendations',

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -17,6 +17,9 @@ const RecommendationsPage = lazy(() =>
 const NewCropPage = lazy(() =>
   import('../pages/NewCropPage').then((m) => ({ default: m.NewCropPage }))
 );
+const PlannerPage = lazy(() =>
+  import('../pages/PlannerPage').then((m) => ({ default: m.PlannerPage }))
+);
 const GardenDesignerPage = lazy(() =>
   import('../pages/GardenDesignerPage').then((m) => ({ default: m.GardenDesignerPage }))
 );
@@ -60,6 +63,7 @@ export function AuthenticatedRoot() {
               <Route path="/" element={<DashboardPage />} />
               <Route path="/crops" element={<CropsPage />} />
               <Route path="/crops/new" element={<NewCropPage />} />
+              <Route path="/planner" element={<PlannerPage />} />
               <Route path="/recommendations" element={<RecommendationsPage />} />
               <Route path="/garden" element={<GardenDesignerPage />} />
               <Route path="/listings" element={<ListingsPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1610,6 +1610,260 @@ body {
 }
 
 /* ==========================================================================
+   Garden Pyramid planner
+   ========================================================================== */
+
+.grn-planner__progress {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.grn-planner__progress-stat {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--og-color-soil);
+}
+
+.grn-planner__progress-stat strong {
+  font-family: var(--og-font-display);
+  font-size: 1.4rem;
+  color: var(--og-color-moss);
+}
+
+.grn-planner__progress-hint {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.7);
+  max-width: 30rem;
+}
+
+.grn-planner__progress-track {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.grn-planner__progress-pip {
+  width: 1.4rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: rgba(79, 56, 37, 0.14);
+}
+
+/* ── The pyramid ─────────────────────────────────────────────────── */
+
+.grn-pyramid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.grn-pyramid__band {
+  --tier-accent: var(--og-color-moss);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3.4rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--og-radius-md);
+  background: linear-gradient(135deg, var(--tier-accent), color-mix(in srgb, var(--tier-accent) 78%, #000));
+  color: #fff7ec;
+  cursor: pointer;
+  text-align: left;
+  box-shadow: 0 4px 12px rgba(38, 23, 15, 0.12);
+  transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
+}
+
+.grn-pyramid__band.is-empty {
+  background: rgba(79, 56, 37, 0.08);
+  color: rgba(79, 56, 37, 0.7);
+  box-shadow: none;
+  border-color: rgba(79, 56, 37, 0.16);
+  border-style: dashed;
+}
+
+.grn-pyramid__band:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.04);
+  box-shadow: 0 8px 18px rgba(38, 23, 15, 0.18);
+}
+
+.grn-pyramid__band.is-active {
+  outline: 3px solid var(--tier-accent);
+  outline-offset: 2px;
+}
+
+.grn-pyramid__band:focus-visible {
+  outline: 3px solid var(--og-color-soil);
+  outline-offset: 2px;
+}
+
+.grn-pyramid__level {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  font-family: var(--og-font-display);
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.grn-pyramid__band.is-empty .grn-pyramid__level {
+  background: rgba(79, 56, 37, 0.12);
+}
+
+.grn-pyramid__band-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.grn-pyramid__band-name {
+  font-family: var(--og-font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.grn-pyramid__band-tagline {
+  font-size: 0.78rem;
+  opacity: 0.85;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.grn-pyramid__band-count {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  min-width: 1.9rem;
+  height: 1.9rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.grn-pyramid__band-count.is-empty {
+  background: rgba(79, 56, 37, 0.12);
+  color: rgba(79, 56, 37, 0.7);
+}
+
+/* ── Tier detail panel ───────────────────────────────────────────── */
+
+.grn-planner__detail {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.grn-planner__detail-head {
+  --tier-accent: var(--og-color-moss);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.grn-planner__detail-level {
+  display: grid;
+  place-items: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  background: var(--tier-accent);
+  color: #fff7ec;
+  font-family: var(--og-font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.grn-planner__detail-name {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.3rem;
+  color: var(--og-color-soil);
+}
+
+.grn-planner__detail-tagline {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(79, 56, 37, 0.75);
+}
+
+.grn-planner__detail-desc {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.85);
+  max-width: 44rem;
+}
+
+.grn-planner__detail-section {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.grn-planner__detail-subhead {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.grn-planner__detail-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(79, 56, 37, 0.55);
+  font-style: italic;
+}
+
+.grn-planner__crop-list,
+.grn-planner__suggestions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.grn-planner__crop-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid rgba(79, 56, 37, 0.2);
+  border-radius: var(--og-radius-pill);
+  background: var(--og-color-paper);
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+}
+
+.grn-planner__suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px dashed currentColor;
+  border-radius: var(--og-radius-pill);
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.grn-planner__detail-actions {
+  margin-top: 0.25rem;
+}
+
+/* ==========================================================================
    Garden Designer
    ========================================================================== */
 

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1613,13 +1613,64 @@ body {
    Garden Pyramid planner
    ========================================================================== */
 
-.grn-planner__progress {
+/* ── Plan health (score gauge + guidance) ────────────────────────── */
+
+.grn-planner__health {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1.5rem;
   flex-wrap: wrap;
-  gap: 0.75rem 1.5rem;
-  margin-bottom: 1.5rem;
+}
+
+.grn-planner__health-body {
+  display: grid;
+  gap: 0.6rem;
+  flex: 1;
+  min-width: 14rem;
+}
+
+.grn-plan-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.grn-plan-score__dial {
+  width: 8.5rem;
+  height: 8.5rem;
+}
+
+.grn-plan-score__value {
+  font-family: var(--og-font-display);
+  font-weight: 700;
+  font-size: 2.4rem;
+}
+
+.grn-plan-score__max {
+  font-size: 0.85rem;
+  fill: rgba(79, 56, 37, 0.55);
+}
+
+.grn-plan-score__label {
+  font-family: var(--og-font-display);
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.grn-planner__guidance {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.85);
+  max-width: 34rem;
+}
+
+.grn-planner__pyramid-title {
+  margin: 0 0 1rem;
+  font-family: var(--og-font-display);
+  font-size: 1.2rem;
+  color: var(--og-color-soil);
+  text-align: center;
 }
 
 .grn-planner__progress-stat {
@@ -1632,13 +1683,6 @@ body {
   font-family: var(--og-font-display);
   font-size: 1.4rem;
   color: var(--og-color-moss);
-}
-
-.grn-planner__progress-hint {
-  margin: 0.15rem 0 0;
-  font-size: 0.85rem;
-  color: rgba(79, 56, 37, 0.7);
-  max-width: 30rem;
 }
 
 .grn-planner__progress-track {
@@ -1667,8 +1711,8 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  min-height: 3.4rem;
-  padding: 0.5rem 1rem;
+  min-height: 4.1rem;
+  padding: 0.55rem 1rem;
   border: 1px solid transparent;
   border-radius: var(--og-radius-md);
   background: linear-gradient(135deg, var(--tier-accent), color-mix(in srgb, var(--tier-accent) 78%, #000));
@@ -1720,11 +1764,53 @@ body {
   background: rgba(79, 56, 37, 0.12);
 }
 
+.grn-pyramid__band-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+  flex: 1;
+}
+
 .grn-pyramid__band-text {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  flex: 1;
+}
+
+.grn-pyramid__crops {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.grn-pyramid__crop-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1px 3px rgba(38, 23, 15, 0.18);
+}
+
+.grn-pyramid__crop-icon.is-ghost {
+  background: rgba(79, 56, 37, 0.06);
+  box-shadow: none;
+  opacity: 0.5;
+}
+
+.grn-pyramid__crop-more {
+  display: inline-flex;
+  align-items: center;
+  height: 1.85rem;
+  padding: 0 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+  font-size: 0.8rem;
+  font-weight: 700;
 }
 
 .grn-pyramid__band-name {

--- a/apps/grn/src/types/listing.ts
+++ b/apps/grn/src/types/listing.ts
@@ -5,6 +5,8 @@ export interface CatalogCrop {
   scientificName: string | null;
   category: string | null;
   description: string | null;
+  /** Garden pyramid layer 1=Foundation..5=Joy; null when not part of the food pyramid. */
+  pyramidTier?: number | null;
 }
 
 export interface CatalogVariety {
@@ -33,6 +35,8 @@ export interface GrowerCropItem {
   expectedHarvestDate: string | null;
   plantCount: number | null;
   spacingInches: number | null;
+  /** Garden pyramid layer resolved from the linked catalog crop; null when unlinked or not in the pyramid. */
+  pyramidTier?: number | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/postman/collections/E2E - Search veggie and add to garden/Step 1 - List Catalog Crops.request.yaml
+++ b/postman/collections/E2E - Search veggie and add to garden/Step 1 - List Catalog Crops.request.yaml
@@ -29,7 +29,21 @@ scripts:
           const crops = jsonData.crops || jsonData.data || jsonData.items || jsonData;
           pm.expect(Array.isArray(crops)).to.be.true;
       });
-      
+
+      pm.test("Catalog crops expose a valid pyramid_tier", function () {
+          const jsonData = pm.response.json();
+          const crops = jsonData.crops || jsonData.data || jsonData.items || jsonData;
+          pm.expect(crops.length, "catalog should not be empty").to.be.above(0);
+          crops.forEach((crop) => {
+              pm.expect(crop, "each catalog crop carries pyramid_tier").to.have.property("pyramid_tier");
+              const tier = crop.pyramid_tier;
+              if (tier !== null) {
+                  pm.expect(tier, "pyramid_tier is an integer 1-5 when set").to.be.a("number");
+                  pm.expect(tier).to.be.within(1, 5);
+              }
+          });
+      });
+
       pm.test("Find and capture matching crop", function () {
           const jsonData = pm.response.json();
           const crops = jsonData.crops || jsonData.data || jsonData.items || jsonData;
@@ -52,7 +66,11 @@ scripts:
           
           pm.collectionVariables.set("catalogCropId", cropId);
           pm.collectionVariables.set("catalogCropName", matchingCrop.common_name || "Unknown Crop");
-          
+          // Capture the catalog tier so later steps can assert it propagates to
+          // the grower crop. Stored as a string ("" when null/absent).
+          const tier = matchingCrop.pyramid_tier;
+          pm.collectionVariables.set("catalogCropPyramidTier", tier === null || tier === undefined ? "" : String(tier));
+
           console.log("Captured catalogCropId: " + cropId);
           console.log("Captured catalogCropName: " + matchingCrop.common_name);
       });

--- a/postman/collections/E2E - Search veggie and add to garden/Step 4a - Verify Crop in List.request.yaml
+++ b/postman/collections/E2E - Search veggie and add to garden/Step 4a - Verify Crop in List.request.yaml
@@ -46,3 +46,21 @@ scripts:
           pm.expect(foundCrop.status).to.eql("growing");
           console.log("Verified: Crop " + createdCropId + " found in user's crop list");
       });
+
+      pm.test("Grower crop carries the catalog pyramid_tier", function () {
+          const jsonData = pm.response.json();
+          const crops = jsonData.crops || jsonData.data || jsonData.items || jsonData;
+          const createdCropId = pm.collectionVariables.get("createdCropId");
+          const foundCrop = crops.find(crop => crop.id === createdCropId);
+
+          pm.expect(foundCrop, "Created crop should be in the user's crop list").to.not.be.undefined;
+          pm.expect(foundCrop, "grower crop carries pyramid_tier from its catalog crop").to.have.property("pyramid_tier");
+
+          // The crop is linked to a catalog crop, so its tier must match the one
+          // captured from /catalog/crops in Step 1 (proves the join propagates).
+          const expectedTier = pm.collectionVariables.get("catalogCropPyramidTier");
+          const actualTier = foundCrop.pyramid_tier === null || foundCrop.pyramid_tier === undefined
+              ? ""
+              : String(foundCrop.pyramid_tier);
+          pm.expect(actualTier, "grower crop tier should match its catalog crop tier").to.eql(expectedTier);
+      });

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -286,6 +286,9 @@ create table if not exists crops (
   scientific_name text,
   category text,
   description text,
+  -- Garden pyramid layer: 1=Foundation, 2=Workhorse, 3=Fresh, 4=Flavor,
+  -- 5=Joy. NULL = not part of the food pyramid (e.g. ornamentals).
+  pyramid_tier smallint check (pyramid_tier is null or pyramid_tier between 1 and 5),
   source_provider text not null default 'internal_seed',
   source_record_id text,
   source_url text,
@@ -299,6 +302,7 @@ create table if not exists crops (
 );
 
 create index if not exists idx_crops_source_provider on crops(source_provider);
+create index if not exists idx_crops_pyramid_tier on crops(pyramid_tier);
 create unique index if not exists idx_crops_source_record
   on crops(source_provider, source_record_id)
   where source_record_id is not null;

--- a/services/grn-api/db/migrations/0033_crops_pyramid_tier.sql
+++ b/services/grn-api/db/migrations/0033_crops_pyramid_tier.sql
@@ -1,0 +1,21 @@
+-- Migration: add a "garden pyramid" tier to catalog crops so the planner can
+-- sort crops into layers objectively from the database instead of guessing from
+-- the crop name at runtime.
+--
+--   1 = Foundation (calorie/storage staples)
+--   2 = Workhorse  (everyday grocery-replacing vegetables)
+--   3 = Fresh      (fast grab-and-go greens)
+--   4 = Flavor     (culinary herbs)
+--   5 = Joy        (berries, fruit, treats, experiments)
+--
+-- NULL means the crop is not part of the food pyramid (e.g. ornamental
+-- flowers). The companion migration 0034 assigns tiers to the seeded catalog.
+
+alter table crops
+  add column if not exists pyramid_tier smallint
+    check (pyramid_tier is null or pyramid_tier between 1 and 5);
+
+comment on column crops.pyramid_tier is
+  'Garden pyramid layer: 1=Foundation, 2=Workhorse, 3=Fresh, 4=Flavor, 5=Joy. NULL = not part of the food pyramid (e.g. ornamentals).';
+
+create index if not exists idx_crops_pyramid_tier on crops(pyramid_tier);

--- a/services/grn-api/db/migrations/0034_seed_pyramid_tiers.sql
+++ b/services/grn-api/db/migrations/0034_seed_pyramid_tiers.sql
@@ -1,0 +1,40 @@
+-- Migration: assign garden-pyramid tiers to the seeded catalog crops.
+--
+-- Idempotent: each statement sets pyramid_tier for a fixed set of slugs, so
+-- re-running simply reasserts the curated tiers. Ornamental flowers are left
+-- with a NULL tier on purpose — they are not part of the food pyramid.
+
+-- Tier 1 — Foundation: calorie-dense, storable staples.
+update crops set pyramid_tier = 1 where slug in (
+  'potato', 'sweet-potato', 'onion', 'garlic', 'shallot',
+  'winter-squash', 'butternut-squash', 'pumpkin'
+);
+
+-- Tier 2 — Workhorse: high-yield, everyday grocery-replacing vegetables.
+update crops set pyramid_tier = 2 where slug in (
+  'tomato', 'carrot', 'cucumber', 'bell-pepper', 'hot-pepper',
+  'broccoli', 'cauliflower', 'cabbage', 'brussels-sprouts', 'kohlrabi',
+  'turnip', 'beet', 'zucchini', 'summer-squash', 'eggplant',
+  'green-bean', 'snap-pea', 'shelling-pea', 'sweet-corn', 'celery',
+  'okra', 'leek', 'asparagus'
+);
+
+-- Tier 3 — Fresh: fast-growing, grab-and-go greens.
+update crops set pyramid_tier = 3 where slug in (
+  'lettuce', 'kale', 'bok-choy', 'radish', 'arugula', 'spinach', 'swiss-chard'
+);
+
+-- Tier 4 — Flavor: culinary herbs.
+update crops set pyramid_tier = 4 where slug in (
+  'basil', 'parsley', 'cilantro', 'mint', 'rosemary', 'thyme', 'sage',
+  'oregano', 'chives', 'dill', 'tarragon', 'lemon-balm', 'chamomile'
+);
+
+-- Tier 5 — Joy: berries, fruit, and specialty/perennial treats.
+update crops set pyramid_tier = 5 where slug in (
+  'strawberry', 'blueberry', 'raspberry', 'blackberry', 'apple', 'pear',
+  'peach', 'nectarine', 'plum', 'cherry', 'apricot', 'fig', 'grape',
+  'watermelon', 'cantaloupe', 'honeydew', 'lemon', 'lime', 'orange',
+  'grapefruit', 'mandarin', 'avocado', 'pomegranate', 'persimmon',
+  'mulberry', 'elderberry', 'currant', 'artichoke', 'rhubarb'
+);

--- a/services/grn-api/db/migrations/0035_seed_pyramid_gap_crops.sql
+++ b/services/grn-api/db/migrations/0035_seed_pyramid_gap_crops.sql
@@ -1,0 +1,34 @@
+-- Migration: seed the crops the garden-pyramid framing was missing, with their
+-- tiers assigned inline. These close gaps in the lower (most important) layers
+-- — especially crops the pyramid philosophy calls out by name (dry beans,
+-- scallions, fennel) that the original catalog lacked.
+--
+-- Idempotent: upserts on slug and reasserts the curated tier on conflict.
+
+insert into crops (slug, common_name, scientific_name, category, pyramid_tier, source_provider, attribution_text)
+values
+  -- Tier 1 — Foundation: storage legumes (protein + calories you can keep).
+  ('dry-bean',        'Dry Bean',        'Phaseolus vulgaris',              'vegetable', 1, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('lentil',          'Lentil',          'Lens culinaris',                  'vegetable', 1, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('chickpea',        'Chickpea',        'Cicer arietinum',                 'vegetable', 1, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('fava-bean',       'Fava Bean',       'Vicia faba',                      'vegetable', 1, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('edamame',         'Edamame',         'Glycine max',                     'vegetable', 1, 'internal_seed', 'Olivia''s Garden curated catalog'),
+
+  -- Tier 2 — Workhorse: storage roots that keep company with beets & turnips.
+  ('parsnip',         'Parsnip',         'Pastinaca sativa',                'vegetable', 2, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('rutabaga',        'Rutabaga',        'Brassica napobrassica',           'vegetable', 2, 'internal_seed', 'Olivia''s Garden curated catalog'),
+
+  -- Tier 3 — Fresh: quick, cut-and-come-again greens and alliums.
+  ('green-onion',     'Green Onion',     'Allium fistulosum',               'vegetable', 3, 'internal_seed', 'Olivia''s Garden curated catalog'),
+  ('collard-greens',  'Collard Greens',  'Brassica oleracea var. viridis',  'vegetable', 3, 'internal_seed', 'Olivia''s Garden curated catalog'),
+
+  -- Tier 4 — Flavor: a herb the original catalog was missing.
+  ('fennel',          'Fennel',          'Foeniculum vulgare',              'herb',      4, 'internal_seed', 'Olivia''s Garden curated catalog')
+on conflict (slug) do update set
+  common_name       = excluded.common_name,
+  scientific_name   = excluded.scientific_name,
+  category          = excluded.category,
+  pyramid_tier      = excluded.pyramid_tier,
+  source_provider   = excluded.source_provider,
+  attribution_text  = excluded.attribution_text,
+  updated_at        = now();

--- a/services/grn-api/src/api/handlers/catalog.rs
+++ b/services/grn-api/src/api/handlers/catalog.rs
@@ -9,7 +9,7 @@ pub async fn list_catalog_crops() -> Result<Response<Body>, lambda_http::Error> 
     let client = db::connect().await?;
     let rows = client
         .query(
-            "select id, slug, common_name, scientific_name, category, description, source_provider, source_record_id, source_url, source_license, attribution_text, import_batch_id, imported_at::text as imported_at, last_verified_at::text as last_verified_at from crops order by common_name asc",
+            "select id, slug, common_name, scientific_name, category, description, pyramid_tier, source_provider, source_record_id, source_url, source_license, attribution_text, import_batch_id, imported_at::text as imported_at, last_verified_at::text as last_verified_at from crops order by common_name asc",
             &[],
         )
         .await
@@ -24,6 +24,7 @@ pub async fn list_catalog_crops() -> Result<Response<Body>, lambda_http::Error> 
             scientific_name: row.get("scientific_name"),
             category: row.get("category"),
             description: row.get("description"),
+            pyramid_tier: row.get("pyramid_tier"),
             source_attribution: SourceAttribution {
                 source: row.get("source_provider"),
                 source_id: row.get("source_record_id"),

--- a/services/grn-api/src/api/handlers/crop.rs
+++ b/services/grn-api/src/api/handlers/crop.rs
@@ -18,9 +18,11 @@ const GROWER_CROP_SELECT: &str = "
            g.bed_id, b.name as bed_name,
            g.planting_date, g.expected_harvest_date,
            g.plant_count, g.spacing_inches,
+           c.pyramid_tier as pyramid_tier,
            g.created_at, g.updated_at
     from grower_crop_library g
     left join garden_beds b on b.id = g.bed_id and b.archived_at is null
+    left join crops c on c.id = g.canonical_id
 ";
 
 pub async fn list_my_crops(
@@ -543,6 +545,7 @@ fn row_to_item(row: &Row) -> GrowerCropItem {
             .map(|d| d.format("%Y-%m-%d").to_string()),
         plant_count: row.get("plant_count"),
         spacing_inches: row.get("spacing_inches"),
+        pyramid_tier: row.get("pyramid_tier"),
         created_at: row
             .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
             .to_rfc3339(),

--- a/services/grn-api/src/api/models/catalog.rs
+++ b/services/grn-api/src/api/models/catalog.rs
@@ -20,6 +20,9 @@ pub struct CatalogCrop {
     pub scientific_name: Option<String>,
     pub category: Option<String>,
     pub description: Option<String>,
+    /// Garden pyramid layer (1=Foundation .. 5=Joy); None for crops that are
+    /// not part of the food pyramid (e.g. ornamental flowers).
+    pub pyramid_tier: Option<i16>,
     pub source_attribution: SourceAttribution,
 }
 

--- a/services/grn-api/src/api/models/crop.rs
+++ b/services/grn-api/src/api/models/crop.rs
@@ -20,6 +20,11 @@ pub struct GrowerCropItem {
     pub expected_harvest_date: Option<String>,
     pub plant_count: Option<i32>,
     pub spacing_inches: Option<i32>,
+    /// Garden pyramid layer (1=Foundation .. 5=Joy) resolved from the linked
+    /// catalog crop. None when the crop has no catalog link or is not part of
+    /// the food pyramid (e.g. ornamentals).
+    #[serde(default)]
+    pub pyramid_tier: Option<i16>,
     pub created_at: String,
     pub updated_at: String,
 }


### PR DESCRIPTION
## Summary

Adds an enhanced, visual garden planner for Good Roots Network growers, structured around a 5-layer **Garden Pyramid** (biggest to smallest): **Foundation → Workhorse → Fresh → Flavor → Joy**. Crop classification is persisted in the database so layers sort objectively, and the planner emphasizes the pyramid itself with each crop's vector icon rendered inside its layer, a progress indicator, and a plan-health evaluation.

Built iteratively across three commits:

1. **Planner v1** — dedicated `/planner` page + grower nav item; auto-classifies tracked crops into layers and suggests crops to fill gaps.
2. **Database-backed tiers** — moves classification from runtime regex into the catalog so sorting is objective and authoritative.
3. **Catalog gap crops** — seeds ten crops the pyramid framing needs but the catalog lacked.

## What's included

### Database
- `0033_crops_pyramid_tier.sql` — adds `pyramid_tier smallint` (check 1–5) + index to the `crops` catalog table; `ddl.sql` updated for fresh environments.
- `0034_seed_pyramid_tiers.sql` — assigns tiers to all 80 food crops in the seed catalog by slug. Ornamental flowers are intentionally left `NULL` (excluded from the food pyramid).
- `0035_seed_pyramid_gap_crops.sql` — seeds dry bean, lentil, chickpea, fava bean, edamame (Foundation); parsnip, rutabaga (Workhorse); green onion, collard greens (Fresh); fennel (Flavor). Closes three gaps the pyramid framing names directly — dry beans, scallions, fennel.

All migrations are idempotent (slug upsert) and run through the existing `db/migrate.sh` runner.

### API (Rust)
- `pyramid_tier` exposed on `CatalogCrop`.
- Grower-crop list/get/create/update responses now join the catalog (`LEFT JOIN crops c ON c.id = g.canonical_id`) and carry the resolved `pyramid_tier`, so the planner reads an authoritative tier. The join matches at most one row (FK to unique PK) — no fan-out.

### Frontend
- `pyramidTier` added to `CatalogCrop`/`GrowerCropItem` types and API mappers.
- Pyramid-forward visual: crop vector icons render inside each layer; empty layers preview faded suggestion icons.
- Radial **plan-score gauge** (0–100) with a friendly label and actionable guidance.
- Scoring is **Foundation-weighted + shape**: rewards covering the lower layers and a true pyramid shape (each layer ≥ the one above). Bucketing prefers the catalog tier and falls back to a name classifier only for free-text crops with no catalog link.

## Testing
- Frontend: **285 tests pass** (typecheck + lint clean), including new unit tests for classification, catalog-tier preference, plan evaluation, and a page render/interaction test.
- API: **226 Rust tests pass**; `cargo check` clean.
- An independent correctness review of the full diff found zero bugs.

## Not verified in CI sandbox
- **Migrations were not executed** — no database is available in the build container. They're verified by inspection against the actual seed slug list; they apply on the next `migrate.sh` run.
- The `vite` production bundle couldn't run due to a pre-existing `lightningcss` native-binary install issue in the container (reproduces on a clean tree, unrelated to this change). TypeScript compilation passes via `tsc`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011JVRA5ZYnLzNGXxjj9SJuE)_