### PR TITLE
GRN: isometric garden masterplan explorer

### DIFF
--- a/apps/grn/src/components/GardenDesigner/annotationPresets.ts
+++ b/apps/grn/src/components/GardenDesigner/annotationPresets.ts
@@ -15,6 +15,10 @@ export interface AnnotationPreset {
 
 // Picked to keep designer scope sane: visual context only, no soil, no
 // crops, no LLM input. The user can rename freely after creation.
+//
+// The `icon` emoji doubles as the discriminator the masterplan view uses
+// to choose an illustrated 3D form (see GardenMasterplan/palette.ts), so
+// each preset keeps a distinct icon.
 export const ANNOTATION_PRESETS: AnnotationPreset[] = [
   {
     id: 'tree',
@@ -24,7 +28,27 @@ export const ANNOTATION_PRESETS: AnnotationPreset[] = [
     defaultLength: 60,
     defaultWidth: 60,
     defaultColor: '#3a7e5a',
-    description: 'A tree, shrub, or other circular landmark.',
+    description: 'A shade tree, shrub, or other circular landmark.',
+  },
+  {
+    id: 'fruit-tree',
+    label: 'Fruit tree',
+    icon: '🍎',
+    shape: 'circle',
+    defaultLength: 48,
+    defaultWidth: 48,
+    defaultColor: '#3a7e5a',
+    description: 'An apple, pear, stone-fruit, or citrus tree.',
+  },
+  {
+    id: 'berry-bush',
+    label: 'Berry bush',
+    icon: '🫐',
+    shape: 'circle',
+    defaultLength: 36,
+    defaultWidth: 36,
+    defaultColor: '#446e3b',
+    description: 'A blueberry, raspberry, currant, or other fruiting shrub.',
   },
   {
     id: 'pond',
@@ -38,16 +62,6 @@ export const ANNOTATION_PRESETS: AnnotationPreset[] = [
     buildPoints: (length, width) => defaultRectPolygonPoints(length, width),
   },
   {
-    id: 'shed',
-    label: 'Shed',
-    icon: '🏚️',
-    shape: 'rect',
-    defaultLength: 96,
-    defaultWidth: 72,
-    defaultColor: '#5b3a1c',
-    description: 'A shed, greenhouse, or other rectangular structure.',
-  },
-  {
     id: 'path',
     label: 'Path',
     icon: '🛤️',
@@ -55,11 +69,75 @@ export const ANNOTATION_PRESETS: AnnotationPreset[] = [
     defaultLength: 240,
     defaultWidth: 12,
     defaultColor: '#8a6230',
-    description: 'A pathway, fence, or other linear feature.',
+    description: 'A walkway or other linear surface.',
     buildPoints: (length) => [
       { x: 0, y: 0 },
       { x: length, y: 0 },
     ],
+  },
+  {
+    id: 'fence',
+    label: 'Fence',
+    icon: '🚧',
+    shape: 'line',
+    defaultLength: 240,
+    defaultWidth: 4,
+    defaultColor: '#8a6230',
+    description: 'A fence line or garden boundary.',
+    buildPoints: (length) => [
+      { x: 0, y: 0 },
+      { x: length, y: 0 },
+    ],
+  },
+  {
+    id: 'shed',
+    label: 'Shed',
+    icon: '🏚️',
+    shape: 'rect',
+    defaultLength: 96,
+    defaultWidth: 72,
+    defaultColor: '#5b3a1c',
+    description: 'A shed, barn, or other solid structure.',
+  },
+  {
+    id: 'greenhouse',
+    label: 'Greenhouse',
+    icon: '🪴',
+    shape: 'rect',
+    defaultLength: 120,
+    defaultWidth: 84,
+    defaultColor: '#7aa18f',
+    description: 'A greenhouse, hoop house, or cold frame.',
+  },
+  {
+    id: 'trellis',
+    label: 'Trellis',
+    icon: '🪜',
+    shape: 'rect',
+    defaultLength: 72,
+    defaultWidth: 12,
+    defaultColor: '#8a6230',
+    description: 'A trellis, arbor, or other climbing support.',
+  },
+  {
+    id: 'compost',
+    label: 'Compost',
+    icon: '♻️',
+    shape: 'rect',
+    defaultLength: 36,
+    defaultWidth: 36,
+    defaultColor: '#5b3a1c',
+    description: 'A compost bin or pile.',
+  },
+  {
+    id: 'coop',
+    label: 'Animal enclosure',
+    icon: '🐔',
+    shape: 'rect',
+    defaultLength: 96,
+    defaultWidth: 72,
+    defaultColor: '#8a6230',
+    description: 'A chicken coop, run, hutch, or other animal enclosure.',
   },
   {
     id: 'custom',

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../../types/listing';
+import { GardenMasterplan } from './GardenMasterplan';
+
+beforeAll(() => {
+  // jsdom has no ResizeObserver; the viewport hook only needs construct/observe.
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+});
+
+const canvas: GardenCanvas = {
+  id: 'canvas-1',
+  userId: 'u1',
+  widthInches: 360,
+  heightInches: 240,
+  backgroundImageKey: null,
+  backgroundImageUrl: null,
+  backgroundOpacity: 0.5,
+  northOffsetDeg: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function makeBed(overrides: Partial<GardenBed>): GardenBed {
+  return {
+    id: 'bed-1',
+    userId: 'u1',
+    name: 'Herb spiral',
+    description: null,
+    sunExposure: 'full_sun',
+    soilType: 'loam,compost_amended',
+    lengthInches: 96,
+    widthInches: 48,
+    locationNotes: null,
+    sortOrder: 0,
+    bedType: 'raised',
+    shape: 'rect',
+    positionX: 24,
+    positionY: 24,
+    rotationDeg: 0,
+    points: null,
+    color: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeAnnotation(overrides: Partial<GardenAnnotation>): GardenAnnotation {
+  return {
+    id: 'ann-1',
+    userId: 'u1',
+    label: 'Old oak',
+    icon: '🌳',
+    shape: 'circle',
+    positionX: 200,
+    positionY: 60,
+    lengthInches: 60,
+    widthInches: 60,
+    rotationDeg: 0,
+    points: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeCrop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
+  return {
+    id: 'crop-1',
+    userId: 'u1',
+    canonicalId: null,
+    cropName: 'Tomato',
+    varietyId: null,
+    status: 'active',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: 'bed-1',
+    bedName: 'Herb spiral',
+    plantingDate: null,
+    expectedHarvestDate: null,
+    plantCount: 4,
+    spacingInches: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderMasterplan(args?: {
+  beds?: GardenBed[];
+  annotations?: GardenAnnotation[];
+  crops?: GrowerCropItem[];
+  selected?: { kind: 'bed' | 'annotation'; id: string } | null;
+  onSelect?: (next: unknown) => void;
+  onOpenLayoutEditor?: () => void;
+}) {
+  const beds = args?.beds ?? [makeBed({})];
+  const annotations = args?.annotations ?? [makeAnnotation({})];
+  const crops = args?.crops ?? [makeCrop({})];
+  const cropsByBedId = new Map<string, GrowerCropItem[]>();
+  for (const crop of crops) {
+    if (!crop.bedId) continue;
+    cropsByBedId.set(crop.bedId, [...(cropsByBedId.get(crop.bedId) ?? []), crop]);
+  }
+  const selected = args?.selected ?? null;
+  return render(
+    <GardenMasterplan
+      canvas={canvas}
+      beds={beds}
+      annotations={annotations}
+      cropsByBedId={cropsByBedId}
+      selected={selected as never}
+      selectedBed={
+        selected?.kind === 'bed' ? beds.find((b) => b.id === selected.id) : undefined
+      }
+      selectedAnnotation={
+        selected?.kind === 'annotation'
+          ? annotations.find((a) => a.id === selected.id)
+          : undefined
+      }
+      onSelect={(args?.onSelect ?? (() => {})) as never}
+      onOpenLayoutEditor={args?.onOpenLayoutEditor ?? (() => {})}
+    />
+  );
+}
+
+describe('GardenMasterplan', () => {
+  it('renders every bed and annotation as a focusable, labelled map element', () => {
+    renderMasterplan();
+    expect(
+      screen.getByRole('button', { name: /herb spiral \(raised bed, 1 crop\)/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /old oak \(tree\)/i })).toBeInTheDocument();
+  });
+
+  it('selects a bed when its map element is clicked', async () => {
+    const onSelect = vi.fn();
+    renderMasterplan({ onSelect });
+    await userEvent.click(
+      screen.getByRole('button', { name: /herb spiral/i })
+    );
+    expect(onSelect).toHaveBeenCalledWith({ kind: 'bed', id: 'bed-1' });
+  });
+
+  it('supports keyboard selection with Enter', async () => {
+    const onSelect = vi.fn();
+    renderMasterplan({ onSelect });
+    const element = screen.getByRole('button', { name: /old oak/i });
+    element.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenCalledWith({ kind: 'annotation', id: 'ann-1' });
+  });
+
+  it('shows the floating detail panel for the selected bed', () => {
+    renderMasterplan({ selected: { kind: 'bed', id: 'bed-1' } });
+    const panel = screen.getByTestId('masterplan-detail-panel');
+    expect(panel).toHaveTextContent('Herb spiral');
+    expect(panel).toHaveTextContent(/raised bed/i);
+    expect(panel).toHaveTextContent('Full sun');
+    expect(panel).toHaveTextContent('Loam');
+    expect(panel).toHaveTextContent('Compost-amended');
+    expect(panel).toHaveTextContent('Tomato');
+    expect(panel).toHaveTextContent('×4');
+  });
+
+  it('jumps to the layout editor from the detail panel', async () => {
+    const onOpenLayoutEditor = vi.fn();
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      onOpenLayoutEditor,
+    });
+    await userEvent.click(
+      screen.getByRole('button', { name: /edit in layout editor/i })
+    );
+    expect(onOpenLayoutEditor).toHaveBeenCalled();
+  });
+
+  it('closes the detail panel via its close button', async () => {
+    const onSelect = vi.fn();
+    renderMasterplan({ selected: { kind: 'bed', id: 'bed-1' }, onSelect });
+    await userEvent.click(screen.getByRole('button', { name: /close details/i }));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('shows an inviting empty state when the garden has no elements', () => {
+    const onOpenLayoutEditor = vi.fn();
+    renderMasterplan({ beds: [], annotations: [], crops: [], onOpenLayoutEditor });
+    expect(screen.getByText(/your property, beautifully mapped/i)).toBeInTheDocument();
+  });
+
+  it('labels annotation kinds for assistive tech', () => {
+    renderMasterplan({
+      annotations: [
+        makeAnnotation({ id: 'gh', label: 'Glass house', icon: '🪴' }),
+        makeAnnotation({ id: 'fence', label: 'Back fence', icon: '🚧', shape: 'line' }),
+      ],
+    });
+    expect(
+      screen.getByRole('button', { name: /glass house \(greenhouse\)/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /back fence \(fence\)/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from 'react';
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../../types/listing';
+import type { SelectedItem } from '../../hooks/useGardenDesigner';
+import { IsoScene, sceneMetrics } from './IsoScene';
+import { MasterplanDetailPanel } from './MasterplanDetailPanel';
+import { useMapViewport } from './useMapViewport';
+
+interface GardenMasterplanProps {
+  canvas: GardenCanvas;
+  beds: GardenBed[];
+  annotations: GardenAnnotation[];
+  cropsByBedId: Map<string, GrowerCropItem[]>;
+  selected: SelectedItem;
+  selectedBed: GardenBed | undefined;
+  selectedAnnotation: GardenAnnotation | undefined;
+  onSelect: (next: SelectedItem) => void;
+  onOpenLayoutEditor: () => void;
+}
+
+/**
+ * The masterplan explorer: an isometric illustrated map of the whole
+ * garden that doubles as navigation. Drag/scroll/pinch to move around,
+ * click any element for its floating detail card. Editing geometry stays
+ * in the layout editor — this view is for understanding and exploring
+ * the property.
+ */
+export function GardenMasterplan({
+  canvas,
+  beds,
+  annotations,
+  cropsByBedId,
+  selected,
+  selectedBed,
+  selectedAnnotation,
+  onSelect,
+  onOpenLayoutEditor,
+}: GardenMasterplanProps) {
+  const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
+  const viewport = useMapViewport(metrics.width, metrics.height);
+  const isEmpty = beds.length === 0 && annotations.length === 0;
+
+  return (
+    <div className="mp-explorer">
+      <div
+        ref={viewport.containerRef}
+        className="mp-explorer__viewport"
+        {...viewport.containerHandlers}
+      >
+        <div className="mp-explorer__content" style={viewport.contentStyle}>
+          <IsoScene
+            canvas={canvas}
+            beds={beds}
+            annotations={annotations}
+            cropsByBedId={cropsByBedId}
+            selected={selected}
+            onSelect={onSelect}
+            shouldIgnoreClick={viewport.shouldIgnoreClick}
+          />
+        </div>
+
+        <div className="mp-explorer__zoom" role="group" aria-label="Map zoom controls">
+          <button
+            type="button"
+            className="mp-explorer__zoom-btn"
+            onClick={viewport.zoomIn}
+            aria-label="Zoom in"
+            title="Zoom in"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            className="mp-explorer__zoom-btn"
+            onClick={viewport.zoomOut}
+            aria-label="Zoom out"
+            title="Zoom out"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            className="mp-explorer__zoom-btn mp-explorer__zoom-btn--fit"
+            onClick={viewport.fitToScreen}
+            aria-label="Fit garden to screen"
+            title="Fit to screen"
+          >
+            ⊡
+          </button>
+        </div>
+
+        {!isEmpty && (
+          <p className="mp-explorer__hint" aria-hidden="true">
+            Drag to explore · scroll to zoom · click anything for details
+          </p>
+        )}
+
+        {isEmpty && (
+          <div className="mp-explorer__empty">
+            <h2>Your property, beautifully mapped</h2>
+            <p>
+              Add beds, trees, paths, and structures in the layout editor and
+              they’ll appear here as an illustrated masterplan.
+            </p>
+            <button
+              type="button"
+              className="mp-panel__action"
+              onClick={onOpenLayoutEditor}
+            >
+              Open the layout editor
+            </button>
+          </div>
+        )}
+      </div>
+
+      {(selectedBed || selectedAnnotation) && (
+        <MasterplanDetailPanel
+          key={selectedBed?.id ?? selectedAnnotation?.id}
+          bed={selectedBed}
+          annotation={selectedAnnotation}
+          crops={selectedBed ? cropsByBedId.get(selectedBed.id) ?? [] : []}
+          onClose={() => onSelect(null)}
+          onOpenLayoutEditor={onOpenLayoutEditor}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/grn/src/components/GardenMasterplan/IsoAnnotation.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoAnnotation.tsx
@@ -1,0 +1,680 @@
+import { memo, type ReactNode } from 'react';
+import type { GardenAnnotation } from '../../types/listing';
+import {
+  PX_PER_INCH,
+  boundsOf,
+  ellipseFootprint,
+  extrude,
+  hashSeed,
+  insetFootprint,
+  polygonFootprint,
+  project,
+  projectFootprint,
+  rectFootprint,
+  rotateWorld,
+  scaleFootprint,
+  smoothClosedPath,
+  smoothOpenPath,
+  toPath,
+  worldCentroid,
+  type WorldPoint,
+} from './iso';
+import {
+  BERRY_DOT,
+  FOLIAGE,
+  FOLIAGE_BERRY,
+  FOLIAGE_FRUIT,
+  FRUIT_DOT,
+  SCENE,
+  annotationKind,
+  materialFrom,
+  mute,
+  shade,
+  tint,
+  type AnnotationKind,
+} from './palette';
+
+// Kinds that sit flush with the ground; the scene paints these before any
+// extruded volume regardless of depth so beds and structures always sit
+// on top of paths and water.
+export const FLAT_KINDS: ReadonlySet<AnnotationKind> = new Set(['path', 'pond']);
+
+function geometry(a: GardenAnnotation) {
+  return {
+    x: a.positionX ?? 12,
+    y: a.positionY ?? 12,
+    length: a.lengthInches ?? 48,
+    width: a.widthInches ?? 48,
+    rotationDeg: a.rotationDeg,
+  };
+}
+
+export function annotationFootprint(a: GardenAnnotation): WorldPoint[] {
+  const g = geometry(a);
+  if (a.shape === 'line' && a.points && a.points.length >= 2) {
+    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
+  }
+  if (a.shape === 'circle') {
+    return ellipseFootprint(g);
+  }
+  if (a.shape === 'polygon' && a.points && a.points.length >= 3) {
+    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
+  }
+  return rectFootprint(g);
+}
+
+// Structures (sheds, greenhouses, bins…) always build from an oriented
+// rectangle so roof/wall construction has four predictable corners, even
+// if the underlying record was created with another shape.
+function structureCorners(a: GardenAnnotation): WorldPoint[] {
+  return rectFootprint(geometry(a));
+}
+
+function avgRadius(footprint: WorldPoint[]): number {
+  const c = worldCentroid(footprint);
+  if (footprint.length === 0) return 12;
+  const total = footprint.reduce((sum, p) => sum + Math.hypot(p.x - c.x, p.y - c.y), 0);
+  return Math.max(8, total / footprint.length);
+}
+
+function groundShadow(footprint: WorldPoint[], spread = 1): ReactNode {
+  const pts = projectFootprint(scaleFootprint(footprint, spread), 0).map((p) => ({
+    x: p.x + 6,
+    y: p.y + 4,
+  }));
+  return <path className="mp-el__shadow" d={smoothClosedPath(pts)} fill={SCENE.elementShadow} />;
+}
+
+// Slightly irregular n-gon for organic canopies; jitter is deterministic
+// per element id so the illustration is stable across renders.
+function organicRing(center: WorldPoint, radius: number, seed: number, segments = 8): WorldPoint[] {
+  const points: WorldPoint[] = [];
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    const wobble = 1 + (((seed * 997 + i * 131) % 23) / 23 - 0.5) * 0.22;
+    points.push({
+      x: center.x + Math.cos(angle) * radius * wobble,
+      y: center.y + Math.sin(angle) * radius * wobble,
+    });
+  }
+  return points;
+}
+
+// --- Kind renderers ---------------------------------------------------------
+
+function renderCanopyPlant(
+  a: GardenAnnotation,
+  kind: 'tree' | 'fruitTree' | 'berryBush'
+): ReactNode {
+  const footprint = annotationFootprint(a);
+  const c = worldCentroid(footprint);
+  const r = avgRadius(footprint);
+  const seed = hashSeed(a.id);
+
+  const base =
+    kind === 'tree'
+      ? FOLIAGE[Math.floor(seed * FOLIAGE.length) % FOLIAGE.length]
+      : kind === 'fruitTree'
+        ? FOLIAGE_FRUIT
+        : FOLIAGE_BERRY;
+
+  const slices =
+    kind === 'berryBush'
+      ? [
+          { scale: 1, z: r * 0.28, fill: shade(base, 0.16) },
+          { scale: 0.62, z: r * 0.62, fill: tint(base, 0.08) },
+        ]
+      : [
+          { scale: 1, z: r * 0.5, fill: shade(base, 0.18) },
+          { scale: 0.74, z: r * 0.82, fill: base },
+          { scale: 0.46, z: r * 1.08, fill: tint(base, 0.16) },
+        ];
+
+  const trunk =
+    kind === 'berryBush'
+      ? null
+      : extrude(
+          rectFootprint({
+            x: c.x - Math.max(2, r * 0.09),
+            y: c.y - Math.max(2, r * 0.09),
+            length: Math.max(4, r * 0.18),
+            width: Math.max(4, r * 0.18),
+          }),
+          r * 0.55
+        );
+
+  const dots: ReactNode[] = [];
+  if (kind !== 'tree') {
+    const dotFill = kind === 'fruitTree' ? FRUIT_DOT : BERRY_DOT;
+    const count = kind === 'fruitTree' ? 5 : 4;
+    for (let i = 0; i < count; i += 1) {
+      const angle = seed * Math.PI * 2 + (i / count) * Math.PI * 2;
+      const dist = r * (0.32 + ((seed * 31 + i * 17) % 10) / 28);
+      const z = kind === 'fruitTree' ? r * 0.82 : r * 0.5;
+      const p = project(c.x + Math.cos(angle) * dist, c.y + Math.sin(angle) * dist, z);
+      dots.push(<circle key={i} cx={p.x} cy={p.y} r={2.3} fill={dotFill} />);
+    }
+  }
+
+  return (
+    <>
+      {groundShadow(footprint, 1.05)}
+      {trunk && (
+        <>
+          {trunk.walls.map((wall, idx) => (
+            <path
+              key={idx}
+              d={toPath(wall.points)}
+              fill={wall.facing === 'right' ? shade(SCENE.trunk, 0.12) : shade(SCENE.trunk, 0.3)}
+            />
+          ))}
+        </>
+      )}
+      {slices.map((slice, idx) => (
+        <path
+          key={idx}
+          d={smoothClosedPath(
+            projectFootprint(organicRing(c, r * slice.scale, seed + idx), slice.z)
+          )}
+          fill={slice.fill}
+        />
+      ))}
+      {dots}
+    </>
+  );
+}
+
+function renderPond(a: GardenAnnotation): ReactNode {
+  const footprint = annotationFootprint(a);
+  const c = worldCentroid(footprint);
+  const ripple1 = projectFootprint(
+    organicRing(c, avgRadius(footprint) * 0.34, hashSeed(a.id), 6),
+    0
+  );
+  return (
+    <>
+      <path
+        d={smoothClosedPath(projectFootprint(scaleFootprint(footprint, 1.12), 0))}
+        fill={SCENE.sand}
+      />
+      <path
+        d={smoothClosedPath(projectFootprint(footprint, 0))}
+        fill={SCENE.water}
+        stroke={SCENE.waterEdge}
+        strokeWidth={1.2}
+      />
+      <path
+        d={smoothClosedPath(projectFootprint(scaleFootprint(footprint, 0.68), 0))}
+        fill={tint(SCENE.water, 0.2)}
+      />
+      <path
+        d={smoothOpenPath(ripple1.slice(0, 4))}
+        fill="none"
+        stroke={tint(SCENE.water, 0.5)}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+      />
+    </>
+  );
+}
+
+function renderPath(a: GardenAnnotation): ReactNode {
+  const footprint = annotationFootprint(a);
+  const projected = projectFootprint(footprint, 0);
+  const d =
+    a.shape === 'line'
+      ? smoothOpenPath(projected)
+      : smoothClosedPath(projected);
+  const widthPx = Math.max(6, (a.widthInches ?? 12) * PX_PER_INCH * 0.9);
+  if (a.shape !== 'line') {
+    // Area paths (patios, gravel pads) fill their footprint instead.
+    return (
+      <path d={d} fill={SCENE.stone} stroke={SCENE.stoneEdge} strokeWidth={1.5} />
+    );
+  }
+  return (
+    <>
+      <path
+        d={d}
+        fill="none"
+        stroke={SCENE.stoneEdge}
+        strokeWidth={widthPx + 3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d={d}
+        fill="none"
+        stroke={SCENE.stone}
+        strokeWidth={widthPx}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </>
+  );
+}
+
+const FENCE_HEIGHT = 34;
+const FENCE_POST_SPACING = 48;
+
+function renderFence(a: GardenAnnotation): ReactNode {
+  let line = annotationFootprint(a);
+  // Rect fences enclose an area: walk the full perimeter.
+  const closed = a.shape !== 'line';
+  if (closed && line.length >= 3) line = [...line, line[0]];
+
+  const posts: WorldPoint[] = [];
+  for (let i = 0; i < line.length - 1; i += 1) {
+    const aPt = line[i];
+    const bPt = line[i + 1];
+    const dist = Math.hypot(bPt.x - aPt.x, bPt.y - aPt.y);
+    const count = Math.max(1, Math.round(dist / FENCE_POST_SPACING));
+    for (let j = 0; j < count; j += 1) {
+      const t = j / count;
+      posts.push({ x: aPt.x + (bPt.x - aPt.x) * t, y: aPt.y + (bPt.y - aPt.y) * t });
+    }
+  }
+  posts.push(line[line.length - 1]);
+
+  const railTop = toPath(projectFootprint(line, FENCE_HEIGHT * 0.82), false);
+  const railMid = toPath(projectFootprint(line, FENCE_HEIGHT * 0.45), false);
+
+  return (
+    <>
+      <path
+        d={toPath(projectFootprint(line, 0), false)}
+        fill="none"
+        stroke={SCENE.elementShadowSoft}
+        strokeWidth={3}
+      />
+      {posts.map((p, idx) => {
+        const bottom = project(p.x, p.y, 0);
+        const top = project(p.x, p.y, FENCE_HEIGHT);
+        return (
+          <line
+            key={idx}
+            x1={bottom.x}
+            y1={bottom.y}
+            x2={top.x}
+            y2={top.y}
+            stroke={shade(SCENE.fence, 0.22)}
+            strokeWidth={2}
+            strokeLinecap="round"
+          />
+        );
+      })}
+      <path d={railTop} fill="none" stroke={SCENE.fence} strokeWidth={1.6} />
+      <path d={railMid} fill="none" stroke={SCENE.fence} strokeWidth={1.6} />
+    </>
+  );
+}
+
+interface RoofSpec {
+  eaves: number;
+  ridge: number;
+  color: string;
+  overhang: number;
+}
+
+// Gabled structure: extruded walls to the eaves plus two flat-shaded roof
+// planes meeting at a ridge along the long axis.
+function renderGabledStructure(
+  a: GardenAnnotation,
+  wallBase: string,
+  roof: RoofSpec,
+  extras?: (corners: WorldPoint[], eaves: number) => ReactNode
+): ReactNode {
+  const g = geometry(a);
+  const corners = structureCorners(a);
+  const walls = extrude(corners, roof.eaves);
+  const material = materialFrom(wallBase);
+
+  const alongX = g.length >= g.width;
+  const ridgeEnds: WorldPoint[] = alongX
+    ? [
+        { x: g.x, y: g.y + g.width / 2 },
+        { x: g.x + g.length, y: g.y + g.width / 2 },
+      ]
+    : [
+        { x: g.x + g.length / 2, y: g.y },
+        { x: g.x + g.length / 2, y: g.y + g.width },
+      ];
+  const [r0, r1] = rotateWorld(ridgeEnds, g.x, g.y, g.rotationDeg);
+
+  const eaveCorners = scaleFootprint(corners, roof.overhang);
+  const [c0, c1, c2, c3] = eaveCorners;
+  // Plane A spans the first long edge to the ridge, plane B the ridge to
+  // the opposite edge. With light from the north-west, A (the back/north
+  // slope) reads lighter.
+  const planeA = alongX ? [c0, c1] : [c1, c2];
+  const planeB = alongX ? [c3, c2] : [c0, c3];
+
+  const roofA = [
+    project(planeA[0].x, planeA[0].y, roof.eaves),
+    project(planeA[1].x, planeA[1].y, roof.eaves),
+    project(r1.x, r1.y, roof.ridge),
+    project(r0.x, r0.y, roof.ridge),
+  ];
+  const roofB = [
+    project(r0.x, r0.y, roof.ridge),
+    project(r1.x, r1.y, roof.ridge),
+    project(planeB[1].x, planeB[1].y, roof.eaves),
+    project(planeB[0].x, planeB[0].y, roof.eaves),
+  ];
+
+  return (
+    <>
+      {groundShadow(corners, 1.08)}
+      {walls.walls.map((wall, idx) => (
+        <path
+          key={idx}
+          d={toPath(wall.points)}
+          fill={wall.facing === 'right' ? material.right : material.left}
+        />
+      ))}
+      {extras?.(corners, roof.eaves)}
+      <path d={toPath(roofA)} fill={tint(roof.color, 0.12)} />
+      <path d={toPath(roofB)} fill={shade(roof.color, 0.14)} />
+      <line
+        x1={project(r0.x, r0.y, roof.ridge).x}
+        y1={project(r0.x, r0.y, roof.ridge).y}
+        x2={project(r1.x, r1.y, roof.ridge).x}
+        y2={project(r1.x, r1.y, roof.ridge).y}
+        stroke={tint(roof.color, 0.35)}
+        strokeWidth={1.2}
+      />
+    </>
+  );
+}
+
+// Door on the south-facing wall, drawn only when that wall faces the camera.
+function doorExtra(doorColor: string) {
+  return (corners: WorldPoint[], eaves: number): ReactNode => {
+    const [, , c2, c3] = corners;
+    const centroid = worldCentroid(corners);
+    const mx = (c2.x + c3.x) / 2;
+    const my = (c2.y + c3.y) / 2;
+    if (mx - centroid.x + (my - centroid.y) <= 0) return null;
+    const half = Math.min(0.2, 12 / Math.max(1, Math.hypot(c2.x - c3.x, c2.y - c3.y)));
+    const d0 = { x: mx + (c3.x - c2.x) * half, y: my + (c3.y - c2.y) * half };
+    const d1 = { x: mx + (c2.x - c3.x) * half, y: my + (c2.y - c3.y) * half };
+    const doorHeight = eaves * 0.78;
+    return (
+      <path
+        d={toPath([
+          project(d0.x, d0.y, 0),
+          project(d1.x, d1.y, 0),
+          project(d1.x, d1.y, doorHeight),
+          project(d0.x, d0.y, doorHeight),
+        ])}
+        fill={doorColor}
+      />
+    );
+  };
+}
+
+function renderGreenhouse(a: GardenAnnotation): ReactNode {
+  const corners = structureCorners(a);
+  const plinth = extrude(corners, 4);
+  return (
+    <>
+      {plinth.walls.map((wall, idx) => (
+        <path
+          key={idx}
+          d={toPath(wall.points)}
+          fill={wall.facing === 'right' ? shade(SCENE.wood, 0.1) : shade(SCENE.wood, 0.28)}
+        />
+      ))}
+      <g className="mp-greenhouse-glass">
+        {renderGabledStructure(
+          a,
+          SCENE.glass,
+          { eaves: 62, ridge: 84, color: SCENE.glass, overhang: 1.04 },
+          (cs, eaves) => {
+            // Mullions on the two camera-facing walls.
+            const lines: ReactNode[] = [];
+            const visible = extrude(cs, eaves).walls;
+            visible.forEach((wall, wIdx) => {
+              const [b0, b1, t1, t0] = wall.points;
+              for (let i = 1; i < 4; i += 1) {
+                const t = i / 4;
+                lines.push(
+                  <line
+                    key={`${wIdx}-${i}`}
+                    x1={b0.x + (b1.x - b0.x) * t}
+                    y1={b0.y + (b1.y - b0.y) * t}
+                    x2={t0.x + (t1.x - t0.x) * t}
+                    y2={t0.y + (t1.y - t0.y) * t}
+                    stroke={SCENE.glassFrame}
+                    strokeWidth={1}
+                  />
+                );
+              }
+            });
+            return <>{lines}</>;
+          }
+        )}
+      </g>
+    </>
+  );
+}
+
+const TRELLIS_HEIGHT = 66;
+
+function renderTrellis(a: GardenAnnotation): ReactNode {
+  const g = geometry(a);
+  const alongX = g.length >= g.width;
+  const ends: WorldPoint[] = alongX
+    ? [
+        { x: g.x, y: g.y + g.width / 2 },
+        { x: g.x + g.length, y: g.y + g.width / 2 },
+      ]
+    : [
+        { x: g.x + g.length / 2, y: g.y },
+        { x: g.x + g.length / 2, y: g.y + g.width },
+      ];
+  const [e0, e1] = rotateWorld(ends, g.x, g.y, g.rotationDeg);
+  const b0 = project(e0.x, e0.y, 0);
+  const b1 = project(e1.x, e1.y, 0);
+  const t0 = project(e0.x, e0.y, TRELLIS_HEIGHT);
+  const t1 = project(e1.x, e1.y, TRELLIS_HEIGHT);
+
+  const verticals: ReactNode[] = [];
+  for (let i = 1; i < 4; i += 1) {
+    const t = i / 4;
+    verticals.push(
+      <line
+        key={i}
+        x1={b0.x + (b1.x - b0.x) * t}
+        y1={b0.y + (b1.y - b0.y) * t}
+        x2={t0.x + (t1.x - t0.x) * t}
+        y2={t0.y + (t1.y - t0.y) * t}
+        stroke={SCENE.woodDark}
+        strokeWidth={1.2}
+      />
+    );
+  }
+  const horizontals = [0.35, 0.7].map((f, idx) => (
+    <line
+      key={idx}
+      x1={b0.x + (t0.x - b0.x) * f}
+      y1={b0.y + (t0.y - b0.y) * f}
+      x2={b1.x + (t1.x - b1.x) * f}
+      y2={b1.y + (t1.y - b1.y) * f}
+      stroke={SCENE.woodDark}
+      strokeWidth={1.2}
+    />
+  ));
+
+  return (
+    <>
+      <path
+        d={toPath([b0, b1].map((p) => ({ x: p.x + 4, y: p.y + 3 })), false)}
+        stroke={SCENE.elementShadowSoft}
+        strokeWidth={4}
+        fill="none"
+        strokeLinecap="round"
+      />
+      <path
+        d={toPath([b0, b1, t1, t0])}
+        fill="rgba(213, 227, 218, 0.18)"
+        stroke={SCENE.wood}
+        strokeWidth={2}
+        strokeLinejoin="round"
+      />
+      {verticals}
+      {horizontals}
+    </>
+  );
+}
+
+function renderCompost(a: GardenAnnotation): ReactNode {
+  const corners = structureCorners(a);
+  const height = 24;
+  const bin = extrude(corners, height);
+  const fill = insetFootprint(corners, 3);
+  const seed = hashSeed(a.id);
+  const c = worldCentroid(corners);
+  return (
+    <>
+      {groundShadow(corners)}
+      {bin.walls.map((wall, idx) => {
+        const [b0, b1, t1, t0] = wall.points;
+        return (
+          <g key={idx}>
+            <path
+              d={toPath(wall.points)}
+              fill={wall.facing === 'right' ? shade(SCENE.wood, 0.14) : shade(SCENE.wood, 0.32)}
+            />
+            {[0.33, 0.66].map((f, i) => (
+              <line
+                key={i}
+                x1={b0.x + (t0.x - b0.x) * f}
+                y1={b0.y + (t0.y - b0.y) * f}
+                x2={b1.x + (t1.x - b1.x) * f}
+                y2={b1.y + (t1.y - b1.y) * f}
+                stroke={shade(SCENE.wood, 0.45)}
+                strokeWidth={0.8}
+              />
+            ))}
+          </g>
+        );
+      })}
+      <path d={toPath(bin.top)} fill={tint(SCENE.wood, 0.08)} />
+      <path d={toPath(projectFootprint(fill, height))} fill={SCENE.compost} />
+      {[0, 1, 2].map((i) => {
+        const angle = seed * 7 + i * 2.1;
+        const p = project(c.x + Math.cos(angle) * 8, c.y + Math.sin(angle) * 8, height);
+        return <circle key={i} cx={p.x} cy={p.y} r={1.6} fill={tint(SCENE.compost, 0.35)} />;
+      })}
+    </>
+  );
+}
+
+function renderMarker(a: GardenAnnotation): ReactNode {
+  const corners = structureCorners(a);
+  const base = a.color ? mute(a.color, 0.4) : SCENE.marker;
+  const material = materialFrom(base);
+  const block = extrude(corners, 8);
+  return (
+    <>
+      {groundShadow(corners)}
+      {block.walls.map((wall, idx) => (
+        <path
+          key={idx}
+          d={toPath(wall.points)}
+          fill={wall.facing === 'right' ? material.right : material.left}
+        />
+      ))}
+      <path d={toPath(block.top)} fill={material.top} />
+    </>
+  );
+}
+
+// --- Component ---------------------------------------------------------------
+
+interface IsoAnnotationProps {
+  annotation: GardenAnnotation;
+  isSelected: boolean;
+}
+
+/**
+ * Pure SVG illustration for one annotation, dispatched on its visual
+ * kind. Like IsoBed this only draws — interaction lives in IsoElement.
+ */
+export const IsoAnnotation = memo(function IsoAnnotation({
+  annotation,
+  isSelected,
+}: IsoAnnotationProps) {
+  const kind = annotationKind(annotation);
+
+  let body: ReactNode;
+  switch (kind) {
+    case 'tree':
+    case 'fruitTree':
+    case 'berryBush':
+      body = renderCanopyPlant(annotation, kind);
+      break;
+    case 'pond':
+      body = renderPond(annotation);
+      break;
+    case 'path':
+      body = renderPath(annotation);
+      break;
+    case 'fence':
+      body = renderFence(annotation);
+      break;
+    case 'shed':
+      body = renderGabledStructure(
+        annotation,
+        annotation.color ? mute(annotation.color, 0.35) : SCENE.woodDark,
+        { eaves: 70, ridge: 96, color: SCENE.terracotta, overhang: 1.06 },
+        doorExtra(shade(SCENE.woodDark, 0.35))
+      );
+      break;
+    case 'greenhouse':
+      body = renderGreenhouse(annotation);
+      break;
+    case 'trellis':
+      body = renderTrellis(annotation);
+      break;
+    case 'compost':
+      body = renderCompost(annotation);
+      break;
+    case 'coop':
+      body = renderGabledStructure(
+        annotation,
+        SCENE.coop,
+        { eaves: 40, ridge: 56, color: shade(SCENE.coop, 0.1), overhang: 1.05 },
+        doorExtra(shade(SCENE.coop, 0.4))
+      );
+      break;
+    case 'marker':
+    default:
+      body = renderMarker(annotation);
+      break;
+  }
+
+  const footprint = annotationFootprint(annotation);
+  const bounds = boundsOf(projectFootprint(footprint, 0));
+  const labelAnchor = (bounds.minX + bounds.maxX) / 2;
+
+  return (
+    <>
+      {body}
+      <text className="mp-label" x={labelAnchor} y={bounds.maxY + 13} textAnchor="middle">
+        {annotation.label}
+      </text>
+      {isSelected && (
+        <path
+          className="mp-el__ring"
+          d={toPath(projectFootprint(scaleFootprint(footprint, 1.12), 0), annotation.shape !== 'line')}
+          fill="none"
+          stroke={SCENE.selection}
+          strokeWidth={1.8}
+          strokeDasharray="5 4"
+        />
+      )}
+    </>
+  );
+});

--- a/apps/grn/src/components/GardenMasterplan/IsoBed.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoBed.tsx
@@ -1,0 +1,212 @@
+import { memo, type ReactNode } from 'react';
+import type { GardenBed, GrowerCropItem } from '../../types/listing';
+import { CROP_ICON_PATHS } from '../CropPlanner/cropIconPaths';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import {
+  boundsOf,
+  ellipseFootprint,
+  extrude,
+  hashSeed,
+  insetFootprint,
+  polygonFootprint,
+  project,
+  projectFootprint,
+  rectFootprint,
+  rotateWorld,
+  scaleFootprint,
+  smoothClosedPath,
+  toPath,
+  worldCentroid,
+  type WorldPoint,
+} from './iso';
+import { SCENE, bedPalette, mute, shade, tint } from './palette';
+
+export const RAISED_BED_HEIGHT = 11;
+export const IN_GROUND_HEIGHT = 2.5;
+const MAX_CROPS = 5;
+const CROP_SPACING_INCHES = 15;
+
+export function bedFootprint(bed: GardenBed): WorldPoint[] {
+  const x = bed.positionX ?? 12;
+  const y = bed.positionY ?? 12;
+  const length = bed.lengthInches ?? 96;
+  const width = bed.widthInches ?? 48;
+  if (bed.shape === 'circle') {
+    return ellipseFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
+  }
+  if (bed.shape === 'polygon' && bed.points && bed.points.length >= 3) {
+    return polygonFootprint({ x, y, points: bed.points, rotationDeg: bed.rotationDeg });
+  }
+  return rectFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
+}
+
+// Evenly spaced world positions along the bed's long axis where crop
+// silhouettes stand. Returned in north-to-south order so the upright
+// billboards overlap correctly when projected.
+function cropAnchors(bed: GardenBed, footprint: WorldPoint[], count: number): WorldPoint[] {
+  if (count === 0) return [];
+  const centroid = worldCentroid(footprint);
+  const length = bed.lengthInches ?? 96;
+  const width = bed.widthInches ?? 48;
+  const alongX = length >= width;
+  const axis = rotateWorld(
+    [{ x: alongX ? 1 : 0, y: alongX ? 0 : 1 }],
+    0,
+    0,
+    bed.rotationDeg
+  )[0];
+  const extent = Math.max(length, width);
+  const usable = Math.max(0, extent - 18);
+  const span = Math.min(usable, (count - 1) * CROP_SPACING_INCHES);
+  const anchors: WorldPoint[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const offset = count === 1 ? 0 : -span / 2 + (span / (count - 1)) * i;
+    anchors.push({
+      x: centroid.x + axis.x * offset,
+      y: centroid.y + axis.y * offset,
+    });
+  }
+  return anchors.sort((a, b) => a.x + a.y - (b.x + b.y));
+}
+
+interface IsoBedProps {
+  bed: GardenBed;
+  crops: GrowerCropItem[];
+  isSelected: boolean;
+}
+
+/**
+ * Pure SVG illustration of one bed: a flat-shaded extruded volume (or
+ * contoured mound), a soil surface, standing crop silhouettes, a soft
+ * ground shadow, and the name label. Interaction lives in the IsoElement
+ * wrapper; this component only draws.
+ */
+export const IsoBed = memo(function IsoBed({ bed, crops, isSelected }: IsoBedProps) {
+  const footprint = bedFootprint(bed);
+  const palette = bedPalette(bed.bedType, bed.color);
+  const height =
+    bed.bedType === 'raised'
+      ? RAISED_BED_HEIGHT
+      : bed.bedType === 'mound'
+        ? 0
+        : IN_GROUND_HEIGHT;
+
+  const shadowPath = toPath(
+    projectFootprint(footprint, 0).map((p) => ({ x: p.x + 6, y: p.y + 4 }))
+  );
+
+  let body: ReactNode;
+  let surfaceZ = height;
+
+  if (bed.bedType === 'mound') {
+    // Mounds render as stacked contour blobs instead of hard walls.
+    const layers: Array<{ scale: number; z: number; fill: string }> = [
+      { scale: 1, z: 0, fill: shade(SCENE.soil, 0.18) },
+      { scale: 0.7, z: 4, fill: SCENE.soil },
+      { scale: 0.42, z: 8, fill: tint(SCENE.soil, 0.16) },
+    ];
+    surfaceZ = 8;
+    body = (
+      <>
+        {layers.map((layer, idx) => (
+          <path
+            key={idx}
+            d={smoothClosedPath(
+              projectFootprint(scaleFootprint(footprint, layer.scale), layer.z)
+            )}
+            fill={layer.fill}
+          />
+        ))}
+      </>
+    );
+  } else {
+    const solid = extrude(footprint, height);
+    const soil = insetFootprint(footprint, bed.bedType === 'raised' ? 3.5 : 1.5);
+    body = (
+      <>
+        {solid.walls.map((wall, idx) => (
+          <path
+            key={idx}
+            d={toPath(wall.points)}
+            fill={wall.facing === 'right' ? palette.frame.right : palette.frame.left}
+          />
+        ))}
+        <path d={toPath(solid.top)} fill={palette.frame.top} />
+        <path
+          d={toPath(projectFootprint(soil, height))}
+          fill={palette.soilTop}
+          stroke={palette.soilEdge}
+          strokeWidth={1}
+        />
+      </>
+    );
+  }
+
+  const visibleCrops = crops.slice(0, MAX_CROPS);
+  const overflow = crops.length - visibleCrops.length;
+  const anchors = cropAnchors(bed, footprint, visibleCrops.length);
+
+  const baseScreen = projectFootprint(footprint, 0);
+  const bounds = boundsOf(baseScreen);
+  const labelAnchor = project(
+    worldCentroid(footprint).x,
+    worldCentroid(footprint).y,
+    0
+  );
+
+  // Stagger crop rows slightly so dense plantings read as planting, not
+  // a picket line. Deterministic per bed.
+  const jitter = hashSeed(bed.id) * 4 - 2;
+
+  return (
+    <>
+      <path className="mp-el__shadow" d={shadowPath} fill={SCENE.elementShadow} />
+      {body}
+      {visibleCrops.map((crop, idx) => {
+        const anchor = anchors[idx];
+        if (!anchor) return null;
+        const visual = visualForCrop(crop.cropName);
+        const p = project(anchor.x, anchor.y, surfaceZ);
+        const k = 1.05;
+        return (
+          <g key={crop.id} className="mp-crop">
+            <ellipse
+              cx={p.x}
+              cy={p.y + 1}
+              rx={7}
+              ry={2.6}
+              fill={SCENE.elementShadowSoft}
+            />
+            <path
+              d={CROP_ICON_PATHS[visual.iconKey]}
+              fill={mute(visual.accent, 0.22)}
+              transform={`translate(${p.x - 12 * k + jitter} ${p.y - 23 * k}) scale(${k})`}
+            />
+          </g>
+        );
+      })}
+      {overflow > 0 && (
+        <text
+          className="mp-label mp-label--count"
+          x={bounds.maxX + 6}
+          y={(bounds.minY + bounds.maxY) / 2}
+        >
+          +{overflow}
+        </text>
+      )}
+      <text className="mp-label" x={labelAnchor.x} y={bounds.maxY + 13} textAnchor="middle">
+        {bed.name}
+      </text>
+      {isSelected && (
+        <path
+          className="mp-el__ring"
+          d={toPath(projectFootprint(scaleFootprint(footprint, 1.12), 0))}
+          fill="none"
+          stroke={SCENE.selection}
+          strokeWidth={1.8}
+          strokeDasharray="5 4"
+        />
+      )}
+    </>
+  );
+});

--- a/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
@@ -1,0 +1,320 @@
+import { memo, useMemo, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../../types/listing';
+import type { SelectedItem } from '../../hooks/useGardenDesigner';
+import {
+  ISO_COS,
+  ISO_SIN,
+  PX_PER_INCH,
+  boundsOf,
+  depthOf,
+  projectFootprint,
+  scaleFootprint,
+  smoothClosedPath,
+  type WorldPoint,
+} from './iso';
+import { FLAT_KINDS, IsoAnnotation, annotationFootprint } from './IsoAnnotation';
+import { IsoBed, bedFootprint } from './IsoBed';
+import { KIND_LABELS, SCENE, annotationKind } from './palette';
+
+// Extra svg space above the ground plate so tall objects (trees, sheds)
+// and crop silhouettes near the north edge never clip.
+const PAD_X = 80;
+const PAD_TOP = 160;
+const PAD_BOTTOM = 90;
+
+export interface SceneMetrics {
+  width: number;
+  height: number;
+  viewBox: string;
+}
+
+export function sceneMetrics(canvas: GardenCanvas): SceneMetrics {
+  const w = canvas.widthInches;
+  const h = canvas.heightInches;
+  const corners = projectFootprint([
+    { x: 0, y: 0 },
+    { x: w, y: 0 },
+    { x: w, y: h },
+    { x: 0, y: h },
+  ]);
+  const b = boundsOf(corners);
+  const width = b.maxX - b.minX + PAD_X * 2;
+  const height = b.maxY - b.minY + PAD_TOP + PAD_BOTTOM;
+  return {
+    width,
+    height,
+    viewBox: `${b.minX - PAD_X} ${b.minY - PAD_TOP} ${width} ${height}`,
+  };
+}
+
+// Organic ring of world points around the canvas rectangle — the lawn
+// plate is a soft blob, not a hard parallelogram, so the plan reads as an
+// illustrated property rather than a CAD sheet.
+function groundRing(w: number, h: number, margin: number): WorldPoint[] {
+  const points: WorldPoint[] = [];
+  const step = Math.max(36, Math.min(w, h) / 5);
+  const wobble = (i: number) => Math.sin(i * 2.7) * Math.min(9, margin * 0.5);
+  for (let x = -margin; x < w + margin; x += step) {
+    points.push({ x, y: -margin + wobble(points.length) });
+  }
+  for (let y = -margin; y < h + margin; y += step) {
+    points.push({ x: w + margin + wobble(points.length), y });
+  }
+  for (let x = w + margin; x > -margin; x -= step) {
+    points.push({ x, y: h + margin + wobble(points.length) });
+  }
+  for (let y = h + margin; y > -margin; y -= step) {
+    points.push({ x: -margin + wobble(points.length), y });
+  }
+  return points;
+}
+
+interface IsoElementProps {
+  label: string;
+  isSelected: boolean;
+  onSelect: () => void;
+  shouldIgnoreClick: () => boolean;
+  children: ReactNode;
+}
+
+// Shared interaction shell: focusable, labelled, and class-driven so
+// hover/dim/selection styling stays in CSS where it can be GPU-animated.
+function IsoElement({ label, isSelected, onSelect, shouldIgnoreClick, children }: IsoElementProps) {
+  function handleClick(event: MouseEvent) {
+    event.stopPropagation();
+    if (shouldIgnoreClick()) return;
+    onSelect();
+  }
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  }
+  return (
+    <g
+      className={`mp-el${isSelected ? ' mp-el--selected' : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      aria-pressed={isSelected}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </g>
+  );
+}
+
+interface IsoSceneProps {
+  canvas: GardenCanvas;
+  beds: GardenBed[];
+  annotations: GardenAnnotation[];
+  cropsByBedId: Map<string, GrowerCropItem[]>;
+  selected: SelectedItem;
+  onSelect: (next: SelectedItem) => void;
+  shouldIgnoreClick: () => boolean;
+}
+
+interface RenderItem {
+  key: string;
+  depth: number;
+  flat: boolean;
+  node: ReactNode;
+}
+
+/**
+ * The full isometric masterplan as a single SVG: lawn plate, contour
+ * accents, depth-sorted garden elements, compass, and scale bar. Pan and
+ * zoom are applied by the parent via a CSS transform on the wrapper, so
+ * this component is layout-independent and cheap to leave untouched
+ * during navigation.
+ */
+export const IsoScene = memo(function IsoScene({
+  canvas,
+  beds,
+  annotations,
+  cropsByBedId,
+  selected,
+  onSelect,
+  shouldIgnoreClick,
+}: IsoSceneProps) {
+  const metrics = sceneMetrics(canvas);
+  const w = canvas.widthInches;
+  const h = canvas.heightInches;
+
+  const ground = useMemo(() => {
+    const margin = Math.max(14, Math.min(w, h) * 0.07);
+    const ring = groundRing(w, h, margin);
+    return {
+      shadow: smoothClosedPath(
+        projectFootprint(ring, 0).map((p) => ({ x: p.x + 10, y: p.y + 8 }))
+      ),
+      lawn: smoothClosedPath(projectFootprint(ring, 0)),
+      wash: smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.93), 0)),
+      contourA: smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.78), 0)),
+      contourB: smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.5), 0)),
+    };
+  }, [w, h]);
+
+  const items = useMemo<RenderItem[]>(() => {
+    const list: RenderItem[] = [];
+    for (const annotation of annotations) {
+      const kind = annotationKind(annotation);
+      list.push({
+        key: `annotation-${annotation.id}`,
+        depth: depthOf(annotationFootprint(annotation)),
+        flat: FLAT_KINDS.has(kind),
+        node: (
+          <IsoElement
+            key={`annotation-${annotation.id}`}
+            label={`${annotation.label} (${KIND_LABELS[kind]})`}
+            isSelected={selected?.kind === 'annotation' && selected.id === annotation.id}
+            onSelect={() => onSelect({ kind: 'annotation', id: annotation.id })}
+            shouldIgnoreClick={shouldIgnoreClick}
+          >
+            <IsoAnnotation
+              annotation={annotation}
+              isSelected={selected?.kind === 'annotation' && selected.id === annotation.id}
+            />
+          </IsoElement>
+        ),
+      });
+    }
+    for (const bed of beds) {
+      const crops = cropsByBedId.get(bed.id) ?? [];
+      list.push({
+        key: `bed-${bed.id}`,
+        depth: depthOf(bedFootprint(bed)),
+        flat: false,
+        node: (
+          <IsoElement
+            key={`bed-${bed.id}`}
+            label={`${bed.name} (${bed.bedType === 'raised' ? 'raised bed' : bed.bedType === 'mound' ? 'mound' : 'in-ground bed'}${crops.length > 0 ? `, ${crops.length} crop${crops.length === 1 ? '' : 's'}` : ''})`}
+            isSelected={selected?.kind === 'bed' && selected.id === bed.id}
+            onSelect={() => onSelect({ kind: 'bed', id: bed.id })}
+            shouldIgnoreClick={shouldIgnoreClick}
+          >
+            <IsoBed
+              bed={bed}
+              crops={crops}
+              isSelected={selected?.kind === 'bed' && selected.id === bed.id}
+            />
+          </IsoElement>
+        ),
+      });
+    }
+    // Painter's algorithm: ground-level surfaces first, then volumes from
+    // back (north-west) to front (south-east).
+    list.sort((a, b) => Number(b.flat) - Number(a.flat) || a.depth - b.depth);
+    return list;
+  }, [annotations, beds, cropsByBedId, onSelect, selected, shouldIgnoreClick]);
+
+  // Compass + scale bar live in screen space at the plate corners.
+  const plate = boundsOf(
+    projectFootprint([
+      { x: 0, y: 0 },
+      { x: w, y: 0 },
+      { x: w, y: h },
+      { x: 0, y: h },
+    ])
+  );
+  const compass = { x: plate.maxX + 38, y: plate.minY + 6 };
+  const scaleBar = {
+    x: plate.minX + 4,
+    y: plate.maxY + 42,
+    dx: 48 * ISO_COS * PX_PER_INCH,
+    dy: 48 * ISO_SIN * PX_PER_INCH,
+  };
+
+  function handleBackgroundClick() {
+    if (shouldIgnoreClick()) return;
+    onSelect(null);
+  }
+
+  return (
+    <svg
+      className="mp-scene"
+      width={metrics.width}
+      height={metrics.height}
+      viewBox={metrics.viewBox}
+      role="group"
+      aria-label="Garden masterplan map"
+      onClick={handleBackgroundClick}
+    >
+      <g className="mp-ground" aria-hidden="true">
+        <path d={ground.shadow} fill={SCENE.groundShadow} />
+        <path d={ground.lawn} fill={SCENE.lawn} />
+        <path d={ground.wash} fill={SCENE.lawnLight} opacity={0.65} />
+        <path
+          d={ground.contourA}
+          fill="none"
+          stroke={SCENE.contour}
+          strokeWidth={1}
+          strokeDasharray="2 7"
+          strokeLinecap="round"
+        />
+        <path
+          d={ground.contourB}
+          fill="none"
+          stroke={SCENE.contour}
+          strokeWidth={1}
+          strokeDasharray="2 9"
+          strokeLinecap="round"
+        />
+      </g>
+      <g className="mp-elements">{items.map((item) => item.node)}</g>
+      <g
+        className="mp-compass"
+        aria-hidden="true"
+        transform={`translate(${compass.x} ${compass.y})`}
+      >
+        <circle r={15} fill={SCENE.labelHalo} stroke={SCENE.contour} strokeWidth={1} />
+        <g transform={`rotate(${canvas.northOffsetDeg})`}>
+          <path d="M0 -10 L4 4 L0 1 L-4 4 Z" fill={SCENE.label} />
+        </g>
+        <text className="mp-compass__n" y={26} textAnchor="middle">
+          N
+        </text>
+      </g>
+      <g className="mp-scalebar" aria-hidden="true">
+        <line
+          x1={scaleBar.x}
+          y1={scaleBar.y}
+          x2={scaleBar.x + scaleBar.dx}
+          y2={scaleBar.y + scaleBar.dy}
+          stroke={SCENE.label}
+          strokeWidth={1.4}
+        />
+        <line
+          x1={scaleBar.x}
+          y1={scaleBar.y - 4}
+          x2={scaleBar.x}
+          y2={scaleBar.y + 4}
+          stroke={SCENE.label}
+          strokeWidth={1.4}
+        />
+        <line
+          x1={scaleBar.x + scaleBar.dx}
+          y1={scaleBar.y + scaleBar.dy - 4}
+          x2={scaleBar.x + scaleBar.dx}
+          y2={scaleBar.y + scaleBar.dy + 4}
+          stroke={SCENE.label}
+          strokeWidth={1.4}
+        />
+        <text
+          className="mp-label"
+          x={scaleBar.x + scaleBar.dx / 2 + 10}
+          y={scaleBar.y + scaleBar.dy / 2 + 2}
+        >
+          4 ft
+        </text>
+      </g>
+    </svg>
+  );
+});

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
@@ -1,0 +1,184 @@
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GrowerCropItem,
+  SunExposure,
+} from '../../types/listing';
+import {
+  bedAreaSquareInches,
+  bedTypeMeta,
+  formatArea,
+  parseSoilField,
+  soilLabel,
+} from '../GardenDesigner/bedDefaults';
+import { CROP_ICON_PATHS } from '../CropPlanner/cropIconPaths';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { KIND_LABELS, annotationKind, mute } from './palette';
+
+const SUN_LABELS: Record<SunExposure, string> = {
+  full_sun: 'Full sun',
+  partial_sun: 'Partial sun',
+  partial_shade: 'Partial shade',
+  full_shade: 'Full shade',
+  mixed: 'Mixed',
+};
+
+function formatFeet(inches: number | null): string {
+  if (!inches) return '—';
+  const feet = inches / 12;
+  return feet >= 1 ? `${Math.round(feet * 10) / 10} ft` : `${Math.round(inches)} in`;
+}
+
+interface MasterplanDetailPanelProps {
+  bed?: GardenBed;
+  annotation?: GardenAnnotation;
+  crops: GrowerCropItem[];
+  onClose: () => void;
+  onOpenLayoutEditor: () => void;
+}
+
+/**
+ * Floating detail card shown over the masterplan when an element is
+ * selected. Read-focused: it surfaces what the element is and what's
+ * growing there, plus a jump into the layout editor for changes. The map
+ * stays visible and navigable behind it.
+ */
+export function MasterplanDetailPanel({
+  bed,
+  annotation,
+  crops,
+  onClose,
+  onOpenLayoutEditor,
+}: MasterplanDetailPanelProps) {
+  if (!bed && !annotation) return null;
+
+  const title = bed ? bed.name : annotation?.label ?? '';
+  const kicker = bed
+    ? `${bedTypeMeta(bed.bedType).label} · ${formatArea(
+        bedAreaSquareInches({
+          shape: bed.shape,
+          lengthInches: bed.lengthInches,
+          widthInches: bed.widthInches,
+          points: bed.points,
+        })
+      )}`
+    : annotation
+      ? KIND_LABELS[annotationKind(annotation)]
+      : '';
+
+  const soils = bed ? parseSoilField(bed.soilType) : [];
+
+  return (
+    <aside
+      className="mp-panel"
+      role="dialog"
+      aria-label={`${title} details`}
+      data-testid="masterplan-detail-panel"
+    >
+      <header className="mp-panel__header">
+        <div>
+          <p className="mp-panel__kicker">{kicker}</p>
+          <h2 className="mp-panel__title">{title}</h2>
+        </div>
+        <button
+          type="button"
+          className="mp-panel__close"
+          onClick={onClose}
+          aria-label="Close details"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="mp-panel__body">
+        {bed?.description && <p className="mp-panel__description">{bed.description}</p>}
+
+        <dl className="mp-panel__meta">
+          {bed && (
+            <div className="mp-panel__meta-row">
+              <dt>Size</dt>
+              <dd>
+                {formatFeet(bed.lengthInches)} × {formatFeet(bed.widthInches)}
+              </dd>
+            </div>
+          )}
+          {bed?.sunExposure && (
+            <div className="mp-panel__meta-row">
+              <dt>Sun</dt>
+              <dd>{SUN_LABELS[bed.sunExposure]}</dd>
+            </div>
+          )}
+          {soils.length > 0 && (
+            <div className="mp-panel__meta-row">
+              <dt>Soil</dt>
+              <dd>
+                <span className="mp-panel__chips">
+                  {soils.map((soil) => (
+                    <span key={soil} className="mp-panel__chip">
+                      {soilLabel(soil)}
+                    </span>
+                  ))}
+                </span>
+              </dd>
+            </div>
+          )}
+          {annotation && (
+            <div className="mp-panel__meta-row">
+              <dt>Size</dt>
+              <dd>
+                {formatFeet(annotation.lengthInches)} × {formatFeet(annotation.widthInches)}
+              </dd>
+            </div>
+          )}
+        </dl>
+
+        {bed && (
+          <section className="mp-panel__crops" aria-label="Crops in this bed">
+            <h3 className="mp-panel__section-title">
+              {crops.length > 0
+                ? `Growing here (${crops.length})`
+                : 'Nothing planted yet'}
+            </h3>
+            {crops.length > 0 && (
+              <ul className="mp-panel__crop-list">
+                {crops.map((crop) => {
+                  const visual = visualForCrop(crop.cropName);
+                  return (
+                    <li key={crop.id} className="mp-panel__crop">
+                      <svg
+                        className="mp-panel__crop-icon"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path
+                          d={CROP_ICON_PATHS[visual.iconKey]}
+                          fill={mute(visual.accent, 0.15)}
+                        />
+                      </svg>
+                      <span className="mp-panel__crop-name">
+                        {crop.nickname || crop.cropName}
+                      </span>
+                      {crop.plantCount != null && crop.plantCount > 0 && (
+                        <span className="mp-panel__crop-count">×{crop.plantCount}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        )}
+
+        {bed?.locationNotes && (
+          <p className="mp-panel__notes">{bed.locationNotes}</p>
+        )}
+      </div>
+
+      <footer className="mp-panel__footer">
+        <button type="button" className="mp-panel__action" onClick={onOpenLayoutEditor}>
+          Edit in layout editor
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/grn/src/components/GardenMasterplan/iso.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/iso.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ISO_COS,
+  ISO_SIN,
+  PX_PER_INCH,
+  Z_PER_INCH,
+  boundsOf,
+  depthOf,
+  ellipseFootprint,
+  extrude,
+  hashSeed,
+  insetFootprint,
+  polygonFootprint,
+  project,
+  rectFootprint,
+  scaleFootprint,
+  smoothClosedPath,
+  toPath,
+  worldCentroid,
+} from './iso';
+
+describe('project', () => {
+  it('maps the world origin to the screen origin', () => {
+    expect(project(0, 0)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('projects +x down-right and +y down-left symmetrically', () => {
+    const px = project(10, 0);
+    const py = project(0, 10);
+    expect(px.x).toBeCloseTo(10 * ISO_COS * PX_PER_INCH);
+    expect(px.y).toBeCloseTo(10 * ISO_SIN * PX_PER_INCH);
+    expect(py.x).toBeCloseTo(-px.x);
+    expect(py.y).toBeCloseTo(px.y);
+  });
+
+  it('moves points straight up with height', () => {
+    const ground = project(24, 36, 0);
+    const raised = project(24, 36, 10);
+    expect(raised.x).toBeCloseTo(ground.x);
+    expect(raised.y).toBeCloseTo(ground.y - 10 * Z_PER_INCH);
+  });
+});
+
+describe('footprints', () => {
+  it('builds rect corners in order', () => {
+    const fp = rectFootprint({ x: 10, y: 20, length: 40, width: 30 });
+    expect(fp).toEqual([
+      { x: 10, y: 20 },
+      { x: 50, y: 20 },
+      { x: 50, y: 50 },
+      { x: 10, y: 50 },
+    ]);
+  });
+
+  it('rotates rects about their position origin like the layout editor', () => {
+    const fp = rectFootprint({ x: 10, y: 10, length: 20, width: 10, rotationDeg: 90 });
+    expect(fp[0].x).toBeCloseTo(10);
+    expect(fp[0].y).toBeCloseTo(10);
+    // (30, 10) rotated 90° about (10, 10) -> (10, 30)
+    expect(fp[1].x).toBeCloseTo(10);
+    expect(fp[1].y).toBeCloseTo(30);
+  });
+
+  it('approximates ellipses with the requested segment count, centered in their box', () => {
+    const fp = ellipseFootprint({ x: 0, y: 0, length: 48, width: 24, segments: 16 });
+    expect(fp).toHaveLength(16);
+    const c = worldCentroid(fp);
+    expect(c.x).toBeCloseTo(24);
+    expect(c.y).toBeCloseTo(12);
+    for (const p of fp) {
+      // Points satisfy the ellipse equation for semi-axes 24 and 12.
+      const e = ((p.x - 24) / 24) ** 2 + ((p.y - 12) / 12) ** 2;
+      expect(e).toBeCloseTo(1);
+    }
+  });
+
+  it('translates polygon points by the element position', () => {
+    const fp = polygonFootprint({
+      x: 5,
+      y: 7,
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+      ],
+    });
+    expect(fp).toEqual([
+      { x: 5, y: 7 },
+      { x: 15, y: 7 },
+      { x: 5, y: 17 },
+    ]);
+  });
+
+  it('insets vertices toward the centroid', () => {
+    const fp = rectFootprint({ x: 0, y: 0, length: 20, width: 20 });
+    const inset = insetFootprint(fp, 5);
+    const c = worldCentroid(fp);
+    for (let i = 0; i < fp.length; i += 1) {
+      const before = Math.hypot(fp[i].x - c.x, fp[i].y - c.y);
+      const after = Math.hypot(inset[i].x - c.x, inset[i].y - c.y);
+      expect(after).toBeLessThan(before);
+    }
+  });
+
+  it('scales about the centroid without moving it', () => {
+    const fp = rectFootprint({ x: 0, y: 0, length: 30, width: 10 });
+    const scaled = scaleFootprint(fp, 0.5);
+    expect(worldCentroid(scaled)).toEqual(worldCentroid(fp));
+    expect(scaled[0].x).toBeCloseTo(7.5);
+  });
+});
+
+describe('depth sorting', () => {
+  it('orders north-west elements before south-east ones', () => {
+    const back = rectFootprint({ x: 0, y: 0, length: 10, width: 10 });
+    const front = rectFootprint({ x: 100, y: 100, length: 10, width: 10 });
+    expect(depthOf(back)).toBeLessThan(depthOf(front));
+  });
+});
+
+describe('extrude', () => {
+  it('shows exactly the two camera-facing walls of an axis-aligned rect', () => {
+    const fp = rectFootprint({ x: 0, y: 0, length: 40, width: 20 });
+    const solid = extrude(fp, 12);
+    expect(solid.walls).toHaveLength(2);
+    const facings = solid.walls.map((w) => w.facing).sort();
+    expect(facings).toEqual(['left', 'right']);
+  });
+
+  it('lifts the top face by the extrusion height', () => {
+    const fp = rectFootprint({ x: 0, y: 0, length: 40, width: 20 });
+    const solid = extrude(fp, 12);
+    for (let i = 0; i < fp.length; i += 1) {
+      expect(solid.top[i].x).toBeCloseTo(solid.base[i].x);
+      expect(solid.top[i].y).toBeCloseTo(solid.base[i].y - 12 * Z_PER_INCH);
+    }
+  });
+
+  it('builds walls as quads from base to top', () => {
+    const fp = rectFootprint({ x: 0, y: 0, length: 40, width: 20 });
+    const solid = extrude(fp, 12);
+    for (const wall of solid.walls) {
+      expect(wall.points).toHaveLength(4);
+      expect(wall.points[3].y).toBeCloseTo(wall.points[0].y - 12 * Z_PER_INCH);
+    }
+  });
+});
+
+describe('svg path helpers', () => {
+  it('emits closed paths with rounded coordinates', () => {
+    const d = toPath([
+      { x: 0.111111, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+    ]);
+    expect(d).toBe('M0.11 0 L10 0 L10 10 Z');
+  });
+
+  it('smooths closed rings into quadratic segments', () => {
+    const d = smoothClosedPath([
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ]);
+    expect(d.startsWith('M')).toBe(true);
+    expect(d).toContain('Q');
+    expect(d.endsWith('Z')).toBe(true);
+  });
+
+  it('computes bounds across points', () => {
+    const b = boundsOf([
+      { x: -5, y: 2 },
+      { x: 9, y: -3 },
+    ]);
+    expect(b).toEqual({ minX: -5, minY: -3, maxX: 9, maxY: 2 });
+  });
+});
+
+describe('hashSeed', () => {
+  it('is deterministic and within [0, 1)', () => {
+    expect(hashSeed('bed-1')).toBe(hashSeed('bed-1'));
+    expect(hashSeed('bed-1')).not.toBe(hashSeed('bed-2'));
+    const v = hashSeed('anything');
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThan(1);
+  });
+});

--- a/apps/grn/src/components/GardenMasterplan/iso.ts
+++ b/apps/grn/src/components/GardenMasterplan/iso.ts
@@ -1,0 +1,311 @@
+// Isometric projection and low-poly geometry helpers for the garden
+// masterplan view.
+//
+// World coordinates are inches on the ground plane and match the layout
+// editor exactly: x grows east (right), y grows south (down). Screen
+// coordinates are SVG pixels in a classic 30° architectural isometric:
+// the world origin projects to (0, 0), +x runs down-right, +y runs
+// down-left, and +z (height above ground) runs straight up.
+
+import type { BedPolygonPoint } from '../../types/listing';
+
+export interface WorldPoint {
+  x: number;
+  y: number;
+}
+
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
+export const ISO_COS = Math.cos(Math.PI / 6); // ≈ 0.866
+export const ISO_SIN = Math.sin(Math.PI / 6); // 0.5
+
+// Ground scale. The layout editor uses 4 px/inch on a flat canvas; the
+// masterplan renders the whole property at once, so a smaller scale keeps
+// SVG coordinates (and text sizes) manageable before viewport zoom.
+export const PX_PER_INCH = 1.6;
+
+// Vertical scale. Slightly flatter than the ground scale so extruded
+// objects read as gentle relief rather than towers — closer to the look
+// of a landscape architect's axonometric than a video-game world.
+export const Z_PER_INCH = 1.15;
+
+export function project(x: number, y: number, z = 0): ScreenPoint {
+  return {
+    x: (x - y) * ISO_COS * PX_PER_INCH,
+    y: (x + y) * ISO_SIN * PX_PER_INCH - z * Z_PER_INCH,
+  };
+}
+
+export function projectPoint(p: WorldPoint, z = 0): ScreenPoint {
+  return project(p.x, p.y, z);
+}
+
+export function projectFootprint(points: WorldPoint[], z = 0): ScreenPoint[] {
+  return points.map((p) => project(p.x, p.y, z));
+}
+
+// --- Footprints -----------------------------------------------------------
+// Every element is normalized to a world-space polygon ("footprint") so
+// projection, extrusion, shadows, and depth sorting share one code path.
+// Rotation semantics match Konva: shapes rotate about their position
+// origin (the un-rotated top-left corner).
+
+export function rotateWorld(
+  points: WorldPoint[],
+  originX: number,
+  originY: number,
+  rotationDeg: number
+): WorldPoint[] {
+  if (!rotationDeg) return points;
+  const rad = (rotationDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return points.map((p) => {
+    const dx = p.x - originX;
+    const dy = p.y - originY;
+    return {
+      x: originX + dx * cos - dy * sin,
+      y: originY + dx * sin + dy * cos,
+    };
+  });
+}
+
+export function rectFootprint(args: {
+  x: number;
+  y: number;
+  length: number;
+  width: number;
+  rotationDeg?: number;
+}): WorldPoint[] {
+  const { x, y, length, width, rotationDeg = 0 } = args;
+  const corners: WorldPoint[] = [
+    { x, y },
+    { x: x + length, y },
+    { x: x + length, y: y + width },
+    { x, y: y + width },
+  ];
+  return rotateWorld(corners, x, y, rotationDeg);
+}
+
+// Circles/ellipses become low-poly n-gons — on-brand for the flat-shaded
+// look, and it lets them share the polygon extrusion path.
+export function ellipseFootprint(args: {
+  x: number;
+  y: number;
+  length: number;
+  width: number;
+  rotationDeg?: number;
+  segments?: number;
+}): WorldPoint[] {
+  const { x, y, length, width, rotationDeg = 0, segments = 20 } = args;
+  const cx = x + length / 2;
+  const cy = y + width / 2;
+  const rx = length / 2;
+  const ry = width / 2;
+  const points: WorldPoint[] = [];
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    points.push({ x: cx + Math.cos(angle) * rx, y: cy + Math.sin(angle) * ry });
+  }
+  return rotateWorld(points, x, y, rotationDeg);
+}
+
+export function polygonFootprint(args: {
+  x: number;
+  y: number;
+  points: BedPolygonPoint[];
+  rotationDeg?: number;
+}): WorldPoint[] {
+  const { x, y, points, rotationDeg = 0 } = args;
+  const translated = points.map((p) => ({ x: x + p.x, y: y + p.y }));
+  return rotateWorld(translated, x, y, rotationDeg);
+}
+
+export function worldCentroid(points: WorldPoint[]): WorldPoint {
+  if (points.length === 0) return { x: 0, y: 0 };
+  let sx = 0;
+  let sy = 0;
+  for (const p of points) {
+    sx += p.x;
+    sy += p.y;
+  }
+  return { x: sx / points.length, y: sy / points.length };
+}
+
+// Painter's-algorithm key: elements farther "north-west" in the world
+// project higher on screen and must paint first. (x + y) of the centroid
+// is exactly the screen-y of the projected centroid, so sorting by it
+// ascending gives correct near-over-far ordering for non-overlapping
+// footprints.
+export function depthOf(points: WorldPoint[]): number {
+  const c = worldCentroid(points);
+  return c.x + c.y;
+}
+
+// Approximate inset by pulling each vertex toward the centroid. Exact
+// polygon offsetting is overkill for soil-rim effects on convex-ish beds.
+export function insetFootprint(points: WorldPoint[], insetInches: number): WorldPoint[] {
+  const c = worldCentroid(points);
+  return points.map((p) => {
+    const dx = c.x - p.x;
+    const dy = c.y - p.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 1e-6) return p;
+    const t = Math.min(0.9, insetInches / dist);
+    return { x: p.x + dx * t, y: p.y + dy * t };
+  });
+}
+
+export function scaleFootprint(points: WorldPoint[], factor: number): WorldPoint[] {
+  const c = worldCentroid(points);
+  return points.map((p) => ({
+    x: c.x + (p.x - c.x) * factor,
+    y: c.y + (p.y - c.y) * factor,
+  }));
+}
+
+// --- Extrusion ------------------------------------------------------------
+// A footprint extruded to height h renders as: visible side walls (only
+// the camera-facing edges), then the top face. Walls are tagged by which
+// way they face so the renderer can flat-shade them as two tones — the
+// whole "hand-illustrated axonometric" effect comes from that two-tone
+// split plus a lighter top.
+
+export interface ExtrudedWall {
+  points: ScreenPoint[];
+  facing: 'left' | 'right';
+}
+
+export interface ExtrudedShape {
+  top: ScreenPoint[];
+  base: ScreenPoint[];
+  walls: ExtrudedWall[];
+}
+
+export function extrude(footprint: WorldPoint[], heightInches: number): ExtrudedShape {
+  const top = projectFootprint(footprint, heightInches);
+  const base = projectFootprint(footprint, 0);
+  const centroid = worldCentroid(footprint);
+  const walls: ExtrudedWall[] = [];
+
+  for (let i = 0; i < footprint.length; i += 1) {
+    const a = footprint[i];
+    const b = footprint[(i + 1) % footprint.length];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    if (Math.hypot(dx, dy) < 1e-6) continue;
+
+    // Outward normal: of the two perpendiculars, keep the one pointing
+    // away from the centroid so winding order doesn't matter.
+    let nx = dy;
+    let ny = -dx;
+    const mx = (a.x + b.x) / 2;
+    const my = (a.y + b.y) / 2;
+    if (nx * (mx - centroid.x) + ny * (my - centroid.y) < 0) {
+      nx = -nx;
+      ny = -ny;
+    }
+
+    // The camera looks toward -x/-y, so walls whose outward normal has a
+    // positive (x + y) component are visible.
+    if (nx + ny <= 1e-6) continue;
+
+    walls.push({
+      points: [
+        project(a.x, a.y, 0),
+        project(b.x, b.y, 0),
+        project(b.x, b.y, heightInches),
+        project(a.x, a.y, heightInches),
+      ],
+      facing: nx >= ny ? 'right' : 'left',
+    });
+  }
+
+  return { top, base, walls };
+}
+
+// --- SVG path helpers -------------------------------------------------------
+
+function fmt(n: number): string {
+  return String(Math.round(n * 100) / 100);
+}
+
+export function toPath(points: ScreenPoint[], closed = true): string {
+  if (points.length === 0) return '';
+  const segments = points.map(
+    (p, i) => `${i === 0 ? 'M' : 'L'}${fmt(p.x)} ${fmt(p.y)}`
+  );
+  return segments.join(' ') + (closed ? ' Z' : '');
+}
+
+// Midpoint-quadratic smoothing turns an angular footprint into the soft
+// organic blob used for ponds, canopies, and the ground plate. Each
+// vertex becomes the control point of a quadratic segment between the
+// midpoints of its adjacent edges.
+export function smoothClosedPath(points: ScreenPoint[]): string {
+  if (points.length < 3) return toPath(points);
+  const mid = (a: ScreenPoint, b: ScreenPoint): ScreenPoint => ({
+    x: (a.x + b.x) / 2,
+    y: (a.y + b.y) / 2,
+  });
+  const first = mid(points[0], points[1]);
+  let d = `M${fmt(first.x)} ${fmt(first.y)}`;
+  for (let i = 1; i <= points.length; i += 1) {
+    const control = points[i % points.length];
+    const next = points[(i + 1) % points.length];
+    const m = mid(control, next);
+    d += ` Q${fmt(control.x)} ${fmt(control.y)} ${fmt(m.x)} ${fmt(m.y)}`;
+  }
+  return d + ' Z';
+}
+
+export function smoothOpenPath(points: ScreenPoint[]): string {
+  if (points.length < 3) return toPath(points, false);
+  let d = `M${fmt(points[0].x)} ${fmt(points[0].y)}`;
+  for (let i = 1; i < points.length - 1; i += 1) {
+    const control = points[i];
+    const next = points[i + 1];
+    const mx = (control.x + next.x) / 2;
+    const my = (control.y + next.y) / 2;
+    d += ` Q${fmt(control.x)} ${fmt(control.y)} ${fmt(mx)} ${fmt(my)}`;
+  }
+  const last = points[points.length - 1];
+  d += ` L${fmt(last.x)} ${fmt(last.y)}`;
+  return d;
+}
+
+export interface ScreenBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export function boundsOf(points: ScreenPoint[]): ScreenBounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+// Deterministic per-element variation (canopy hue, fruit placement, …)
+// derived from the element id so the map looks organic but never shifts
+// between renders.
+export function hashSeed(id: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < id.length; i += 1) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0) / 4294967296;
+}

--- a/apps/grn/src/components/GardenMasterplan/palette.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/palette.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { GardenAnnotation } from '../../types/listing';
+import { annotationKind, materialFrom, mixHex, mute, shade, tint } from './palette';
+
+function makeAnnotation(overrides: Partial<GardenAnnotation>): GardenAnnotation {
+  return {
+    id: 'a1',
+    userId: 'u1',
+    label: 'Thing',
+    icon: null,
+    shape: 'rect',
+    positionX: 0,
+    positionY: 0,
+    lengthInches: 48,
+    widthInches: 48,
+    rotationDeg: 0,
+    points: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('color math', () => {
+  it('mixes two hex colors linearly', () => {
+    expect(mixHex('#000000', '#ffffff', 0.5)).toBe('#808080');
+    expect(mixHex('#ff0000', '#00ff00', 0)).toBe('#ff0000');
+    expect(mixHex('#ff0000', '#00ff00', 1)).toBe('#00ff00');
+  });
+
+  it('supports shorthand hex', () => {
+    expect(mixHex('#fff', '#fff', 0.5)).toBe('#ffffff');
+  });
+
+  it('shade darkens and tint lightens', () => {
+    const base = '#8aa874';
+    const darker = shade(base, 0.3);
+    const lighter = tint(base, 0.3);
+    const [r] = [parseInt(base.slice(1, 3), 16)];
+    expect(parseInt(darker.slice(1, 3), 16)).toBeLessThan(r);
+    expect(parseInt(lighter.slice(1, 3), 16)).toBeGreaterThan(r);
+  });
+
+  it('mute pulls saturated colors toward warm grey', () => {
+    const muted = mute('#ff0000', 0.5);
+    expect(muted).not.toBe('#ff0000');
+    // Red channel drops, green/blue rise.
+    expect(parseInt(muted.slice(1, 3), 16)).toBeLessThan(255);
+    expect(parseInt(muted.slice(3, 5), 16)).toBeGreaterThan(0);
+  });
+
+  it('builds a material with top lighter than left', () => {
+    const m = materialFrom('#b1906a');
+    expect(parseInt(m.top.slice(1, 3), 16)).toBeGreaterThan(
+      parseInt(m.left.slice(1, 3), 16)
+    );
+  });
+});
+
+describe('annotationKind', () => {
+  it('maps preset icons to kinds', () => {
+    expect(annotationKind(makeAnnotation({ icon: '🌳' }))).toBe('tree');
+    expect(annotationKind(makeAnnotation({ icon: '🍎' }))).toBe('fruitTree');
+    expect(annotationKind(makeAnnotation({ icon: '🫐' }))).toBe('berryBush');
+    expect(annotationKind(makeAnnotation({ icon: '💧' }))).toBe('pond');
+    expect(annotationKind(makeAnnotation({ icon: '🏚️' }))).toBe('shed');
+    expect(annotationKind(makeAnnotation({ icon: '🪴' }))).toBe('greenhouse');
+    expect(annotationKind(makeAnnotation({ icon: '🪜' }))).toBe('trellis');
+    expect(annotationKind(makeAnnotation({ icon: '♻️' }))).toBe('compost');
+    expect(annotationKind(makeAnnotation({ icon: '🚧' }))).toBe('fence');
+    expect(annotationKind(makeAnnotation({ icon: '🛤️' }))).toBe('path');
+    expect(annotationKind(makeAnnotation({ icon: '🐔' }))).toBe('coop');
+    expect(annotationKind(makeAnnotation({ icon: '📍' }))).toBe('marker');
+  });
+
+  it('falls back to label matching when the icon is unknown', () => {
+    expect(annotationKind(makeAnnotation({ label: 'Back greenhouse' }))).toBe('greenhouse');
+    expect(annotationKind(makeAnnotation({ label: 'Chicken coop' }))).toBe('coop');
+    expect(annotationKind(makeAnnotation({ label: 'Peach tree' }))).toBe('fruitTree');
+    expect(annotationKind(makeAnnotation({ label: 'Rain barrel' }))).toBe('pond');
+  });
+
+  it('falls back to geometry when nothing else matches', () => {
+    expect(annotationKind(makeAnnotation({ label: 'Mystery', shape: 'line' }))).toBe('path');
+    expect(annotationKind(makeAnnotation({ label: 'Mystery', shape: 'circle' }))).toBe('tree');
+    expect(annotationKind(makeAnnotation({ label: 'Mystery', shape: 'rect' }))).toBe('marker');
+  });
+});

--- a/apps/grn/src/components/GardenMasterplan/palette.ts
+++ b/apps/grn/src/components/GardenMasterplan/palette.ts
@@ -1,0 +1,227 @@
+// Color system for the masterplan view.
+//
+// The palette is deliberately muted — closer to a landscape architect's
+// marker rendering than to the saturated chips used in the layout editor.
+// Flat shading is derived, not hand-picked: every material starts from a
+// base hex and gets a lighter top face, a mid right face, and a darker
+// left face, which keeps the whole scene tonally consistent.
+
+import type { BedType, GardenAnnotation } from '../../types/listing';
+
+// --- Color math -------------------------------------------------------------
+
+function clamp255(n: number): number {
+  return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.replace('#', '');
+  const full =
+    value.length === 3
+      ? value
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : value;
+  const num = parseInt(full, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b].map((c) => clamp255(c).toString(16).padStart(2, '0')).join('')}`;
+}
+
+export function mixHex(hex: string, other: string, t: number): string {
+  const [r1, g1, b1] = hexToRgb(hex);
+  const [r2, g2, b2] = hexToRgb(other);
+  return rgbToHex(r1 + (r2 - r1) * t, g1 + (g2 - g1) * t, b1 + (b2 - b1) * t);
+}
+
+// Shadows mix toward a deep olive-umber rather than black so darkened
+// faces stay warm and natural.
+const SHADE_TARGET = '#2c2b1f';
+const TINT_TARGET = '#fdfaf1';
+const MUTE_TARGET = '#b3ac99';
+
+export function shade(hex: string, t: number): string {
+  return mixHex(hex, SHADE_TARGET, t);
+}
+
+export function tint(hex: string, t: number): string {
+  return mixHex(hex, TINT_TARGET, t);
+}
+
+// Pulls a saturated user-picked color toward warm grey so custom bed
+// colors sit comfortably in the muted scene.
+export function mute(hex: string, t = 0.4): string {
+  return mixHex(hex, MUTE_TARGET, t);
+}
+
+export interface IsoMaterial {
+  top: string;
+  right: string;
+  left: string;
+}
+
+export function materialFrom(base: string): IsoMaterial {
+  return {
+    top: tint(base, 0.1),
+    right: shade(base, 0.18),
+    left: shade(base, 0.34),
+  };
+}
+
+// --- Scene palette ----------------------------------------------------------
+
+export const SCENE = {
+  paper: '#f7f2e7',
+  groundShadow: 'rgba(76, 69, 50, 0.16)',
+  lawn: '#c3cda4',
+  lawnLight: '#cdd6b0',
+  lawnBand: 'rgba(253, 250, 241, 0.25)',
+  contour: 'rgba(86, 96, 64, 0.25)',
+  elementShadow: 'rgba(58, 54, 38, 0.22)',
+  elementShadowSoft: 'rgba(58, 54, 38, 0.1)',
+  label: '#3c3527',
+  labelHalo: 'rgba(247, 242, 231, 0.9)',
+  selection: '#a8632f',
+
+  soil: '#9a7c5c',
+  soilDark: '#7c6248',
+  wood: '#b1906a',
+  woodDark: '#8d6f4e',
+  stone: '#d9d3c2',
+  stoneEdge: '#b9b09a',
+  sand: '#e2d8bd',
+  water: '#a7c4cb',
+  waterDeep: '#86a9b4',
+  waterEdge: '#7d9da9',
+  trunk: '#8a6a4d',
+  terracotta: '#c08a68',
+  glass: '#d5e3da',
+  glassFrame: '#9eb3a6',
+  compost: '#6f5a40',
+  fence: '#a98f6c',
+  coop: '#b3826a',
+  marker: '#b8aa90',
+} as const;
+
+// A small set of muted foliage greens; trees pick one deterministically
+// so a row of trees reads as varied planting rather than copy-paste.
+export const FOLIAGE: string[] = ['#8aa874', '#7b9c6b', '#9bb182', '#6f9162'];
+
+export const FOLIAGE_FRUIT = '#86a86e';
+export const FOLIAGE_BERRY = '#5f7f55';
+export const FRUIT_DOT = '#c2674f';
+export const BERRY_DOT = '#6d5d94';
+
+// --- Bed materials ----------------------------------------------------------
+
+export interface BedPaletteResult {
+  frame: IsoMaterial;
+  soilTop: string;
+  soilEdge: string;
+}
+
+export function bedPalette(bedType: BedType, color: string | null): BedPaletteResult {
+  const frameBase = color ? mute(color, 0.45) : bedTypeBase(bedType);
+  return {
+    frame: materialFrom(frameBase),
+    soilTop: SCENE.soil,
+    soilEdge: SCENE.soilDark,
+  };
+}
+
+function bedTypeBase(bedType: BedType): string {
+  switch (bedType) {
+    case 'raised':
+      return SCENE.wood;
+    case 'mound':
+      return SCENE.soil;
+    case 'in_ground':
+    default:
+      return '#8c9a6e';
+  }
+}
+
+// --- Annotation kinds ---------------------------------------------------------
+// Annotations are generic records (label + icon + geometry); the
+// masterplan maps them onto a richer visual vocabulary. The stored icon
+// emoji is the primary discriminator, the label a fallback for renamed
+// items, and the geometry a last resort.
+
+export type AnnotationKind =
+  | 'tree'
+  | 'fruitTree'
+  | 'berryBush'
+  | 'pond'
+  | 'shed'
+  | 'greenhouse'
+  | 'trellis'
+  | 'compost'
+  | 'fence'
+  | 'path'
+  | 'coop'
+  | 'marker';
+
+const ICON_TO_KIND: Record<string, AnnotationKind> = {
+  '🌳': 'tree',
+  '🌲': 'tree',
+  '🍎': 'fruitTree',
+  '🍏': 'fruitTree',
+  '🍑': 'fruitTree',
+  '🫐': 'berryBush',
+  '🍓': 'berryBush',
+  '💧': 'pond',
+  '⛲': 'pond',
+  '🏚️': 'shed',
+  '🏠': 'shed',
+  '🪴': 'greenhouse',
+  '🪜': 'trellis',
+  '♻️': 'compost',
+  '🚧': 'fence',
+  '🛤️': 'path',
+  '🐔': 'coop',
+  '📍': 'marker',
+};
+
+const LABEL_TO_KIND: Array<{ match: RegExp; kind: AnnotationKind }> = [
+  { match: /greenhouse|hoop ?house|cold frame/i, kind: 'greenhouse' },
+  { match: /trellis|arbor|pergola|arch/i, kind: 'trellis' },
+  { match: /compost|worm bin/i, kind: 'compost' },
+  { match: /fence|gate/i, kind: 'fence' },
+  { match: /path|walk|gravel|trail/i, kind: 'path' },
+  { match: /chicken|coop|duck|rabbit|goat|hive|animal|run\b/i, kind: 'coop' },
+  { match: /pond|water|fountain|rain barrel|birdbath/i, kind: 'pond' },
+  { match: /apple|pear|peach|plum|cherry|citrus|fig|fruit tree|orchard/i, kind: 'fruitTree' },
+  { match: /berry|bush|currant|shrub/i, kind: 'berryBush' },
+  { match: /tree|maple|oak|willow/i, kind: 'tree' },
+  { match: /shed|barn|garage|studio/i, kind: 'shed' },
+];
+
+export function annotationKind(annotation: GardenAnnotation): AnnotationKind {
+  if (annotation.icon && ICON_TO_KIND[annotation.icon]) {
+    return ICON_TO_KIND[annotation.icon];
+  }
+  for (const { match, kind } of LABEL_TO_KIND) {
+    if (match.test(annotation.label)) return kind;
+  }
+  if (annotation.shape === 'line') return 'path';
+  if (annotation.shape === 'circle') return 'tree';
+  return 'marker';
+}
+
+export const KIND_LABELS: Record<AnnotationKind, string> = {
+  tree: 'Tree',
+  fruitTree: 'Fruit tree',
+  berryBush: 'Berry bush',
+  pond: 'Water feature',
+  shed: 'Shed',
+  greenhouse: 'Greenhouse',
+  trellis: 'Trellis',
+  compost: 'Compost',
+  fence: 'Fence',
+  path: 'Path',
+  coop: 'Animal enclosure',
+  marker: 'Landmark',
+};

--- a/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
+++ b/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
@@ -1,0 +1,287 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+// Pan/zoom controller for the masterplan. The scene SVG renders once at
+// its natural size and the hook moves it with a single translate3d/scale
+// transform on a wrapper div — the browser composites that on the GPU,
+// so navigation stays smooth no matter how many elements the SVG holds.
+//
+// Gestures: drag to pan (mouse or single touch), wheel/trackpad to zoom
+// at the cursor, two-finger pinch to zoom at the gesture midpoint,
+// double-click/tap to zoom in a step. A small movement threshold keeps
+// click-to-select working: shouldIgnoreClick() reports whether the
+// gesture that just ended was actually a drag.
+
+const MIN_SCALE = 0.3;
+const MAX_SCALE = 4;
+const FIT_PADDING = 36;
+const BUTTON_ZOOM_STEP = 1.3;
+const DRAG_THRESHOLD_PX = 6;
+// Keep at least this much of the scene visible so it can't be flung
+// entirely off screen.
+const MIN_VISIBLE_PX = 90;
+
+interface Transform {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+export interface MapViewport {
+  containerRef: (node: HTMLDivElement | null) => void;
+  containerHandlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onPointerCancel: (event: ReactPointerEvent<HTMLDivElement>) => void;
+    onDoubleClick: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  };
+  contentStyle: CSSProperties;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  fitToScreen: () => void;
+  shouldIgnoreClick: () => boolean;
+}
+
+export function useMapViewport(contentWidth: number, contentHeight: number): MapViewport {
+  const [transform, setTransform] = useState<Transform>({ scale: 1, x: 0, y: 0 });
+  const transformRef = useRef(transform);
+  transformRef.current = transform;
+
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const wheelCleanupRef = useRef<(() => void) | null>(null);
+  const sizeRef = useRef({ width: 0, height: 0 });
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const fittedRef = useRef(false);
+
+  // Active pointers for pan/pinch. Pinch state snapshots the transform at
+  // gesture start so each move is computed absolutely (no drift).
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const draggedRef = useRef(false);
+  const lastPanRef = useRef<{ x: number; y: number } | null>(null);
+  const pinchRef = useRef<{
+    startDistance: number;
+    startMid: { x: number; y: number };
+    start: Transform;
+  } | null>(null);
+
+  const clampTransform = useCallback(
+    (next: Transform): Transform => {
+      const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, next.scale));
+      const { width, height } = sizeRef.current;
+      if (width === 0 || height === 0) return { ...next, scale };
+      const minX = MIN_VISIBLE_PX - contentWidth * scale;
+      const maxX = width - MIN_VISIBLE_PX;
+      const minY = MIN_VISIBLE_PX - contentHeight * scale;
+      const maxY = height - MIN_VISIBLE_PX;
+      return {
+        scale,
+        x: Math.max(minX, Math.min(maxX, next.x)),
+        y: Math.max(minY, Math.min(maxY, next.y)),
+      };
+    },
+    [contentWidth, contentHeight]
+  );
+
+  const fitToScreen = useCallback(() => {
+    const { width, height } = sizeRef.current;
+    if (width === 0 || height === 0 || contentWidth === 0 || contentHeight === 0) return;
+    const scale = Math.max(
+      MIN_SCALE,
+      Math.min(
+        MAX_SCALE,
+        Math.min(
+          (width - FIT_PADDING * 2) / contentWidth,
+          (height - FIT_PADDING * 2) / contentHeight
+        )
+      )
+    );
+    setTransform({
+      scale,
+      x: (width - contentWidth * scale) / 2,
+      y: (height - contentHeight * scale) / 2,
+    });
+  }, [contentWidth, contentHeight]);
+
+  const zoomAt = useCallback(
+    (cx: number, cy: number, factor: number) => {
+      const current = transformRef.current;
+      const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, current.scale * factor));
+      if (scale === current.scale) return;
+      const worldX = (cx - current.x) / current.scale;
+      const worldY = (cy - current.y) / current.scale;
+      setTransform(
+        clampTransform({ scale, x: cx - worldX * scale, y: cy - worldY * scale })
+      );
+    },
+    [clampTransform]
+  );
+
+  const zoomAtCenter = useCallback(
+    (factor: number) => {
+      const { width, height } = sizeRef.current;
+      zoomAt(width / 2, height / 2, factor);
+    },
+    [zoomAt]
+  );
+
+  // Callback ref so wheel (non-passive) + ResizeObserver bind to whatever
+  // node React gives us, including remounts.
+  const containerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      wheelCleanupRef.current?.();
+      wheelCleanupRef.current = null;
+      nodeRef.current = node;
+      if (!node) return;
+
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        sizeRef.current = {
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        };
+        if (!fittedRef.current && sizeRef.current.width > 0) {
+          fittedRef.current = true;
+          fitToScreen();
+        }
+      });
+      observer.observe(node);
+      observerRef.current = observer;
+
+      const onWheel = (event: WheelEvent) => {
+        event.preventDefault();
+        const rect = node.getBoundingClientRect();
+        // Trackpad pinches arrive as ctrl+wheel with fine deltas;
+        // discrete mouse wheels send large deltas. Normalize both to a
+        // gentle exponential zoom.
+        const intensity = event.ctrlKey ? 0.012 : 0.0022;
+        const factor = Math.exp(-event.deltaY * intensity);
+        zoomAt(event.clientX - rect.left, event.clientY - rect.top, factor);
+      };
+      node.addEventListener('wheel', onWheel, { passive: false });
+      wheelCleanupRef.current = () => node.removeEventListener('wheel', onWheel);
+    },
+    [fitToScreen, zoomAt]
+  );
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+      wheelCleanupRef.current?.();
+    },
+    []
+  );
+
+  function localPoint(event: ReactPointerEvent<HTMLDivElement>) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+  }
+
+  function onPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
+    const p = localPoint(event);
+    pointersRef.current.set(event.pointerId, p);
+    draggedRef.current = false;
+    if (pointersRef.current.size === 1) {
+      // Don't capture yet: capturing on pointerdown would retarget the
+      // eventual click to this container and break element selection.
+      // Capture starts when real dragging starts (below).
+      lastPanRef.current = p;
+      pinchRef.current = null;
+    } else if (pointersRef.current.size === 2) {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      const [a, b] = [...pointersRef.current.values()];
+      pinchRef.current = {
+        startDistance: Math.hypot(b.x - a.x, b.y - a.y),
+        startMid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+        start: transformRef.current,
+      };
+      lastPanRef.current = null;
+    }
+  }
+
+  function onPointerMove(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!pointersRef.current.has(event.pointerId)) return;
+    const p = localPoint(event);
+    const previous = pointersRef.current.get(event.pointerId);
+    pointersRef.current.set(event.pointerId, p);
+
+    const pinch = pinchRef.current;
+    if (pinch && pointersRef.current.size >= 2) {
+      const [a, b] = [...pointersRef.current.values()];
+      const distance = Math.hypot(b.x - a.x, b.y - a.y);
+      const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+      const ratio = pinch.startDistance > 0 ? distance / pinch.startDistance : 1;
+      const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, pinch.start.scale * ratio));
+      // Anchor on the starting midpoint so the world tracks the fingers;
+      // midpoint drift doubles as two-finger pan.
+      const worldX = (pinch.startMid.x - pinch.start.x) / pinch.start.scale;
+      const worldY = (pinch.startMid.y - pinch.start.y) / pinch.start.scale;
+      draggedRef.current = true;
+      setTransform(
+        clampTransform({ scale, x: mid.x - worldX * scale, y: mid.y - worldY * scale })
+      );
+      return;
+    }
+
+    if (lastPanRef.current && previous) {
+      const dx = p.x - lastPanRef.current.x;
+      const dy = p.y - lastPanRef.current.y;
+      if (!draggedRef.current && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+      if (!draggedRef.current) {
+        // The gesture is now a pan: capture so it survives leaving the
+        // container, and so the click that fires on release is ignored.
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+      draggedRef.current = true;
+      lastPanRef.current = p;
+      const current = transformRef.current;
+      setTransform(clampTransform({ ...current, x: current.x + dx, y: current.y + dy }));
+    }
+  }
+
+  function onPointerUp(event: ReactPointerEvent<HTMLDivElement>) {
+    pointersRef.current.delete(event.pointerId);
+    if (pointersRef.current.size < 2) pinchRef.current = null;
+    if (pointersRef.current.size === 1) {
+      lastPanRef.current = [...pointersRef.current.values()][0];
+    } else if (pointersRef.current.size === 0) {
+      lastPanRef.current = null;
+    }
+  }
+
+  function onDoubleClick(event: ReactPointerEvent<HTMLDivElement>) {
+    const p = localPoint(event);
+    zoomAt(p.x, p.y, 1.6);
+  }
+
+  return {
+    containerRef,
+    containerHandlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+      onDoubleClick,
+    },
+    contentStyle: {
+      width: contentWidth,
+      height: contentHeight,
+      transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(${transform.scale})`,
+      transformOrigin: '0 0',
+      willChange: 'transform',
+    },
+    zoomIn: () => zoomAtCenter(BUTTON_ZOOM_STEP),
+    zoomOut: () => zoomAtCenter(1 / BUTTON_ZOOM_STEP),
+    fitToScreen,
+    shouldIgnoreClick: () => draggedRef.current,
+  };
+}

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -8,12 +8,27 @@ import {
 } from '../components/GardenDesigner/Canvas';
 import { GardenPropertiesBar } from '../components/GardenDesigner/GardenPropertiesBar';
 import { Toolbar } from '../components/GardenDesigner/Toolbar';
+import { GardenMasterplan } from '../components/GardenMasterplan/GardenMasterplan';
 import { useGardenDesigner } from '../hooks/useGardenDesigner';
 
+type GardenView = 'masterplan' | 'layout';
+
+/**
+ * The garden page hosts two complementary views of the same data:
+ *
+ * - Masterplan (default): an illustrated isometric map for exploring the
+ *   property. Clicking an element opens a floating detail card.
+ * - Layout editor: the original top-down canvas for moving, resizing,
+ *   drawing, and editing beds and landmarks.
+ *
+ * Selection is shared, so jumping from the masterplan into the editor
+ * lands with the same element selected and its inspector open.
+ */
 export function GardenDesignerPage() {
   const designer = useGardenDesigner();
   const canvasRef = useRef<DesignerCanvasHandle | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [view, setView] = useState<GardenView>('masterplan');
 
   if (designer.isLoading) {
     return (
@@ -39,7 +54,16 @@ export function GardenDesignerPage() {
   }
 
   const inspectorOpen =
-    designer.selectedBed !== undefined || designer.selectedAnnotation !== undefined;
+    view === 'layout' &&
+    (designer.selectedBed !== undefined || designer.selectedAnnotation !== undefined);
+
+  function switchView(next: GardenView) {
+    if (next === 'masterplan') {
+      // Drawing only exists in the editor; never leave it armed.
+      designer.setMode('idle');
+    }
+    setView(next);
+  }
 
   async function handlePickBackgroundFile(file: File) {
     setUploadError(null);
@@ -59,122 +83,155 @@ export function GardenDesignerPage() {
     >
       <header className="grn-designer-page__header">
         <div className="grn-designer-page__title-block">
-          <h1 className="grn-designer-page__title">Garden designer</h1>
+          <h1 className="grn-designer-page__title">Garden</h1>
           <p className="grn-designer-page__subtitle">
-            Lay out your beds, drop in crops, and watch it come together.
+            {view === 'masterplan'
+              ? 'An illustrated masterplan of your growing space — click anything to explore.'
+              : 'Lay out your beds, drop in crops, and watch it come together.'}
           </p>
         </div>
-        {designer.beds.length === 0 && designer.annotations.length === 0 && (
-          <p className="grn-designer-page__hint">
-            Start by adding a bed or a landmark from the toolbar on the left.
-          </p>
-        )}
+        <div className="grn-view-toggle" role="group" aria-label="Garden view">
+          <button
+            type="button"
+            className={`grn-view-toggle__btn ${
+              view === 'masterplan' ? 'is-active' : ''
+            }`}
+            aria-pressed={view === 'masterplan'}
+            onClick={() => switchView('masterplan')}
+          >
+            Masterplan
+          </button>
+          <button
+            type="button"
+            className={`grn-view-toggle__btn ${view === 'layout' ? 'is-active' : ''}`}
+            aria-pressed={view === 'layout'}
+            onClick={() => switchView('layout')}
+          >
+            Layout editor
+          </button>
+        </div>
       </header>
 
-      <GardenPropertiesBar
-        canvas={designer.canvas}
-        beds={designer.beds}
-        annotations={designer.annotations}
-        isEditable={designer.isEditable}
-        isSaving={designer.isSaving}
-        isMobile={designer.isMobile}
-        onCanvasChange={designer.patchCanvas}
-        hasBackground={Boolean(designer.canvas.backgroundImageKey)}
-        onPickBackgroundFile={handlePickBackgroundFile}
-        onClearBackground={() => {
-          setUploadError(null);
-          void designer.clearBackgroundImage();
-        }}
-      />
-
-      {uploadError && (
-        <div className="grn-designer-page__error" role="alert">
-          {uploadError}
-        </div>
-      )}
-
-      <div className="grn-designer-page__layout">
-        <Toolbar
-          isMobile={designer.isMobile}
-          mode={designer.mode}
-          onAddBed={(shape) => {
-            void designer.addBed(shape);
-          }}
-          onAddAnnotation={(presetId) => {
-            void designer.addAnnotation(presetId);
-          }}
-          onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
-          onCancelDrawingPolygon={() => designer.setMode('idle')}
-          gridSnap={designer.snap}
-          onGridSnapChange={designer.setSnap}
-          onFitToScreen={() => canvasRef.current?.fitToScreen()}
-        />
-
-        <DesignerCanvas
-          ref={canvasRef}
+      {view === 'masterplan' ? (
+        <GardenMasterplan
           canvas={designer.canvas}
           beds={designer.beds}
           annotations={designer.annotations}
           cropsByBedId={designer.cropsByBedId}
           selected={designer.selected}
-          isEditable={designer.isEditable}
-          mode={designer.mode}
-          snap={designer.snap}
-          backgroundImageUrl={designer.canvas.backgroundImageUrl}
+          selectedBed={designer.selectedBed}
+          selectedAnnotation={designer.selectedAnnotation}
           onSelect={designer.setSelected}
-          onMoveBed={designer.moveBed}
-          onResizeBed={designer.resizeBed}
-          onMoveAnnotation={designer.moveAnnotation}
-          onResizeAnnotation={designer.resizeAnnotation}
-          onCommitPolygon={(points) => {
-            void designer.commitPolygon(points);
-          }}
-          onCancelPolygon={() => designer.setMode('idle')}
+          onOpenLayoutEditor={() => switchView('layout')}
         />
-
-        {designer.selectedBed && (
-          <BedInspector
-            key={designer.selectedBed.id}
-            bed={designer.selectedBed}
-            cropsForBed={designer.cropsByBedId.get(designer.selectedBed.id) ?? []}
+      ) : (
+        <>
+          <GardenPropertiesBar
+            canvas={designer.canvas}
+            beds={designer.beds}
+            annotations={designer.annotations}
             isEditable={designer.isEditable}
             isSaving={designer.isSaving}
             isMobile={designer.isMobile}
-            onChange={(patch) => {
-              if (designer.selectedBed) {
-                designer.patchBed(designer.selectedBed.id, patch);
-              }
+            onCanvasChange={designer.patchCanvas}
+            hasBackground={Boolean(designer.canvas.backgroundImageKey)}
+            onPickBackgroundFile={handlePickBackgroundFile}
+            onClearBackground={() => {
+              setUploadError(null);
+              void designer.clearBackgroundImage();
             }}
-            onDelete={() => {
-              if (designer.selectedBed) {
-                void designer.deleteBed(designer.selectedBed.id);
-              }
-            }}
-            onClose={() => designer.setSelected(null)}
           />
-        )}
 
-        {designer.selectedAnnotation && (
-          <AnnotationInspector
-            key={designer.selectedAnnotation.id}
-            annotation={designer.selectedAnnotation}
-            isEditable={designer.isEditable}
-            isSaving={designer.isSaving}
-            isMobile={designer.isMobile}
-            onChange={(patch) => {
-              if (designer.selectedAnnotation) {
-                designer.patchAnnotation(designer.selectedAnnotation.id, patch);
-              }
-            }}
-            onDelete={() => {
-              if (designer.selectedAnnotation) {
-                void designer.deleteAnnotation(designer.selectedAnnotation.id);
-              }
-            }}
-            onClose={() => designer.setSelected(null)}
-          />
-        )}
-      </div>
+          {uploadError && (
+            <div className="grn-designer-page__error" role="alert">
+              {uploadError}
+            </div>
+          )}
+
+          <div className="grn-designer-page__layout">
+            <Toolbar
+              isMobile={designer.isMobile}
+              mode={designer.mode}
+              onAddBed={(shape) => {
+                void designer.addBed(shape);
+              }}
+              onAddAnnotation={(presetId) => {
+                void designer.addAnnotation(presetId);
+              }}
+              onStartDrawingPolygon={() => designer.setMode('drawing-polygon')}
+              onCancelDrawingPolygon={() => designer.setMode('idle')}
+              gridSnap={designer.snap}
+              onGridSnapChange={designer.setSnap}
+              onFitToScreen={() => canvasRef.current?.fitToScreen()}
+            />
+
+            <DesignerCanvas
+              ref={canvasRef}
+              canvas={designer.canvas}
+              beds={designer.beds}
+              annotations={designer.annotations}
+              cropsByBedId={designer.cropsByBedId}
+              selected={designer.selected}
+              isEditable={designer.isEditable}
+              mode={designer.mode}
+              snap={designer.snap}
+              backgroundImageUrl={designer.canvas.backgroundImageUrl}
+              onSelect={designer.setSelected}
+              onMoveBed={designer.moveBed}
+              onResizeBed={designer.resizeBed}
+              onMoveAnnotation={designer.moveAnnotation}
+              onResizeAnnotation={designer.resizeAnnotation}
+              onCommitPolygon={(points) => {
+                void designer.commitPolygon(points);
+              }}
+              onCancelPolygon={() => designer.setMode('idle')}
+            />
+
+            {designer.selectedBed && (
+              <BedInspector
+                key={designer.selectedBed.id}
+                bed={designer.selectedBed}
+                cropsForBed={designer.cropsByBedId.get(designer.selectedBed.id) ?? []}
+                isEditable={designer.isEditable}
+                isSaving={designer.isSaving}
+                isMobile={designer.isMobile}
+                onChange={(patch) => {
+                  if (designer.selectedBed) {
+                    designer.patchBed(designer.selectedBed.id, patch);
+                  }
+                }}
+                onDelete={() => {
+                  if (designer.selectedBed) {
+                    void designer.deleteBed(designer.selectedBed.id);
+                  }
+                }}
+                onClose={() => designer.setSelected(null)}
+              />
+            )}
+
+            {designer.selectedAnnotation && (
+              <AnnotationInspector
+                key={designer.selectedAnnotation.id}
+                annotation={designer.selectedAnnotation}
+                isEditable={designer.isEditable}
+                isSaving={designer.isSaving}
+                isMobile={designer.isMobile}
+                onChange={(patch) => {
+                  if (designer.selectedAnnotation) {
+                    designer.patchAnnotation(designer.selectedAnnotation.id, patch);
+                  }
+                }}
+                onDelete={() => {
+                  if (designer.selectedAnnotation) {
+                    void designer.deleteAnnotation(designer.selectedAnnotation.id);
+                  }
+                }}
+                onClose={() => designer.setSelected(null)}
+              />
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -3170,3 +3170,531 @@ body {
 .grn-new-crop__locked-bed strong {
   color: var(--og-color-soil);
 }
+
+/* ==========================================================================
+   Garden Masterplan (isometric explorer)
+   ========================================================================== */
+
+/* Segmented view toggle in the garden page header. */
+.grn-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.25rem;
+  border-radius: var(--og-radius-pill);
+  background: rgba(91, 58, 28, 0.08);
+  border: 1px solid rgba(91, 58, 28, 0.1);
+}
+
+.grn-view-toggle__btn {
+  padding: 0.4rem 0.95rem;
+  border: none;
+  border-radius: var(--og-radius-pill);
+  background: transparent;
+  color: rgba(79, 56, 37, 0.75);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms var(--easing-out), color 150ms var(--easing-out);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.grn-view-toggle__btn:hover {
+  color: var(--og-color-soil);
+}
+
+.grn-view-toggle__btn:focus-visible {
+  outline: 2px solid var(--og-color-moss);
+  outline-offset: 1px;
+}
+
+.grn-view-toggle__btn.is-active {
+  background: var(--og-color-paper);
+  color: var(--og-color-soil);
+  box-shadow: 0 2px 8px rgba(91, 58, 28, 0.16);
+}
+
+/* --- Explorer shell -------------------------------------------------------- */
+
+.mp-explorer {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.mp-explorer__viewport {
+  position: relative;
+  flex: 1;
+  min-height: 520px;
+  overflow: hidden;
+  border-radius: var(--og-radius-md);
+  border: 1px solid rgba(86, 96, 64, 0.16);
+  background:
+    radial-gradient(120% 90% at 50% 8%, rgba(255, 253, 248, 0.85) 0%, transparent 55%),
+    linear-gradient(180deg, #f3eddd 0%, #efe7d4 100%);
+  box-shadow: var(--og-shadow-card), inset 0 0 0 1px rgba(255, 253, 248, 0.5);
+  /* The viewport owns all gestures: block browser pan/zoom + text selection. */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: grab;
+}
+
+.mp-explorer__viewport:active {
+  cursor: grabbing;
+}
+
+@media (max-width: 768px) {
+  .mp-explorer__viewport {
+    min-height: 68vh;
+  }
+}
+
+.mp-explorer__content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* transform (translate3d + scale) is applied inline by useMapViewport so
+     pan/zoom stays on the compositor. */
+}
+
+.mp-scene {
+  display: block;
+  overflow: visible;
+}
+
+/* --- Elements: hover, dim, selection ---------------------------------------- */
+
+.mp-el {
+  cursor: pointer;
+  outline: none;
+  transition:
+    opacity 200ms var(--easing-out),
+    filter 200ms var(--easing-out),
+    transform 180ms var(--easing-out);
+}
+
+/* The map is the navigation: hovering (or keyboard-focusing) one element
+   gently lifts and brightens it while the rest of the planting recedes. */
+.mp-scene:has(.mp-el:hover, .mp-el:focus-visible)
+  .mp-el:not(:hover):not(:focus-visible):not(.mp-el--selected) {
+  opacity: 0.45;
+}
+
+.mp-el:hover,
+.mp-el:focus-visible {
+  filter: brightness(1.07) saturate(1.04);
+  transform: translateY(-3px);
+}
+
+.mp-el:focus-visible {
+  filter: brightness(1.07) saturate(1.04)
+    drop-shadow(0 0 5px rgba(168, 99, 47, 0.65));
+}
+
+.mp-el--selected {
+  filter: brightness(1.05);
+  transform: translateY(-3px);
+}
+
+.mp-el__shadow {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 180ms var(--easing-out), opacity 180ms var(--easing-out);
+}
+
+.mp-el:hover .mp-el__shadow,
+.mp-el--selected .mp-el__shadow {
+  /* The element lifts, so its ground shadow spreads slightly and softens. */
+  transform: translateY(4px) scale(1.03);
+  opacity: 0.75;
+}
+
+.mp-el__ring {
+  pointer-events: none;
+  animation: mp-ring-in 220ms var(--easing-out);
+}
+
+@keyframes mp-ring-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* --- Cartography ------------------------------------------------------------ */
+
+.mp-label {
+  font-family: var(--og-font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  fill: #3c3527;
+  paint-order: stroke;
+  stroke: rgba(247, 242, 231, 0.9);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.mp-label--count {
+  font-size: 10px;
+  fill: #6b6049;
+}
+
+.mp-compass__n {
+  font-family: var(--og-font-display);
+  font-size: 11px;
+  fill: #3c3527;
+}
+
+.mp-crop {
+  pointer-events: none;
+}
+
+/* --- Zoom controls + hint ----------------------------------------------------- */
+
+.mp-explorer__zoom {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  z-index: 5;
+}
+
+.mp-explorer__zoom-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(91, 58, 28, 0.15);
+  background: var(--og-color-paper);
+  color: var(--og-color-soil);
+  font-size: 1.15rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 16px rgba(91, 58, 28, 0.14);
+  transition: background 120ms ease, transform 80ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mp-explorer__zoom-btn:hover,
+.mp-explorer__zoom-btn:focus-visible {
+  background: rgba(91, 140, 74, 0.14);
+  outline: none;
+  border-color: var(--og-color-moss);
+}
+
+.mp-explorer__zoom-btn:active {
+  transform: scale(0.95);
+}
+
+.mp-explorer__zoom-btn--fit {
+  font-size: 1rem;
+}
+
+@media (max-width: 768px) {
+  .mp-explorer__zoom-btn {
+    width: 44px;
+    height: 44px;
+    font-size: 1.25rem;
+  }
+}
+
+.mp-explorer__hint {
+  position: absolute;
+  bottom: 0.85rem;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0.4rem 0.9rem;
+  background: rgba(58, 43, 26, 0.78);
+  color: var(--og-color-cream);
+  font-size: 0.78rem;
+  border-radius: 999px;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .mp-explorer__hint {
+    display: none;
+  }
+}
+
+/* --- Empty state --------------------------------------------------------------- */
+
+.mp-explorer__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+.mp-explorer__empty h2 {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--og-color-soil);
+}
+
+.mp-explorer__empty p {
+  margin: 0 0 0.6rem;
+  max-width: 34ch;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.95rem;
+}
+
+/* --- Floating detail panel ------------------------------------------------------ */
+
+.mp-panel {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: clamp(290px, 26vw, 360px);
+  max-height: calc(100% - 2rem);
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 253, 248, 0.93);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(91, 58, 28, 0.12);
+  box-shadow: var(--og-shadow-card);
+  z-index: 6;
+  animation: mp-panel-in 220ms var(--easing-out);
+}
+
+@keyframes mp-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .mp-panel {
+    top: auto;
+    right: 0.5rem;
+    left: 0.5rem;
+    bottom: 0.5rem;
+    width: auto;
+    max-height: 46vh;
+  }
+}
+
+.mp-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem 0.6rem;
+}
+
+.mp-panel__kicker {
+  margin: 0 0 0.15rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--og-color-sage);
+}
+
+.mp-panel__title {
+  margin: 0;
+  font-family: var(--og-font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--og-color-soil);
+  letter-spacing: 0;
+}
+
+.mp-panel__close {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(91, 58, 28, 0.08);
+  color: var(--og-color-soil);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.mp-panel__close:hover,
+.mp-panel__close:focus-visible {
+  background: rgba(91, 58, 28, 0.16);
+  outline: none;
+}
+
+.mp-panel__body {
+  padding: 0 1.1rem 0.85rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.mp-panel__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(79, 56, 37, 0.85);
+}
+
+.mp-panel__meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mp-panel__meta-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.mp-panel__meta-row dt {
+  flex: 0 0 3.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(79, 56, 37, 0.55);
+}
+
+.mp-panel__meta-row dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--og-color-ink);
+}
+
+.mp-panel__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.mp-panel__chip {
+  padding: 0.12rem 0.55rem;
+  border-radius: var(--og-radius-pill);
+  background: rgba(111, 143, 95, 0.14);
+  color: var(--og-color-moss);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.mp-panel__section-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(79, 56, 37, 0.55);
+}
+
+.mp-panel__crop-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.mp-panel__crop {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mp-panel__crop-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.mp-panel__crop-name {
+  font-size: 0.9rem;
+  color: var(--og-color-ink);
+}
+
+.mp-panel__crop-count {
+  font-size: 0.8rem;
+  color: rgba(79, 56, 37, 0.6);
+}
+
+.mp-panel__notes {
+  margin: 0;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--og-radius-sm);
+  background: rgba(216, 167, 65, 0.1);
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.85);
+}
+
+.mp-panel__footer {
+  padding: 0.75rem 1.1rem 1rem;
+  border-top: 1px solid rgba(91, 58, 28, 0.08);
+}
+
+.mp-panel__action {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: var(--og-radius-pill);
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--og-shadow-button);
+  transition: background 150ms var(--easing-out), transform 80ms ease;
+}
+
+.mp-panel__action:hover,
+.mp-panel__action:focus-visible {
+  background: #365733;
+  outline: none;
+}
+
+.mp-panel__action:active {
+  transform: scale(0.98);
+}
+
+/* --- Motion preferences ---------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .mp-el,
+  .mp-el__shadow,
+  .mp-panel,
+  .mp-el__ring {
+    transition: none;
+    animation: none;
+  }
+  .mp-el:hover,
+  .mp-el:focus-visible,
+  .mp-el--selected {
+    transform: none;
+  }
+}


### PR DESCRIPTION
> **Stacked on #341** — based on `fix/grn-react-lockfile-dedupe` so CI runs against the deduped lockfile. Merge #341 first; GitHub will retarget this PR to `main` automatically.

## What

Redesigns the Garden page around an **illustrated isometric masterplan** as the default view — flat-shaded low-poly volumes in a muted landscape-architecture palette on an organic lawn plate, with compass and scale bar. The original Konva canvas is preserved unchanged behind a "Layout editor" toggle for moving/resizing/drawing geometry.

No backend changes: everything renders from the existing beds/annotations/crops data.

## Experience

- **The map is the navigation.** Drag to pan, scroll/pinch to zoom, double-click to zoom in — all applied as a single `translate3d/scale` compositor transform, so the SVG never re-renders during navigation regardless of element count.
- **Hover** lifts and brightens an element while the rest of the plan dims to 45% (200ms eased, pure CSS via `:has()`).
- **Click** opens a floating glass detail card — bed type, area, sun, soil chips, crop list with counts, notes — while the map stays visible and navigable behind it. Bottom sheet on mobile.
- **Selection is shared between views**: "Edit in layout editor" jumps to the editor with the same element selected and its inspector open.
- **Accessibility:** every element is keyboard-focusable with a descriptive ARIA label, Enter/Space selects, `prefers-reduced-motion` honored.

## Object vocabulary

Beds render as wood-framed raised beds with soil surfaces and standing crop silhouettes (reusing the flat crop icon paths), contoured mounds, or in-ground patches. Annotations get illustrated forms keyed off their icon: stepped low-poly tree canopies (deterministically varied per id), fruit trees/berry bushes with fruit dots, ponds with sand shores and ripples, gabled sheds with doors, glass greenhouses with mullions, trellises, slatted compost bins, split-rail fences, stone paths, coops. New presets added: fruit tree, berry bush, fence, greenhouse, trellis, compost, animal enclosure.

## Implementation

| Piece | Role |
|---|---|
| `iso.ts` | 30° projection, footprint normalization, extrusion w/ camera-facing wall detection, depth sort |
| `palette.ts` | muted palette; derived top/right/left flat shading; icon/label → visual-kind mapping |
| `IsoBed` / `IsoAnnotation` / `IsoScene` | pure SVG illustration components (memoized) |
| `useMapViewport.ts` | GPU pan/zoom/pinch + drag-vs-click disambiguation |
| `MasterplanDetailPanel.tsx` | floating detail card |

## Verification

- `tsc --noEmit` clean; `npm run build` green
- 318/318 tests pass, including 28 new ones (projection math, extrusion/depth-sort invariants, kind mapping, component interaction/a11y)
- Visually verified in-browser with a 17-element sample garden across desktop and zoomed inspection (hover dim, selection ring, labels, all object kinds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)