### PR TITLE
GRN: layer ordering and per-vertex bed editing in the garden designer

### DIFF
--- a/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
@@ -139,6 +139,32 @@ export function AnnotationInspector({
           </label>
         )}
 
+        <div className="grn-designer-inspector__field">
+          <span>Stacking</span>
+          <div
+            className="grn-designer-inspector__arrange"
+            role="group"
+            aria-label="Stacking order"
+          >
+            <button
+              type="button"
+              className="grn-designer-inspector__arrange-btn"
+              onClick={() => commit({ sortOrder: annotation.sortOrder - 1 })}
+              title="Draw this annotation beneath overlapping elements"
+            >
+              ↓ Send backward
+            </button>
+            <button
+              type="button"
+              className="grn-designer-inspector__arrange-btn"
+              onClick={() => commit({ sortOrder: annotation.sortOrder + 1 })}
+              title="Draw this annotation above overlapping elements"
+            >
+              ↑ Bring forward
+            </button>
+          </div>
+        </div>
+
         <fieldset className="grn-designer-inspector__color">
           <legend>Color</legend>
           <div className="grn-designer-inspector__color-row" role="radiogroup" aria-label="Annotation color">

--- a/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
@@ -1,7 +1,19 @@
 import type Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
+import 'konva/lib/shapes/Circle';
+import 'konva/lib/shapes/Line';
+import 'konva/lib/shapes/Rect';
+import 'konva/lib/shapes/Text';
+import 'konva/lib/shapes/Transformer';
 import { useEffect, useRef } from 'react';
-import { Circle, Group, Line, Rect, Text, Transformer } from 'react-konva';
+import {
+  Circle,
+  Group,
+  Line,
+  Rect,
+  Text,
+  Transformer,
+} from 'react-konva/lib/ReactKonvaCore';
 import type { GardenAnnotation } from '../../types/listing';
 
 interface AnnotationShapeProps {

--- a/apps/grn/src/components/GardenDesigner/BackgroundLayer.tsx
+++ b/apps/grn/src/components/GardenDesigner/BackgroundLayer.tsx
@@ -1,5 +1,6 @@
+import 'konva/lib/shapes/Image';
 import { useEffect, useState } from 'react';
-import { Image as KonvaImage } from 'react-konva';
+import { Image as KonvaImage } from 'react-konva/lib/ReactKonvaCore';
 
 interface BackgroundLayerProps {
   src: string | null;

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -9,6 +9,8 @@ import {
   BED_TYPES,
   bedAreaSquareInches,
   bedTypeMeta,
+  defaultRectPolygonPoints,
+  ellipsePolygonPoints,
   formatArea,
   parseSoilField,
   serializeSoilField,
@@ -21,6 +23,8 @@ interface BedInspectorProps {
   isEditable: boolean;
   isSaving: boolean;
   isMobile: boolean;
+  isVertexEditing: boolean;
+  onToggleVertexEditing: () => void;
   onChange: (patch: Partial<GardenBed>) => void;
   onDelete: () => void;
   onClose: () => void;
@@ -45,6 +49,8 @@ export function BedInspector({
   isEditable,
   isSaving,
   isMobile,
+  isVertexEditing,
+  onToggleVertexEditing,
   onChange,
   onDelete,
   onClose,
@@ -95,6 +101,17 @@ export function BedInspector({
   function commit(patch: Partial<GardenBed>) {
     if (!isEditable) return;
     onChange(patch);
+  }
+
+  function convertToPolygon() {
+    const length = bed.lengthInches ?? 96;
+    const width = bed.widthInches ?? 48;
+    const points =
+      bed.shape === 'circle'
+        ? ellipsePolygonPoints(length, width)
+        : defaultRectPolygonPoints(length, width);
+    commit({ shape: 'polygon', points });
+    onToggleVertexEditing();
   }
 
   function toggleSoil(value: string) {
@@ -204,6 +221,57 @@ export function BedInspector({
               }}
             />
           </label>
+        </div>
+
+        <div className="grn-designer-inspector__field">
+          <span>Shape</span>
+          {bed.shape === 'polygon' ? (
+            <button
+              type="button"
+              className={`grn-designer-inspector__shape-btn ${
+                isVertexEditing ? 'is-active' : ''
+              }`}
+              onClick={onToggleVertexEditing}
+              title="Drag, add, or remove the points of this bed's outline on the canvas"
+            >
+              {isVertexEditing ? '✓ Done editing points' : '⬡ Edit shape points'}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="grn-designer-inspector__shape-btn"
+              onClick={convertToPolygon}
+              title="Turn this bed into a custom outline with movable points"
+            >
+              ⬡ Convert to custom shape
+            </button>
+          )}
+        </div>
+
+        <div className="grn-designer-inspector__field">
+          <span>Stacking</span>
+          <div
+            className="grn-designer-inspector__arrange"
+            role="group"
+            aria-label="Stacking order"
+          >
+            <button
+              type="button"
+              className="grn-designer-inspector__arrange-btn"
+              onClick={() => commit({ sortOrder: bed.sortOrder - 1 })}
+              title="Draw this bed beneath overlapping elements"
+            >
+              ↓ Send backward
+            </button>
+            <button
+              type="button"
+              className="grn-designer-inspector__arrange-btn"
+              onClick={() => commit({ sortOrder: bed.sortOrder + 1 })}
+              title="Draw this bed above overlapping elements"
+            >
+              ↑ Bring forward
+            </button>
+          </div>
         </div>
 
         <label className="grn-designer-inspector__field">

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -1,7 +1,21 @@
 import type Konva from 'konva';
 import type { KonvaEventObject } from 'konva/lib/Node';
+import 'konva/lib/shapes/Ellipse';
+import 'konva/lib/shapes/Line';
+import 'konva/lib/shapes/Path';
+import 'konva/lib/shapes/Rect';
+import 'konva/lib/shapes/Text';
+import 'konva/lib/shapes/Transformer';
 import { useEffect, useRef } from 'react';
-import { Ellipse, Group, Line, Path, Rect, Text, Transformer } from 'react-konva';
+import {
+  Ellipse,
+  Group,
+  Line,
+  Path,
+  Rect,
+  Text,
+  Transformer,
+} from 'react-konva/lib/ReactKonvaCore';
 import type { BedType, GardenBed, GrowerCropItem } from '../../types/listing';
 import { bedStyleFor } from './bedDefaults';
 import { visualForCrop } from '../CropPlanner/cropVisuals';

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -1,4 +1,10 @@
-import Konva from 'konva';
+// The designer imports Konva's core plus only the shapes it renders
+// (react-konva's "minimal bundle" pattern) — the full konva build carries
+// every shape and filter and blows the app's JS performance budget.
+import Konva from 'konva/lib/Core';
+import 'konva/lib/shapes/Circle';
+import 'konva/lib/shapes/Line';
+import 'konva/lib/shapes/Rect';
 import {
   forwardRef,
   useCallback,
@@ -8,7 +14,8 @@ import {
 } from 'react';
 import { useImperativeHandle } from 'react';
 import type { KonvaEventObject } from 'konva/lib/Node';
-import { Circle, Layer, Line, Rect, Stage } from 'react-konva';
+import type { Stage as KonvaStage } from 'konva/lib/Stage';
+import { Circle, Layer, Line, Rect, Stage } from 'react-konva/lib/ReactKonvaCore';
 
 // Tighten Konva's click-vs-drag detection. The default of 0px means any
 // pointer jitter on a draggable Group fires a drag instead of a click,
@@ -126,7 +133,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     ref
   ) {
     const containerRef = useRef<HTMLDivElement | null>(null);
-    const stageRef = useRef<Konva.Stage | null>(null);
+    const stageRef = useRef<KonvaStage | null>(null);
     // Seed with non-zero defaults so the Konva Stage mounts on first render.
     // The grid + min-height CSS guarantees the container will have at least
     // these dimensions; the ResizeObserver below replaces them with the real
@@ -377,7 +384,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       };
     }, []);
 
-    function relativePointer(stage: Konva.Stage): { x: number; y: number } | null {
+    function relativePointer(stage: KonvaStage): { x: number; y: number } | null {
       const pos = stage.getRelativePointerPosition();
       if (!pos) return null;
       return { x: pos.x, y: pos.y };
@@ -444,7 +451,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     function handleStageDragEnd(event: KonvaEventObject<DragEvent>) {
       // Stage-level drag = pan. Sync local state so the controlled
       // x/y/scale values reflect Konva's internal positioning.
-      const target = event.target as Konva.Stage;
+      const target = event.target as KonvaStage;
       if (target === stageRef.current) {
         setPosition({ x: target.x(), y: target.y() });
       }

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -28,6 +28,7 @@ import { AnnotationShape } from './AnnotationShape';
 import { BackgroundLayer } from './BackgroundLayer';
 import { BedShape } from './BedShape';
 import { Grid } from './Grid';
+import { VertexEditor } from './VertexEditor';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import type { DesignerMode, GridSnap } from './Toolbar';
 
@@ -68,6 +69,7 @@ interface DesignerCanvasProps {
   ) => void;
   onCommitPolygon: (points: BedPolygonPoint[]) => void;
   onCancelPolygon: () => void;
+  onUpdateBedPoints: (bedId: string, points: BedPolygonPoint[]) => void;
 }
 
 export interface DesignerCanvasHandle {
@@ -119,6 +121,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       onResizeAnnotation,
       onCommitPolygon,
       onCancelPolygon,
+      onUpdateBedPoints,
     },
     ref
   ) {
@@ -236,6 +239,48 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     }, [mode, onCancelPolygon]);
 
     const drawing = mode === 'drawing-polygon';
+
+    // The bed whose vertices are being reshaped, if any. Its own
+    // drag/Transformer interactions are suspended while the handles own
+    // the gesture space.
+    const vertexEditBed =
+      mode === 'editing-vertices' && selected?.kind === 'bed'
+        ? beds.find(
+            (b) =>
+              b.id === selected.id &&
+              b.shape === 'polygon' &&
+              (b.points?.length ?? 0) >= 3
+          )
+        : undefined;
+
+    // Beds and annotations stack by their persisted sortOrder (the same
+    // value the masterplan uses for paint order). At equal sortOrder,
+    // annotations keep their historical place under beds.
+    const stacked: Array<
+      | { kind: 'bed'; sortOrder: number; tier: number; index: number; bed: GardenBed }
+      | {
+          kind: 'annotation';
+          sortOrder: number;
+          tier: number;
+          index: number;
+          annotation: GardenAnnotation;
+        }
+    > = [
+      ...annotations.map((annotation, index) => ({
+        kind: 'annotation' as const,
+        sortOrder: annotation.sortOrder,
+        tier: 0,
+        index,
+        annotation,
+      })),
+      ...beds.map((bed, index) => ({
+        kind: 'bed' as const,
+        sortOrder: bed.sortOrder,
+        tier: 1,
+        index,
+        bed,
+      })),
+    ].sort((a, b) => a.sortOrder - b.sortOrder || a.tier - b.tier || a.index - b.index);
 
     // --- Touch pinch-to-zoom + two-finger pan ------------------------------
     //
@@ -471,33 +516,45 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
               />
             </Layer>
             <Layer>
-              {annotations.map((annotation) => (
-                <AnnotationShape
-                  key={annotation.id}
-                  annotation={annotation}
+              {stacked.map((item) =>
+                item.kind === 'annotation' ? (
+                  <AnnotationShape
+                    key={item.annotation.id}
+                    annotation={item.annotation}
+                    pxPerInch={PX_PER_INCH}
+                    isSelected={
+                      selected?.kind === 'annotation' && selected.id === item.annotation.id
+                    }
+                    isEditable={isEditable && !drawing}
+                    onSelect={(id) => onSelect({ kind: 'annotation', id })}
+                    onMove={onMoveAnnotation}
+                    onResize={onResizeAnnotation}
+                  />
+                ) : (
+                  <BedShape
+                    key={item.bed.id}
+                    bed={item.bed}
+                    pxPerInch={PX_PER_INCH}
+                    isSelected={selected?.kind === 'bed' && selected.id === item.bed.id}
+                    isEditable={
+                      isEditable && !drawing && item.bed.id !== vertexEditBed?.id
+                    }
+                    crops={cropsByBedId.get(item.bed.id) ?? []}
+                    onSelect={(id) => onSelect({ kind: 'bed', id })}
+                    onMove={handleBedMove}
+                    onResize={onResizeBed}
+                  />
+                )
+              )}
+              {vertexEditBed && (
+                <VertexEditor
+                  key={vertexEditBed.id}
+                  bed={vertexEditBed}
                   pxPerInch={PX_PER_INCH}
-                  isSelected={
-                    selected?.kind === 'annotation' && selected.id === annotation.id
-                  }
-                  isEditable={isEditable && !drawing}
-                  onSelect={(id) => onSelect({ kind: 'annotation', id })}
-                  onMove={onMoveAnnotation}
-                  onResize={onResizeAnnotation}
+                  snap={snap}
+                  onCommit={(points) => onUpdateBedPoints(vertexEditBed.id, points)}
                 />
-              ))}
-              {beds.map((bed) => (
-                <BedShape
-                  key={bed.id}
-                  bed={bed}
-                  pxPerInch={PX_PER_INCH}
-                  isSelected={selected?.kind === 'bed' && selected.id === bed.id}
-                  isEditable={isEditable && !drawing}
-                  crops={cropsByBedId.get(bed.id) ?? []}
-                  onSelect={(id) => onSelect({ kind: 'bed', id })}
-                  onMove={handleBedMove}
-                  onResize={onResizeBed}
-                />
-              ))}
+              )}
               {drawing && draftLinePoints.length >= 4 && (
                 <Line
                   points={draftLinePoints}
@@ -563,6 +620,12 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
         {drawing && (
           <div className="grn-designer-canvas__draw-hint" role="status">
             Tap to add points · double-tap to finish · esc to cancel
+          </div>
+        )}
+        {vertexEditBed && (
+          <div className="grn-designer-canvas__draw-hint" role="status">
+            Drag points to reshape · tap an edge dot to add · double-tap a point
+            to remove · esc to finish
           </div>
         )}
       </div>

--- a/apps/grn/src/components/GardenDesigner/Grid.tsx
+++ b/apps/grn/src/components/GardenDesigner/Grid.tsx
@@ -1,4 +1,6 @@
-import { Group, Line, Rect } from 'react-konva';
+import 'konva/lib/shapes/Line';
+import 'konva/lib/shapes/Rect';
+import { Group, Line, Rect } from 'react-konva/lib/ReactKonvaCore';
 
 interface GridProps {
   widthInches: number;

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -3,7 +3,7 @@ import type { BedShape } from '../../types/listing';
 import { ANNOTATION_PRESETS } from './annotationPresets';
 import { BED_SHAPES } from './bedDefaults';
 
-export type DesignerMode = 'idle' | 'drawing-polygon';
+export type DesignerMode = 'idle' | 'drawing-polygon' | 'editing-vertices';
 export type GridSnap = 'off' | '6' | '12';
 
 interface ToolbarProps {

--- a/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
+++ b/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
@@ -1,0 +1,157 @@
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { useState } from 'react';
+import { Circle, Group, Line } from 'react-konva';
+import type { BedPolygonPoint, GardenBed } from '../../types/listing';
+import type { GridSnap } from './Toolbar';
+
+interface VertexEditorProps {
+  bed: GardenBed;
+  pxPerInch: number;
+  snap: GridSnap;
+  onCommit: (points: BedPolygonPoint[]) => void;
+}
+
+const MIN_POINTS = 3;
+
+// Like Transformer anchors, vertex handles need to be finger-sized on
+// touch devices (see BedShape's ANCHOR_SIZE rationale).
+const TOUCH_DEVICE =
+  typeof window !== 'undefined' &&
+  (window.matchMedia('(pointer: coarse)').matches || 'ontouchstart' in window);
+const HANDLE_RADIUS = TOUCH_DEVICE ? 11 : 7;
+const MIDPOINT_RADIUS = TOUCH_DEVICE ? 8 : 5;
+
+function snapInches(value: number, snap: GridSnap): number {
+  if (snap === 'off') return Math.round(value);
+  const step = snap === '6' ? 6 : 12;
+  return Math.round(value / step) * step;
+}
+
+/**
+ * Per-vertex reshaping overlay for a selected polygon bed. Rendered in
+ * the bed's local frame (same position/rotation as its BedShape group) so
+ * handle drags map 1:1 onto the stored point list:
+ *
+ * - drag a solid handle to move that vertex (snapped on release)
+ * - press a hollow midpoint handle to split the edge with a new vertex
+ * - double-click/double-tap a handle to remove it (min 3 remain)
+ *
+ * A local draft keeps the dashed outline live during a drag; every
+ * completed gesture commits the full point list upward, where the hook
+ * re-anchors the geometry and persists it.
+ */
+export function VertexEditor({ bed, pxPerInch, snap, onCommit }: VertexEditorProps) {
+  const [draft, setDraft] = useState<BedPolygonPoint[] | null>(null);
+
+  const points = draft ?? bed.points ?? [];
+  if (points.length < MIN_POINTS) return null;
+
+  const positionX = (bed.positionX ?? 12) * pxPerInch;
+  const positionY = (bed.positionY ?? 12) * pxPerInch;
+
+  function replacePoint(index: number, next: BedPolygonPoint): BedPolygonPoint[] {
+    return points.map((p, i) => (i === index ? next : p));
+  }
+
+  function handleDragMove(index: number, event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    setDraft(
+      replacePoint(index, { x: node.x() / pxPerInch, y: node.y() / pxPerInch })
+    );
+  }
+
+  function handleDragEnd(index: number, event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    const snapped = {
+      x: snapInches(node.x() / pxPerInch, snap),
+      y: snapInches(node.y() / pxPerInch, snap),
+    };
+    // Park the node on the snapped spot so it doesn't flash at the raw
+    // drop position while the optimistic update round-trips.
+    node.position({ x: snapped.x * pxPerInch, y: snapped.y * pxPerInch });
+    setDraft(null);
+    onCommit(replacePoint(index, snapped));
+  }
+
+  function handleRemove(index: number) {
+    if (points.length <= MIN_POINTS) return;
+    setDraft(null);
+    onCommit(points.filter((_, i) => i !== index));
+  }
+
+  function handleInsertAfter(index: number, midpoint: BedPolygonPoint) {
+    const next = [...points];
+    next.splice(index + 1, 0, {
+      x: Math.round(midpoint.x),
+      y: Math.round(midpoint.y),
+    });
+    setDraft(null);
+    onCommit(next);
+  }
+
+  const outline = points.flatMap((p) => [p.x * pxPerInch, p.y * pxPerInch]);
+
+  return (
+    <Group x={positionX} y={positionY} rotation={bed.rotationDeg}>
+      <Line
+        points={outline}
+        closed
+        stroke="#3a7e5a"
+        strokeWidth={1.5}
+        dash={[6, 4]}
+        listening={false}
+      />
+      {points.map((point, idx) => {
+        const next = points[(idx + 1) % points.length];
+        const midpoint = { x: (point.x + next.x) / 2, y: (point.y + next.y) / 2 };
+        return (
+          <Circle
+            key={`mid-${idx}`}
+            x={midpoint.x * pxPerInch}
+            y={midpoint.y * pxPerInch}
+            radius={MIDPOINT_RADIUS}
+            fill="rgba(255, 255, 255, 0.9)"
+            stroke="#3a7e5a"
+            strokeWidth={1.5}
+            onMouseDown={(event) => {
+              event.cancelBubble = true;
+              handleInsertAfter(idx, midpoint);
+            }}
+            onTouchStart={(event) => {
+              event.cancelBubble = true;
+              handleInsertAfter(idx, midpoint);
+            }}
+          />
+        );
+      })}
+      {points.map((point, idx) => (
+        <Circle
+          key={`vertex-${idx}`}
+          x={point.x * pxPerInch}
+          y={point.y * pxPerInch}
+          radius={HANDLE_RADIUS}
+          fill="#3a7e5a"
+          stroke="#fff"
+          strokeWidth={2}
+          draggable
+          onMouseDown={(event) => {
+            event.cancelBubble = true;
+          }}
+          onTouchStart={(event) => {
+            event.cancelBubble = true;
+          }}
+          onDragMove={(event) => handleDragMove(idx, event)}
+          onDragEnd={(event) => handleDragEnd(idx, event)}
+          onDblClick={(event) => {
+            event.cancelBubble = true;
+            handleRemove(idx);
+          }}
+          onDblTap={(event) => {
+            event.cancelBubble = true;
+            handleRemove(idx);
+          }}
+        />
+      ))}
+    </Group>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
+++ b/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
@@ -1,6 +1,8 @@
 import type { KonvaEventObject } from 'konva/lib/Node';
+import 'konva/lib/shapes/Circle';
+import 'konva/lib/shapes/Line';
 import { useState } from 'react';
-import { Circle, Group, Line } from 'react-konva';
+import { Circle, Group, Line } from 'react-konva/lib/ReactKonvaCore';
 import type { BedPolygonPoint, GardenBed } from '../../types/listing';
 import type { GridSnap } from './Toolbar';
 

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.test.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bedAreaSquareInches,
+  defaultRectPolygonPoints,
+  ellipsePolygonPoints,
+  normalizePolygonGeometry,
+} from './bedDefaults';
+
+describe('ellipsePolygonPoints', () => {
+  it('produces the requested number of vertices inside the bounding box', () => {
+    const points = ellipsePolygonPoints(96, 48);
+    expect(points).toHaveLength(12);
+    for (const p of points) {
+      expect(p.x).toBeGreaterThanOrEqual(0);
+      expect(p.x).toBeLessThanOrEqual(96);
+      expect(p.y).toBeGreaterThanOrEqual(0);
+      expect(p.y).toBeLessThanOrEqual(48);
+    }
+  });
+
+  it('approximates the ellipse area', () => {
+    const points = ellipsePolygonPoints(96, 48);
+    const polygonArea = bedAreaSquareInches({
+      shape: 'polygon',
+      lengthInches: 96,
+      widthInches: 48,
+      points,
+    });
+    const ellipseArea = Math.PI * 48 * 24;
+    // A 12-gon inscribed in an ellipse covers ~95.5% of its area.
+    expect(polygonArea).toBeGreaterThan(ellipseArea * 0.9);
+    expect(polygonArea).toBeLessThanOrEqual(ellipseArea);
+  });
+});
+
+describe('normalizePolygonGeometry', () => {
+  it('leaves an already-anchored polygon untouched', () => {
+    const points = defaultRectPolygonPoints(96, 48);
+    const result = normalizePolygonGeometry({
+      positionX: 24,
+      positionY: 36,
+      rotationDeg: 0,
+      points,
+    });
+    expect(result).toEqual({
+      positionX: 24,
+      positionY: 36,
+      lengthInches: 96,
+      widthInches: 48,
+      points,
+    });
+  });
+
+  it('re-anchors drifted points into the position when unrotated', () => {
+    const result = normalizePolygonGeometry({
+      positionX: 100,
+      positionY: 100,
+      rotationDeg: 0,
+      points: [
+        { x: -10, y: 5 },
+        { x: 50, y: 5 },
+        { x: 50, y: 45 },
+        { x: -10, y: 45 },
+      ],
+    });
+    expect(result.positionX).toBe(90);
+    expect(result.positionY).toBe(105);
+    expect(result.lengthInches).toBe(60);
+    expect(result.widthInches).toBe(40);
+    expect(result.points).toEqual([
+      { x: 0, y: 0 },
+      { x: 60, y: 0 },
+      { x: 60, y: 40 },
+      { x: 0, y: 40 },
+    ]);
+  });
+
+  it('rotates the anchor offset so a rotated bed stays visually put', () => {
+    // At 90°, a local offset of (10, 0) points straight "down" in world
+    // space, so the position shifts on Y rather than X.
+    const result = normalizePolygonGeometry({
+      positionX: 100,
+      positionY: 100,
+      rotationDeg: 90,
+      points: [
+        { x: 10, y: 0 },
+        { x: 70, y: 0 },
+        { x: 70, y: 40 },
+        { x: 10, y: 40 },
+      ],
+    });
+    expect(result.positionX).toBe(100);
+    expect(result.positionY).toBe(110);
+    expect(result.points[0]).toEqual({ x: 0, y: 0 });
+    expect(result.lengthInches).toBe(60);
+    expect(result.widthInches).toBe(40);
+  });
+
+  it('clamps the anchored position at the canvas origin', () => {
+    const result = normalizePolygonGeometry({
+      positionX: 4,
+      positionY: 4,
+      rotationDeg: 0,
+      points: [
+        { x: -12, y: -12 },
+        { x: 36, y: -12 },
+        { x: 36, y: 36 },
+        { x: -12, y: 36 },
+      ],
+    });
+    expect(result.positionX).toBe(0);
+    expect(result.positionY).toBe(0);
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/bedDefaults.ts
+++ b/apps/grn/src/components/GardenDesigner/bedDefaults.ts
@@ -48,10 +48,10 @@ export interface BedShapeMeta {
 // Bed *shape* is geometry. Each toolbar button picks a shape and
 // drops a default-sized bed of that geometry onto the canvas.
 //
-// Only Rectangle and Circle are presets — a "polygon preset" would be
-// indistinguishable from a rectangle until per-vertex editing lands.
-// Custom polygons come from the "Draw shape" tool, which is wired up
-// separately in the toolbar.
+// Only Rectangle and Circle are presets — a "polygon preset" would just
+// be a rectangle until the user reshapes it. Custom polygons come from
+// the "Draw shape" tool, or from converting an existing bed via the
+// inspector's "Convert to custom shape" action.
 export const BED_SHAPES: BedShapeMeta[] = [
   { value: 'rect', label: 'Rectangle', emoji: '▭', hint: 'Add a rectangular bed' },
   { value: 'circle', label: 'Circle', emoji: '◯', hint: 'Add a circular bed' },
@@ -84,6 +84,68 @@ export function defaultRectPolygonPoints(width: number, height: number): BedPoly
     { x: width, y: height },
     { x: 0, y: height },
   ];
+}
+
+// Low-poly ellipse used when converting a circle bed to a custom shape.
+// 12 vertices keeps the silhouette round while leaving each handle big
+// enough to grab.
+export function ellipsePolygonPoints(
+  length: number,
+  width: number,
+  segments = 12
+): BedPolygonPoint[] {
+  const rx = length / 2;
+  const ry = width / 2;
+  const points: BedPolygonPoint[] = [];
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    points.push({
+      x: Math.round(rx + Math.cos(angle) * rx),
+      y: Math.round(ry + Math.sin(angle) * ry),
+    });
+  }
+  return points;
+}
+
+export interface PolygonGeometry {
+  positionX: number;
+  positionY: number;
+  lengthInches: number;
+  widthInches: number;
+  points: BedPolygonPoint[];
+}
+
+// After a vertex edit the point set can drift away from its (0,0)-anchored
+// convention. Re-anchor it: translate points so their bounding box starts
+// at the origin and absorb the shift into the bed position. Because
+// rotation pivots about the position origin, the offset has to be rotated
+// into world space for the bed to stay visually put.
+export function normalizePolygonGeometry(args: {
+  positionX: number;
+  positionY: number;
+  rotationDeg: number;
+  points: BedPolygonPoint[];
+}): PolygonGeometry {
+  const { positionX, positionY, rotationDeg, points } = args;
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  const rad = (rotationDeg * Math.PI) / 180;
+  const offsetX = minX * Math.cos(rad) - minY * Math.sin(rad);
+  const offsetY = minX * Math.sin(rad) + minY * Math.cos(rad);
+  return {
+    positionX: Math.max(0, Math.round(positionX + offsetX)),
+    positionY: Math.max(0, Math.round(positionY + offsetY)),
+    lengthInches: Math.round(maxX - minX),
+    widthInches: Math.round(maxY - minY),
+    points: points.map((p) => ({
+      x: Math.round(p.x - minX),
+      y: Math.round(p.y - minY),
+    })),
+  };
 }
 
 // --- Soil ----------------------------------------------------------------

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -109,6 +109,8 @@ function renderMasterplan(args?: {
   crops?: GrowerCropItem[];
   selected?: { kind: 'bed' | 'annotation'; id: string } | null;
   onSelect?: (next: unknown) => void;
+  onPatchBed?: (bedId: string, patch: Partial<GardenBed>) => void;
+  onPatchAnnotation?: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
   onOpenLayoutEditor?: () => void;
 }) {
   const beds = args?.beds ?? [makeBed({})];
@@ -136,6 +138,8 @@ function renderMasterplan(args?: {
           : undefined
       }
       onSelect={(args?.onSelect ?? (() => {})) as never}
+      onPatchBed={args?.onPatchBed ?? (() => {})}
+      onPatchAnnotation={args?.onPatchAnnotation ?? (() => {})}
       onOpenLayoutEditor={args?.onOpenLayoutEditor ?? (() => {})}
     />
   );
@@ -203,6 +207,110 @@ describe('GardenMasterplan', () => {
     const onOpenLayoutEditor = vi.fn();
     renderMasterplan({ beds: [], annotations: [], crops: [], onOpenLayoutEditor });
     expect(screen.getByText(/your property, beautifully mapped/i)).toBeInTheDocument();
+  });
+
+  it('paints elements back-to-front by depth when no layer order is set', () => {
+    const { container } = renderMasterplan({
+      beds: [
+        // South-east bed is "nearer" the camera, so it paints last.
+        makeBed({ id: 'near', name: 'Near bed', positionX: 200, positionY: 160 }),
+        makeBed({ id: 'far', name: 'Far bed', positionX: 24, positionY: 24 }),
+      ],
+      annotations: [],
+      crops: [],
+    });
+    const labels = Array.from(container.querySelectorAll('.mp-el')).map((el) =>
+      el.getAttribute('aria-label')
+    );
+    expect(labels[0]).toMatch(/far bed/i);
+    expect(labels[1]).toMatch(/near bed/i);
+  });
+
+  it('lets sortOrder override the geometric paint order', () => {
+    const { container } = renderMasterplan({
+      beds: [
+        makeBed({ id: 'near', name: 'Near bed', positionX: 200, positionY: 160 }),
+        // Raised a layer, the far bed now paints on top of the near one.
+        makeBed({ id: 'far', name: 'Far bed', positionX: 24, positionY: 24, sortOrder: 1 }),
+      ],
+      annotations: [],
+      crops: [],
+    });
+    const labels = Array.from(container.querySelectorAll('.mp-el')).map((el) =>
+      el.getAttribute('aria-label')
+    );
+    expect(labels[0]).toMatch(/near bed/i);
+    expect(labels[1]).toMatch(/far bed/i);
+  });
+
+  it('lets a raised flat annotation paint above beds', () => {
+    const { container } = renderMasterplan({
+      beds: [makeBed({})],
+      annotations: [
+        makeAnnotation({
+          id: 'path-1',
+          label: 'Gravel path',
+          icon: '🛤️',
+          shape: 'line',
+          points: [
+            { x: 0, y: 0 },
+            { x: 240, y: 0 },
+          ],
+          sortOrder: 1,
+        }),
+      ],
+      crops: [],
+    });
+    const labels = Array.from(container.querySelectorAll('.mp-el')).map((el) =>
+      el.getAttribute('aria-label')
+    );
+    // Paths normally paint first (under everything); sortOrder lifts it above.
+    expect(labels[0]).toMatch(/herb spiral/i);
+    expect(labels[1]).toMatch(/gravel path/i);
+  });
+
+  it('changes stacking order from the detail panel', async () => {
+    const onPatchBed = vi.fn();
+    renderMasterplan({ selected: { kind: 'bed', id: 'bed-1' }, onPatchBed });
+    await userEvent.click(screen.getByRole('button', { name: /bring forward/i }));
+    expect(onPatchBed).toHaveBeenCalledWith('bed-1', { sortOrder: 1 });
+    await userEvent.click(screen.getByRole('button', { name: /send backward/i }));
+    expect(onPatchBed).toHaveBeenCalledWith('bed-1', { sortOrder: -1 });
+  });
+
+  it('changes annotation stacking order from the detail panel', async () => {
+    const onPatchAnnotation = vi.fn();
+    renderMasterplan({
+      selected: { kind: 'annotation', id: 'ann-1' },
+      onPatchAnnotation,
+    });
+    await userEvent.click(screen.getByRole('button', { name: /send backward/i }));
+    expect(onPatchAnnotation).toHaveBeenCalledWith('ann-1', { sortOrder: -1 });
+  });
+
+  it('renders a polygon bed with custom vertices in the scene', () => {
+    renderMasterplan({
+      beds: [
+        makeBed({
+          id: 'poly',
+          name: 'L-shaped bed',
+          shape: 'polygon',
+          points: [
+            { x: 0, y: 0 },
+            { x: 96, y: 0 },
+            { x: 96, y: 24 },
+            { x: 48, y: 24 },
+            { x: 48, y: 48 },
+            { x: 0, y: 48 },
+          ],
+        }),
+      ],
+      annotations: [],
+      crops: [],
+    });
+    expect(
+      screen.getByRole('button', { name: /l-shaped bed \(raised bed\)/i })
+    ).toBeInTheDocument();
   });
 
   it('labels annotation kinds for assistive tech', () => {

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -6,7 +6,8 @@ import type {
   GrowerCropItem,
 } from '../../types/listing';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
-import { IsoScene, sceneMetrics } from './IsoScene';
+import { sceneMetrics } from './footprints';
+import { IsoScene } from './IsoScene';
 import { MasterplanDetailPanel } from './MasterplanDetailPanel';
 import { useMapViewport } from './useMapViewport';
 
@@ -45,17 +46,28 @@ export function GardenMasterplan({
   onOpenLayoutEditor,
 }: GardenMasterplanProps) {
   const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
-  const viewport = useMapViewport(metrics.width, metrics.height);
+  // Destructured (rather than kept as one `viewport` object) so the
+  // react-hooks/refs rule can see that only the callback ref goes to the
+  // ref prop and everything else is plain render data.
+  const {
+    containerRef,
+    containerHandlers,
+    contentStyle,
+    zoomIn,
+    zoomOut,
+    fitToScreen,
+    shouldIgnoreClick,
+  } = useMapViewport(metrics.width, metrics.height);
   const isEmpty = beds.length === 0 && annotations.length === 0;
 
   return (
     <div className="mp-explorer">
       <div
-        ref={viewport.containerRef}
+        ref={containerRef}
         className="mp-explorer__viewport"
-        {...viewport.containerHandlers}
+        {...containerHandlers}
       >
-        <div className="mp-explorer__content" style={viewport.contentStyle}>
+        <div className="mp-explorer__content" style={contentStyle}>
           <IsoScene
             canvas={canvas}
             beds={beds}
@@ -63,7 +75,7 @@ export function GardenMasterplan({
             cropsByBedId={cropsByBedId}
             selected={selected}
             onSelect={onSelect}
-            shouldIgnoreClick={viewport.shouldIgnoreClick}
+            shouldIgnoreClick={shouldIgnoreClick}
           />
         </div>
 
@@ -71,7 +83,7 @@ export function GardenMasterplan({
           <button
             type="button"
             className="mp-explorer__zoom-btn"
-            onClick={viewport.zoomIn}
+            onClick={zoomIn}
             aria-label="Zoom in"
             title="Zoom in"
           >
@@ -80,7 +92,7 @@ export function GardenMasterplan({
           <button
             type="button"
             className="mp-explorer__zoom-btn"
-            onClick={viewport.zoomOut}
+            onClick={zoomOut}
             aria-label="Zoom out"
             title="Zoom out"
           >
@@ -89,7 +101,7 @@ export function GardenMasterplan({
           <button
             type="button"
             className="mp-explorer__zoom-btn mp-explorer__zoom-btn--fit"
-            onClick={viewport.fitToScreen}
+            onClick={fitToScreen}
             aria-label="Fit garden to screen"
             title="Fit to screen"
           >

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -19,6 +19,8 @@ interface GardenMasterplanProps {
   selectedBed: GardenBed | undefined;
   selectedAnnotation: GardenAnnotation | undefined;
   onSelect: (next: SelectedItem) => void;
+  onPatchBed: (bedId: string, patch: Partial<GardenBed>) => void;
+  onPatchAnnotation: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
   onOpenLayoutEditor: () => void;
 }
 
@@ -38,6 +40,8 @@ export function GardenMasterplan({
   selectedBed,
   selectedAnnotation,
   onSelect,
+  onPatchBed,
+  onPatchAnnotation,
   onOpenLayoutEditor,
 }: GardenMasterplanProps) {
   const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
@@ -123,6 +127,16 @@ export function GardenMasterplan({
           bed={selectedBed}
           annotation={selectedAnnotation}
           crops={selectedBed ? cropsByBedId.get(selectedBed.id) ?? [] : []}
+          onArrange={(direction) => {
+            const delta = direction === 'forward' ? 1 : -1;
+            if (selectedBed) {
+              onPatchBed(selectedBed.id, { sortOrder: selectedBed.sortOrder + delta });
+            } else if (selectedAnnotation) {
+              onPatchAnnotation(selectedAnnotation.id, {
+                sortOrder: selectedAnnotation.sortOrder + delta,
+              });
+            }
+          }}
           onClose={() => onSelect(null)}
           onOpenLayoutEditor={onOpenLayoutEditor}
         />

--- a/apps/grn/src/components/GardenMasterplan/IsoAnnotation.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoAnnotation.tsx
@@ -1,13 +1,12 @@
 import { memo, type ReactNode } from 'react';
 import type { GardenAnnotation } from '../../types/listing';
+import { annotationFootprint, annotationGeometry } from './footprints';
 import {
   PX_PER_INCH,
   boundsOf,
-  ellipseFootprint,
   extrude,
   hashSeed,
   insetFootprint,
-  polygonFootprint,
   project,
   projectFootprint,
   rectFootprint,
@@ -31,43 +30,13 @@ import {
   mute,
   shade,
   tint,
-  type AnnotationKind,
 } from './palette';
-
-// Kinds that sit flush with the ground; the scene paints these before any
-// extruded volume regardless of depth so beds and structures always sit
-// on top of paths and water.
-export const FLAT_KINDS: ReadonlySet<AnnotationKind> = new Set(['path', 'pond']);
-
-function geometry(a: GardenAnnotation) {
-  return {
-    x: a.positionX ?? 12,
-    y: a.positionY ?? 12,
-    length: a.lengthInches ?? 48,
-    width: a.widthInches ?? 48,
-    rotationDeg: a.rotationDeg,
-  };
-}
-
-export function annotationFootprint(a: GardenAnnotation): WorldPoint[] {
-  const g = geometry(a);
-  if (a.shape === 'line' && a.points && a.points.length >= 2) {
-    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
-  }
-  if (a.shape === 'circle') {
-    return ellipseFootprint(g);
-  }
-  if (a.shape === 'polygon' && a.points && a.points.length >= 3) {
-    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
-  }
-  return rectFootprint(g);
-}
 
 // Structures (sheds, greenhouses, bins…) always build from an oriented
 // rectangle so roof/wall construction has four predictable corners, even
 // if the underlying record was created with another shape.
 function structureCorners(a: GardenAnnotation): WorldPoint[] {
-  return rectFootprint(geometry(a));
+  return rectFootprint(annotationGeometry(a));
 }
 
 function avgRadius(footprint: WorldPoint[]): number {
@@ -324,7 +293,7 @@ function renderGabledStructure(
   roof: RoofSpec,
   extras?: (corners: WorldPoint[], eaves: number) => ReactNode
 ): ReactNode {
-  const g = geometry(a);
+  const g = annotationGeometry(a);
   const corners = structureCorners(a);
   const walls = extrude(corners, roof.eaves);
   const material = materialFrom(wallBase);
@@ -462,7 +431,7 @@ function renderGreenhouse(a: GardenAnnotation): ReactNode {
 const TRELLIS_HEIGHT = 66;
 
 function renderTrellis(a: GardenAnnotation): ReactNode {
-  const g = geometry(a);
+  const g = annotationGeometry(a);
   const alongX = g.length >= g.width;
   const ends: WorldPoint[] = alongX
     ? [

--- a/apps/grn/src/components/GardenMasterplan/IsoBed.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoBed.tsx
@@ -2,16 +2,14 @@ import { memo, type ReactNode } from 'react';
 import type { GardenBed, GrowerCropItem } from '../../types/listing';
 import { CROP_ICON_PATHS } from '../CropPlanner/cropIconPaths';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { bedFootprint } from './footprints';
 import {
   boundsOf,
-  ellipseFootprint,
   extrude,
   hashSeed,
   insetFootprint,
-  polygonFootprint,
   project,
   projectFootprint,
-  rectFootprint,
   rotateWorld,
   scaleFootprint,
   smoothClosedPath,
@@ -21,24 +19,10 @@ import {
 } from './iso';
 import { SCENE, bedPalette, mute, shade, tint } from './palette';
 
-export const RAISED_BED_HEIGHT = 11;
-export const IN_GROUND_HEIGHT = 2.5;
+const RAISED_BED_HEIGHT = 11;
+const IN_GROUND_HEIGHT = 2.5;
 const MAX_CROPS = 5;
 const CROP_SPACING_INCHES = 15;
-
-export function bedFootprint(bed: GardenBed): WorldPoint[] {
-  const x = bed.positionX ?? 12;
-  const y = bed.positionY ?? 12;
-  const length = bed.lengthInches ?? 96;
-  const width = bed.widthInches ?? 48;
-  if (bed.shape === 'circle') {
-    return ellipseFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
-  }
-  if (bed.shape === 'polygon' && bed.points && bed.points.length >= 3) {
-    return polygonFootprint({ x, y, points: bed.points, rotationDeg: bed.rotationDeg });
-  }
-  return rectFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
-}
 
 // Evenly spaced world positions along the bed's long axis where crop
 // silhouettes stand. Returned in north-to-south order so the upright

--- a/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
@@ -123,6 +123,7 @@ interface IsoSceneProps {
 
 interface RenderItem {
   key: string;
+  layer: number;
   depth: number;
   flat: boolean;
   node: ReactNode;
@@ -168,6 +169,7 @@ export const IsoScene = memo(function IsoScene({
       const kind = annotationKind(annotation);
       list.push({
         key: `annotation-${annotation.id}`,
+        layer: annotation.sortOrder,
         depth: depthOf(annotationFootprint(annotation)),
         flat: FLAT_KINDS.has(kind),
         node: (
@@ -190,6 +192,7 @@ export const IsoScene = memo(function IsoScene({
       const crops = cropsByBedId.get(bed.id) ?? [];
       list.push({
         key: `bed-${bed.id}`,
+        layer: bed.sortOrder,
         depth: depthOf(bedFootprint(bed)),
         flat: false,
         node: (
@@ -209,9 +212,15 @@ export const IsoScene = memo(function IsoScene({
         ),
       });
     }
-    // Painter's algorithm: ground-level surfaces first, then volumes from
-    // back (north-west) to front (south-east).
-    list.sort((a, b) => Number(b.flat) - Number(a.flat) || a.depth - b.depth);
+    // Painter's algorithm with a user override: the persisted sortOrder
+    // acts as an explicit layer (everything defaults to 0, so untouched
+    // gardens keep the pure geometric ordering). Within a layer,
+    // ground-level surfaces paint first, then volumes from back
+    // (north-west) to front (south-east).
+    list.sort(
+      (a, b) =>
+        a.layer - b.layer || Number(b.flat) - Number(a.flat) || a.depth - b.depth
+    );
     return list;
   }, [annotations, beds, cropsByBedId, onSelect, selected, shouldIgnoreClick]);
 

--- a/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
@@ -7,6 +7,12 @@ import type {
 } from '../../types/listing';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import {
+  FLAT_KINDS,
+  annotationFootprint,
+  bedFootprint,
+  sceneMetrics,
+} from './footprints';
+import {
   ISO_COS,
   ISO_SIN,
   PX_PER_INCH,
@@ -17,40 +23,9 @@ import {
   smoothClosedPath,
   type WorldPoint,
 } from './iso';
-import { FLAT_KINDS, IsoAnnotation, annotationFootprint } from './IsoAnnotation';
-import { IsoBed, bedFootprint } from './IsoBed';
+import { IsoAnnotation } from './IsoAnnotation';
+import { IsoBed } from './IsoBed';
 import { KIND_LABELS, SCENE, annotationKind } from './palette';
-
-// Extra svg space above the ground plate so tall objects (trees, sheds)
-// and crop silhouettes near the north edge never clip.
-const PAD_X = 80;
-const PAD_TOP = 160;
-const PAD_BOTTOM = 90;
-
-export interface SceneMetrics {
-  width: number;
-  height: number;
-  viewBox: string;
-}
-
-export function sceneMetrics(canvas: GardenCanvas): SceneMetrics {
-  const w = canvas.widthInches;
-  const h = canvas.heightInches;
-  const corners = projectFootprint([
-    { x: 0, y: 0 },
-    { x: w, y: 0 },
-    { x: w, y: h },
-    { x: 0, y: h },
-  ]);
-  const b = boundsOf(corners);
-  const width = b.maxX - b.minX + PAD_X * 2;
-  const height = b.maxY - b.minY + PAD_TOP + PAD_BOTTOM;
-  return {
-    width,
-    height,
-    viewBox: `${b.minX - PAD_X} ${b.minY - PAD_TOP} ${width} ${height}`,
-  };
-}
 
 // Organic ring of world points around the canvas rectangle — the lawn
 // plate is a soft blob, not a hard parallelogram, so the plan reads as an

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
@@ -33,6 +33,7 @@ interface MasterplanDetailPanelProps {
   bed?: GardenBed;
   annotation?: GardenAnnotation;
   crops: GrowerCropItem[];
+  onArrange: (direction: 'forward' | 'backward') => void;
   onClose: () => void;
   onOpenLayoutEditor: () => void;
 }
@@ -47,6 +48,7 @@ export function MasterplanDetailPanel({
   bed,
   annotation,
   crops,
+  onArrange,
   onClose,
   onOpenLayoutEditor,
 }: MasterplanDetailPanelProps) {
@@ -175,6 +177,24 @@ export function MasterplanDetailPanel({
       </div>
 
       <footer className="mp-panel__footer">
+        <div className="mp-panel__arrange" role="group" aria-label="Stacking order">
+          <button
+            type="button"
+            className="mp-panel__arrange-btn"
+            onClick={() => onArrange('backward')}
+            title="Draw this element behind overlapping neighbors"
+          >
+            ↓ Send backward
+          </button>
+          <button
+            type="button"
+            className="mp-panel__arrange-btn"
+            onClick={() => onArrange('forward')}
+            title="Draw this element in front of overlapping neighbors"
+          >
+            ↑ Bring forward
+          </button>
+        </div>
         <button type="button" className="mp-panel__action" onClick={onOpenLayoutEditor}>
           Edit in layout editor
         </button>

--- a/apps/grn/src/components/GardenMasterplan/footprints.ts
+++ b/apps/grn/src/components/GardenMasterplan/footprints.ts
@@ -1,0 +1,90 @@
+// World-space footprint builders and scene sizing shared by the
+// masterplan components. These live apart from the Iso* component files
+// so those stay component-only modules (react-refresh requires it) while
+// the scene, the bed/annotation illustrations, and tests can all reason
+// about the same geometry.
+
+import type { GardenAnnotation, GardenBed, GardenCanvas } from '../../types/listing';
+import {
+  boundsOf,
+  ellipseFootprint,
+  polygonFootprint,
+  projectFootprint,
+  rectFootprint,
+  type WorldPoint,
+} from './iso';
+import type { AnnotationKind } from './palette';
+
+// Kinds that sit flush with the ground; the scene paints these before any
+// extruded volume regardless of depth so beds and structures always sit
+// on top of paths and water.
+export const FLAT_KINDS: ReadonlySet<AnnotationKind> = new Set(['path', 'pond']);
+
+export function annotationGeometry(a: GardenAnnotation) {
+  return {
+    x: a.positionX ?? 12,
+    y: a.positionY ?? 12,
+    length: a.lengthInches ?? 48,
+    width: a.widthInches ?? 48,
+    rotationDeg: a.rotationDeg,
+  };
+}
+
+export function annotationFootprint(a: GardenAnnotation): WorldPoint[] {
+  const g = annotationGeometry(a);
+  if (a.shape === 'line' && a.points && a.points.length >= 2) {
+    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
+  }
+  if (a.shape === 'circle') {
+    return ellipseFootprint(g);
+  }
+  if (a.shape === 'polygon' && a.points && a.points.length >= 3) {
+    return polygonFootprint({ x: g.x, y: g.y, points: a.points, rotationDeg: g.rotationDeg });
+  }
+  return rectFootprint(g);
+}
+
+export function bedFootprint(bed: GardenBed): WorldPoint[] {
+  const x = bed.positionX ?? 12;
+  const y = bed.positionY ?? 12;
+  const length = bed.lengthInches ?? 96;
+  const width = bed.widthInches ?? 48;
+  if (bed.shape === 'circle') {
+    return ellipseFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
+  }
+  if (bed.shape === 'polygon' && bed.points && bed.points.length >= 3) {
+    return polygonFootprint({ x, y, points: bed.points, rotationDeg: bed.rotationDeg });
+  }
+  return rectFootprint({ x, y, length, width, rotationDeg: bed.rotationDeg });
+}
+
+// Extra svg space above the ground plate so tall objects (trees, sheds)
+// and crop silhouettes near the north edge never clip.
+const PAD_X = 80;
+const PAD_TOP = 160;
+const PAD_BOTTOM = 90;
+
+export interface SceneMetrics {
+  width: number;
+  height: number;
+  viewBox: string;
+}
+
+export function sceneMetrics(canvas: GardenCanvas): SceneMetrics {
+  const w = canvas.widthInches;
+  const h = canvas.heightInches;
+  const corners = projectFootprint([
+    { x: 0, y: 0 },
+    { x: w, y: 0 },
+    { x: w, y: h },
+    { x: 0, y: h },
+  ]);
+  const b = boundsOf(corners);
+  const width = b.maxX - b.minX + PAD_X * 2;
+  const height = b.maxY - b.minY + PAD_TOP + PAD_BOTTOM;
+  return {
+    width,
+    height,
+    viewBox: `${b.minX - PAD_X} ${b.minY - PAD_TOP} ${width} ${height}`,
+  };
+}

--- a/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
+++ b/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
@@ -51,8 +51,13 @@ export interface MapViewport {
 
 export function useMapViewport(contentWidth: number, contentHeight: number): MapViewport {
   const [transform, setTransform] = useState<Transform>({ scale: 1, x: 0, y: 0 });
+  // Latest-value mirror for gesture handlers. Synced in an effect (not
+  // during render) per the react-hooks/refs rule; every consumer is an
+  // event handler, which always fires after the commit that updates it.
   const transformRef = useRef(transform);
-  transformRef.current = transform;
+  useEffect(() => {
+    transformRef.current = transform;
+  }, [transform]);
 
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const wheelCleanupRef = useRef<(() => void) | null>(null);

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -27,6 +27,7 @@ import type {
 } from '../types/listing';
 import {
   defaultRectPolygonPoints,
+  normalizePolygonGeometry,
   shapeDefaults,
 } from '../components/GardenDesigner/bedDefaults';
 import {
@@ -79,6 +80,7 @@ export interface UseGardenDesignerResult {
     }
   ) => void;
   patchBed: (bedId: string, patch: Partial<GardenBed>) => void;
+  updateBedPoints: (bedId: string, points: BedPolygonPoint[]) => void;
   deleteBed: (bedId: string) => Promise<void>;
   addAnnotation: (presetId: string) => Promise<void>;
   moveAnnotation: (annotationId: string, positionX: number, positionY: number) => void;
@@ -166,6 +168,23 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   const [selected, setSelected] = useState<SelectedItem>(null);
   const [mode, setMode] = useState<DesignerMode>('idle');
   const [snap, setSnap] = useState<GridSnap>('12');
+
+  // All selection changes funnel through this wrapper so vertex editing
+  // ends the moment focus moves off the bed being reshaped (deselect,
+  // another element, a freshly created one). Re-clicking the same bed
+  // keeps the handles up.
+  const selectItem = useCallback(
+    (next: SelectedItem) => {
+      setMode((current) => {
+        if (current !== 'editing-vertices') return current;
+        const sameBed =
+          next?.kind === 'bed' && selected?.kind === 'bed' && next.id === selected.id;
+        return sameBed ? current : 'idle';
+      });
+      setSelected(next);
+    },
+    [selected]
+  );
 
   const canvasQuery = useQuery({
     queryKey: CANVAS_QUERY_KEY,
@@ -454,9 +473,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
             ? defaultRectPolygonPoints(defaults.lengthInches, defaults.widthInches)
             : null,
       });
-      setSelected({ kind: 'bed', id: created.id });
+      selectItem({ kind: 'bed', id: created.id });
     },
-    [beds.length, canvasQuery.data, createBedMutation, isEditable]
+    [beds.length, canvasQuery.data, createBedMutation, isEditable, selectItem]
   );
 
   const commitPolygon = useCallback(
@@ -480,10 +499,10 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         rotationDeg: 0,
         points: normalized,
       });
-      setSelected({ kind: 'bed', id: created.id });
+      selectItem({ kind: 'bed', id: created.id });
       setMode('idle');
     },
-    [beds.length, createBedMutation, isEditable]
+    [beds.length, createBedMutation, isEditable, selectItem]
   );
 
   const moveBed = useCallback(
@@ -534,15 +553,34 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     [beds, updateBedMutation]
   );
 
+  // Vertex edits arrive as the full reshaped point list (in the bed's
+  // local frame). Re-anchor it to (0,0) and refresh the bounding box so
+  // the inspector dimensions and iso footprint stay truthful.
+  const updateBedPoints = useCallback(
+    (bedId: string, points: BedPolygonPoint[]) => {
+      const bed = beds.find((b) => b.id === bedId);
+      if (!bed || bed.shape !== 'polygon' || points.length < 3) return;
+      const geometry = normalizePolygonGeometry({
+        positionX: bed.positionX ?? 12,
+        positionY: bed.positionY ?? 12,
+        rotationDeg: bed.rotationDeg,
+        points,
+      });
+      const payload = bedToUpsertPayload({ ...bed, ...geometry });
+      updateBedMutation.mutate({ bedId, payload });
+    },
+    [beds, updateBedMutation]
+  );
+
   const deleteBed = useCallback(
     async (bedId: string) => {
       if (!isEditable) return;
       await deleteBedMutation.mutateAsync(bedId);
       if (selected?.kind === 'bed' && selected.id === bedId) {
-        setSelected(null);
+        selectItem(null);
       }
     },
-    [deleteBedMutation, isEditable, selected]
+    [deleteBedMutation, isEditable, selected, selectItem]
   );
 
   const addAnnotation = useCallback(
@@ -571,9 +609,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         color: preset.defaultColor,
         points,
       });
-      setSelected({ kind: 'annotation', id: created.id });
+      selectItem({ kind: 'annotation', id: created.id });
     },
-    [canvasQuery.data, createAnnotationMutation, isEditable]
+    [canvasQuery.data, createAnnotationMutation, isEditable, selectItem]
   );
 
   const moveAnnotation = useCallback(
@@ -633,10 +671,10 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       if (!isEditable) return;
       await deleteAnnotationMutation.mutateAsync(annotationId);
       if (selected?.kind === 'annotation' && selected.id === annotationId) {
-        setSelected(null);
+        selectItem(null);
       }
     },
-    [deleteAnnotationMutation, isEditable, selected]
+    [deleteAnnotationMutation, isEditable, selected, selectItem]
   );
 
   const patchCanvas = useCallback(
@@ -666,6 +704,12 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       if (isEditingText(event.target)) return;
 
       if (event.key === 'Escape') {
+        // Step out of vertex editing first; a second Esc deselects.
+        if (mode === 'editing-vertices') {
+          event.preventDefault();
+          setMode('idle');
+          return;
+        }
         if (selected !== null) {
           event.preventDefault();
           setSelected(null);
@@ -674,6 +718,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       }
 
       if (event.key === 'Delete' || event.key === 'Backspace') {
+        // While reshaping, Delete is too close to "remove that vertex" to
+        // risk it nuking the whole bed.
+        if (mode === 'editing-vertices') return;
         if (!isEditable || !selected) return;
         if (selected.kind === 'bed' && selectedBed) {
           event.preventDefault();
@@ -743,7 +790,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       (annotationsQuery.error as Error | null) ??
       null,
     selected,
-    setSelected,
+    setSelected: selectItem,
     selectedBed,
     selectedAnnotation,
     mode,
@@ -758,6 +805,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     moveBed,
     resizeBed,
     patchBed,
+    updateBedPoints,
     deleteBed,
     addAnnotation,
     moveAnnotation,

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -122,6 +122,8 @@ export function GardenDesignerPage() {
           selectedBed={designer.selectedBed}
           selectedAnnotation={designer.selectedAnnotation}
           onSelect={designer.setSelected}
+          onPatchBed={designer.patchBed}
+          onPatchAnnotation={designer.patchAnnotation}
           onOpenLayoutEditor={() => switchView('layout')}
         />
       ) : (
@@ -185,6 +187,7 @@ export function GardenDesignerPage() {
                 void designer.commitPolygon(points);
               }}
               onCancelPolygon={() => designer.setMode('idle')}
+              onUpdateBedPoints={designer.updateBedPoints}
             />
 
             {designer.selectedBed && (
@@ -195,6 +198,12 @@ export function GardenDesignerPage() {
                 isEditable={designer.isEditable}
                 isSaving={designer.isSaving}
                 isMobile={designer.isMobile}
+                isVertexEditing={designer.mode === 'editing-vertices'}
+                onToggleVertexEditing={() =>
+                  designer.setMode(
+                    designer.mode === 'editing-vertices' ? 'idle' : 'editing-vertices'
+                  )
+                }
                 onChange={(patch) => {
                   if (designer.selectedBed) {
                     designer.patchBed(designer.selectedBed.id, patch);

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -2946,6 +2946,38 @@ body {
   color: var(--og-color-soil);
 }
 
+.grn-designer-inspector__shape-btn,
+.grn-designer-inspector__arrange-btn {
+  font: inherit;
+  font-size: 0.85rem;
+  color: var(--og-color-soil);
+  background: transparent;
+  border: 1px solid rgba(91, 140, 74, 0.45);
+  border-radius: var(--og-radius-sm);
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+}
+
+.grn-designer-inspector__shape-btn:hover:not(:disabled),
+.grn-designer-inspector__shape-btn:focus-visible,
+.grn-designer-inspector__arrange-btn:hover:not(:disabled),
+.grn-designer-inspector__arrange-btn:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  outline: none;
+}
+
+.grn-designer-inspector__shape-btn.is-active {
+  background: var(--og-color-moss);
+  border-color: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-inspector__arrange {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
 .grn-designer-inspector__add-crop {
   font: inherit;
   font-size: 0.85rem;
@@ -3656,6 +3688,31 @@ body {
 .mp-panel__footer {
   padding: 0.75rem 1.1rem 1rem;
   border-top: 1px solid rgba(91, 58, 28, 0.08);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.mp-panel__arrange {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.mp-panel__arrange-btn {
+  font: inherit;
+  font-size: 0.84rem;
+  color: var(--og-color-soil);
+  background: transparent;
+  border: 1px solid rgba(91, 140, 74, 0.45);
+  border-radius: var(--og-radius-pill);
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+}
+
+.mp-panel__arrange-btn:hover,
+.mp-panel__arrange-btn:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  outline: none;
 }
 
 .mp-panel__action {


### PR DESCRIPTION
Adds the two controls the isometric masterplan (#342) was missing: explicit stacking order for any element, and per-vertex editing of bed outlines so custom shapes render as illustrations.

## Layer ordering

Rides the existing `sort_order` field (already persisted, defaulted to 0, and ordered by the API), so **no backend changes**:

- **IsoScene** paints by `sortOrder` first, then the flat-kind grouping and painter's-algorithm depth. Untouched gardens render exactly as before; raising an element lifts it above overlapping neighbors (including lifting a path above a bed).
- The **Konva layout editor** renders beds and annotations as a single list sorted the same way, so both views always agree on stacking.
- **"Bring forward / Send backward"** buttons in the bed and annotation inspectors and in the masterplan detail panel (so you can fix stacking right where you notice it).

## Vertex editing

New `editing-vertices` designer mode:

- **VertexEditor** overlays the selected polygon bed with draggable, grid-snapped vertex handles, midpoint handles that split an edge, and double-click/double-tap removal (minimum 3 points). Touch-sized targets on coarse pointers.
- **`normalizePolygonGeometry`** re-anchors edited points to (0,0), rotating the offset into world space so rotated beds stay visually put, and refreshes the bounding-box dimensions.
- **BedInspector** gains "Edit shape points" for polygon beds and "Convert to custom shape" for rect/circle beds (circles become a 12-point low-poly ellipse).
- Esc steps out of the mode before deselecting; Delete is ignored while reshaping so it can't delete the bed mid-edit; moving the selection ends the mode automatically.

The iso renderer already normalized polygon footprints, so reshaped beds show up in the masterplan with no rendering changes.

## CI fixes (inherited from #342)

The first push surfaced two failures that pre-dated this branch — main itself was red on both. Fixed at the root rather than suppressed:

- **Frontend lint (11 errors):** `useMapViewport` wrote its latest-transform mirror ref during render (one render-time ref write that also tainted every `viewport.*` access in `GardenMasterplan`); the sync now happens in an effect and the hook result is destructured. The non-component exports (`bedFootprint`, `annotationFootprint`, `FLAT_KINDS`, `sceneMetrics`) moved to a new `footprints.ts` so the Iso* files satisfy react-refresh.
- **Performance budget (12 KB over before this branch):** the designer now uses react-konva's minimal-bundle pattern (`ReactKonvaCore` + only the shapes it renders) instead of the full konva build. GardenDesignerPage chunk shrinks 31.6 KB; total JS is 1,036,002 bytes, back under the 1,048,576-byte budget with headroom.

## Testing

- `npm test` (grn): 37 files, 330 tests pass — includes new unit tests for `normalizePolygonGeometry` / `ellipsePolygonPoints` and masterplan tests covering depth-vs-sortOrder paint order, flat-annotation lifting, detail-panel stacking buttons, and polygon bed rendering.
- `npm run typecheck`: clean.
- `npm run lint`: 0 errors.
- `npm run build` + `npm run perf:budget`: pass.
- No API endpoints changed, so no Postman updates required.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b