### PR TITLE
GRN: garden designer fundamentals — undo/redo, nudging, measuring, alignment, duplicate

### DIFF
--- a/apps/grn/scripts/check-performance-budget.mjs
+++ b/apps/grn/scripts/check-performance-budget.mjs
@@ -18,9 +18,12 @@ const vendorBundle = jsFiles.find((file) => file.name.includes('vendor'));
 const MAX_MAIN_BYTES = 220 * 1024;
 const MAX_VENDOR_BYTES = 520 * 1024;
 // Total includes lazy chunks. The designer route lazy-loads konva
-// (~150 KB gz), which lifts the total well above the pre-designer
-// baseline. The main and vendor caps still guard initial-load perf.
-const MAX_TOTAL_BYTES = 1024 * 1024;
+// (~120 KB gz even with the minimal-core build), and the 2026 designer
+// feature program (undo/redo, measuring, alignment, capacity, seasons,
+// shadows, templates, calibration, export) lives in that same lazy
+// chunk. The main and vendor caps above still guard initial-load perf;
+// this cap tracks overall growth.
+const MAX_TOTAL_BYTES = 1200 * 1024;
 
 const totalBytes = jsFiles.reduce((sum, file) => sum + file.size, 0);
 

--- a/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationInspector.tsx
@@ -9,6 +9,7 @@ interface AnnotationInspectorProps {
   isSaving: boolean;
   isMobile: boolean;
   onChange: (patch: Partial<GardenAnnotation>) => void;
+  onDuplicate: () => void;
   onDelete: () => void;
   onClose: () => void;
 }
@@ -19,6 +20,7 @@ export function AnnotationInspector({
   isSaving,
   isMobile,
   onChange,
+  onDuplicate,
   onDelete,
   onClose,
 }: AnnotationInspectorProps) {
@@ -206,15 +208,26 @@ export function AnnotationInspector({
         >
           {isSaving ? 'Saving…' : 'Saved'}
         </span>
-        <button
-          type="button"
-          className="grn-designer-inspector__delete"
-          onClick={onDelete}
-          disabled={!isEditable}
-          title="Delete annotation (Del or Backspace)"
-        >
-          Delete
-        </button>
+        <div className="grn-designer-inspector__footer-actions">
+          <button
+            type="button"
+            className="grn-designer-inspector__duplicate"
+            onClick={onDuplicate}
+            disabled={!isEditable}
+            title="Duplicate annotation (Ctrl+D)"
+          >
+            Duplicate
+          </button>
+          <button
+            type="button"
+            className="grn-designer-inspector__delete"
+            onClick={onDelete}
+            disabled={!isEditable}
+            title="Delete annotation (Del or Backspace)"
+          >
+            Delete
+          </button>
+        </div>
       </footer>
     </InspectorShell>
   );

--- a/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
@@ -28,6 +28,9 @@ interface AnnotationShapeProps {
   isEditable: boolean;
   onSelect: (annotationId: string) => void;
   onMove: (annotationId: string, positionX: number, positionY: number) => void;
+  /** Smart-alignment hook: given the in-flight drag position (inches),
+   * returns the position nudged onto neighbor alignment lines. */
+  onDragSnap?: (id: string, x: number, y: number) => { x: number; y: number } | null;
   onResize: (
     annotationId: string,
     next: {
@@ -69,6 +72,7 @@ export function AnnotationShape({
   isEditable,
   onSelect,
   onMove,
+  onDragSnap,
   onResize,
 }: AnnotationShapeProps) {
   const groupRef = useRef<Konva.Group | null>(null);
@@ -172,8 +176,23 @@ export function AnnotationShape({
     refreshDimsAnchor,
   ]);
 
+  function handleDragMove(event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    if (node === groupRef.current && onDragSnap) {
+      const snapped = onDragSnap(
+        annotation.id,
+        node.x() / pxPerInch,
+        node.y() / pxPerInch
+      );
+      if (snapped) {
+        node.position({ x: snapped.x * pxPerInch, y: snapped.y * pxPerInch });
+      }
+    }
+    refreshDimsAnchor();
+  }
+
   const dragProps = isEditable
-    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: refreshDimsAnchor }
+    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: handleDragMove }
     : { draggable: false };
 
   // Lines read better as a single run length ("24'") than as a bounding

--- a/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
@@ -5,7 +5,7 @@ import 'konva/lib/shapes/Line';
 import 'konva/lib/shapes/Rect';
 import 'konva/lib/shapes/Text';
 import 'konva/lib/shapes/Transformer';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Circle,
   Group,
@@ -15,6 +15,11 @@ import {
   Transformer,
 } from 'react-konva/lib/ReactKonvaCore';
 import type { GardenAnnotation } from '../../types/listing';
+import {
+  formatDimensions,
+  formatInchesAsFeetInches,
+  polylineLengthInches,
+} from './measure';
 
 interface AnnotationShapeProps {
   annotation: GardenAnnotation;
@@ -68,6 +73,19 @@ export function AnnotationShape({
 }: AnnotationShapeProps) {
   const groupRef = useRef<Konva.Group | null>(null);
   const transformerRef = useRef<Konva.Transformer | null>(null);
+  // Live size readout mid-transform; anchor for the label kept outside
+  // the group so the text never rotates or stretches. Mirrors BedShape.
+  const [liveScale, setLiveScale] = useState<{ x: number; y: number } | null>(null);
+  const [dimsAnchor, setDimsAnchor] = useState<{ x: number; y: number } | null>(null);
+
+  const refreshDimsAnchor = useCallback(() => {
+    const node = groupRef.current;
+    if (!node) return;
+    const layer = node.getLayer();
+    if (!layer) return;
+    const rect = node.getClientRect({ relativeTo: layer });
+    setDimsAnchor({ x: rect.x + 2, y: rect.y + rect.height + 6 });
+  }, []);
 
   const positionX = (annotation.positionX ?? 12) * pxPerInch;
   const positionY = (annotation.positionY ?? 12) * pxPerInch;
@@ -99,7 +117,15 @@ export function AnnotationShape({
     onMove(annotation.id, Math.max(0, nextX), Math.max(0, nextY));
   }
 
+  function handleTransform() {
+    const node = groupRef.current;
+    if (!node) return;
+    setLiveScale({ x: node.scaleX(), y: node.scaleY() });
+    refreshDimsAnchor();
+  }
+
   function handleTransformEnd() {
+    setLiveScale(null);
     const node = groupRef.current;
     if (!node) return;
     const scaleX = node.scaleX();
@@ -134,9 +160,40 @@ export function AnnotationShape({
     });
   }
 
+  useEffect(() => {
+    if (isSelected) refreshDimsAnchor();
+  }, [
+    isSelected,
+    positionX,
+    positionY,
+    widthPx,
+    heightPx,
+    annotation.rotationDeg,
+    refreshDimsAnchor,
+  ]);
+
   const dragProps = isEditable
-    ? { draggable: true, onDragEnd: handleDragEnd }
+    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: refreshDimsAnchor }
     : { draggable: false };
+
+  // Lines read better as a single run length ("24'") than as a bounding
+  // box; everything else shows length × width.
+  function dimsText(): string {
+    const sx = liveScale?.x ?? 1;
+    const sy = liveScale?.y ?? 1;
+    if (annotation.shape === 'line' && annotation.points && annotation.points.length >= 2) {
+      const scaled = annotation.points.map((p) => ({ x: p.x * sx, y: p.y * sy }));
+      return formatInchesAsFeetInches(polylineLengthInches(scaled));
+    }
+    if (annotation.shape === 'circle') {
+      const d = Math.round((annotation.lengthInches ?? 48) * ((sx + sy) / 2));
+      return `${formatInchesAsFeetInches(d)} across`;
+    }
+    return formatDimensions(
+      Math.round((annotation.lengthInches ?? 48) * sx),
+      Math.round((annotation.widthInches ?? 48) * sy)
+    );
+  }
 
   function renderShape() {
     if (annotation.shape === 'circle') {
@@ -202,6 +259,7 @@ export function AnnotationShape({
         rotation={annotation.rotationDeg}
         onMouseDown={() => onSelect(annotation.id)}
         onTouchStart={() => onSelect(annotation.id)}
+        onTransform={handleTransform}
         onTransformEnd={handleTransformEnd}
         {...dragProps}
       >
@@ -225,6 +283,20 @@ export function AnnotationShape({
           listening={false}
         />
       </Group>
+      {isSelected && dimsAnchor && (
+        <Text
+          x={dimsAnchor.x}
+          y={dimsAnchor.y}
+          text={dimsText()}
+          fontSize={13}
+          fontStyle="600"
+          fill="#3a7e5a"
+          shadowColor="#fff"
+          shadowBlur={5}
+          shadowOpacity={0.9}
+          listening={false}
+        />
+      )}
       {isEditable && (
         <Transformer
           ref={transformerRef}

--- a/apps/grn/src/components/GardenDesigner/BedInspector.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedInspector.tsx
@@ -26,6 +26,7 @@ interface BedInspectorProps {
   isVertexEditing: boolean;
   onToggleVertexEditing: () => void;
   onChange: (patch: Partial<GardenBed>) => void;
+  onDuplicate: () => void;
   onDelete: () => void;
   onClose: () => void;
 }
@@ -52,6 +53,7 @@ export function BedInspector({
   isVertexEditing,
   onToggleVertexEditing,
   onChange,
+  onDuplicate,
   onDelete,
   onClose,
 }: BedInspectorProps) {
@@ -400,15 +402,26 @@ export function BedInspector({
         >
           {isSaving ? 'Saving…' : 'Saved'}
         </span>
-        <button
-          type="button"
-          className="grn-designer-inspector__delete"
-          onClick={onDelete}
-          disabled={!isEditable}
-          title="Delete bed (Del or Backspace)"
-        >
-          Delete bed
-        </button>
+        <div className="grn-designer-inspector__footer-actions">
+          <button
+            type="button"
+            className="grn-designer-inspector__duplicate"
+            onClick={onDuplicate}
+            disabled={!isEditable}
+            title="Duplicate bed (Ctrl+D)"
+          >
+            Duplicate
+          </button>
+          <button
+            type="button"
+            className="grn-designer-inspector__delete"
+            onClick={onDelete}
+            disabled={!isEditable}
+            title="Delete bed (Del or Backspace)"
+          >
+            Delete bed
+          </button>
+        </div>
       </footer>
       <AddCropModal bed={bed} open={addCropOpen} onClose={() => setAddCropOpen(false)} />
     </InspectorShell>

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -30,6 +30,9 @@ interface BedShapeProps {
   crops: GrowerCropItem[];
   onSelect: (bedId: string) => void;
   onMove: (bedId: string, positionX: number, positionY: number) => void;
+  /** Smart-alignment hook: given the in-flight drag position (inches),
+   * returns the position nudged onto neighbor alignment lines. */
+  onDragSnap?: (id: string, x: number, y: number) => { x: number; y: number } | null;
   onResize: (
     bedId: string,
     next: {
@@ -83,6 +86,7 @@ export function BedShape({
   crops,
   onSelect,
   onMove,
+  onDragSnap,
   onResize,
 }: BedShapeProps) {
   const groupRef = useRef<Konva.Group | null>(null);
@@ -198,8 +202,19 @@ export function BedShape({
     refreshDimsAnchor,
   ]);
 
+  function handleDragMove(event: KonvaEventObject<DragEvent>) {
+    const node = event.target;
+    if (node === groupRef.current && onDragSnap) {
+      const snapped = onDragSnap(bed.id, node.x() / pxPerInch, node.y() / pxPerInch);
+      if (snapped) {
+        node.position({ x: snapped.x * pxPerInch, y: snapped.y * pxPerInch });
+      }
+    }
+    refreshDimsAnchor();
+  }
+
   const dragProps = isEditable
-    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: refreshDimsAnchor }
+    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: handleDragMove }
     : { draggable: false };
 
   function renderShape() {

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -6,7 +6,7 @@ import 'konva/lib/shapes/Path';
 import 'konva/lib/shapes/Rect';
 import 'konva/lib/shapes/Text';
 import 'konva/lib/shapes/Transformer';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Ellipse,
   Group,
@@ -18,6 +18,7 @@ import {
 } from 'react-konva/lib/ReactKonvaCore';
 import type { BedType, GardenBed, GrowerCropItem } from '../../types/listing';
 import { bedStyleFor } from './bedDefaults';
+import { formatDimensions } from './measure';
 import { visualForCrop } from '../CropPlanner/cropVisuals';
 import { CROP_ICON_PATHS } from '../CropPlanner/cropIconPaths';
 
@@ -86,6 +87,23 @@ export function BedShape({
 }: BedShapeProps) {
   const groupRef = useRef<Konva.Group | null>(null);
   const transformerRef = useRef<Konva.Transformer | null>(null);
+  // Live dimensions readout while the Transformer is mid-gesture; null
+  // means "show the committed dimensions".
+  const [liveDims, setLiveDims] = useState<{ length: number; width: number } | null>(
+    null
+  );
+  // Anchor (layer coords) for the dimensions label beneath the bed. Kept
+  // outside the group so the text never rotates or stretches with it.
+  const [dimsAnchor, setDimsAnchor] = useState<{ x: number; y: number } | null>(null);
+
+  const refreshDimsAnchor = useCallback(() => {
+    const node = groupRef.current;
+    if (!node) return;
+    const layer = node.getLayer();
+    if (!layer) return;
+    const rect = node.getClientRect({ relativeTo: layer });
+    setDimsAnchor({ x: rect.x + 2, y: rect.y + rect.height + 6 });
+  }, []);
 
   const positionX = (bed.positionX ?? 12) * pxPerInch;
   const positionY = (bed.positionY ?? 12) * pxPerInch;
@@ -120,7 +138,18 @@ export function BedShape({
     onMove(bed.id, nextX, nextY);
   }
 
+  function handleTransform() {
+    const node = groupRef.current;
+    if (!node) return;
+    setLiveDims({
+      length: Math.round((bed.lengthInches ?? 96) * node.scaleX()),
+      width: Math.round((bed.widthInches ?? 48) * node.scaleY()),
+    });
+    refreshDimsAnchor();
+  }
+
   function handleTransformEnd() {
+    setLiveDims(null);
     const node = groupRef.current;
     if (!node) return;
     const scaleX = node.scaleX();
@@ -155,8 +184,22 @@ export function BedShape({
     });
   }
 
+  // Keep the dimensions label anchored as the bed moves or its committed
+  // geometry changes.
+  useEffect(() => {
+    if (isSelected) refreshDimsAnchor();
+  }, [
+    isSelected,
+    positionX,
+    positionY,
+    widthPx,
+    heightPx,
+    bed.rotationDeg,
+    refreshDimsAnchor,
+  ]);
+
   const dragProps = isEditable
-    ? { draggable: true, onDragEnd: handleDragEnd }
+    ? { draggable: true, onDragEnd: handleDragEnd, onDragMove: refreshDimsAnchor }
     : { draggable: false };
 
   function renderShape() {
@@ -234,6 +277,7 @@ export function BedShape({
       rotation={bed.rotationDeg}
       onMouseDown={() => onSelect(bed.id)}
       onTouchStart={() => onSelect(bed.id)}
+      onTransform={handleTransform}
       onTransformEnd={handleTransformEnd}
       {...dragProps}
     >
@@ -276,6 +320,23 @@ export function BedShape({
         />
       )}
     </Group>
+    {isSelected && dimsAnchor && (
+      <Text
+        x={dimsAnchor.x}
+        y={dimsAnchor.y}
+        text={formatDimensions(
+          liveDims?.length ?? bed.lengthInches ?? 96,
+          liveDims?.width ?? bed.widthInches ?? 48
+        )}
+        fontSize={13}
+        fontStyle="600"
+        fill="#3a7e5a"
+        shadowColor="#fff"
+        shadowBlur={5}
+        shadowOpacity={0.9}
+        listening={false}
+      />
+    )}
     {isEditable && (
       <Transformer
         ref={transformerRef}

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -37,6 +37,11 @@ import { BackgroundLayer } from './BackgroundLayer';
 import { BedShape } from './BedShape';
 import { Grid } from './Grid';
 import { VertexEditor } from './VertexEditor';
+import {
+  snapToNeighbors,
+  type AlignmentGuide,
+  type ElementBounds,
+} from './alignment';
 import { distanceInches, formatInchesAsFeetInches } from './measure';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import type { DesignerMode, GridSnap } from './Toolbar';
@@ -152,6 +157,10 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     // segment); a third click starts a fresh measurement.
     const [measureA, setMeasureA] = useState<BedPolygonPoint | null>(null);
     const [measureB, setMeasureB] = useState<BedPolygonPoint | null>(null);
+    // Smart-alignment guide lines shown while a drag is locked onto a
+    // neighbor's edge or center.
+    const [alignGuides, setAlignGuides] = useState<AlignmentGuide[]>([]);
+    const elementSnapActiveRef = useRef(false);
 
     // Refs used during touch gestures so handlers don't need to be
     // re-bound on every render. The pinch handler in particular runs
@@ -486,10 +495,87 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       }
     }
 
+    // Bounds of everything except the dragged element, for smart
+    // alignment. Rotated elements are skipped — their axis-aligned box
+    // doesn't match their visual edges.
+    function neighborBounds(excludeKind: 'bed' | 'annotation', excludeId: string): ElementBounds[] {
+      const list: ElementBounds[] = [];
+      for (const bed of beds) {
+        if (excludeKind === 'bed' && bed.id === excludeId) continue;
+        if (bed.rotationDeg % 360 !== 0) continue;
+        const x = bed.positionX ?? 12;
+        const y = bed.positionY ?? 12;
+        list.push({
+          left: x,
+          top: y,
+          right: x + (bed.lengthInches ?? 96),
+          bottom: y + (bed.widthInches ?? 48),
+        });
+      }
+      for (const annotation of annotations) {
+        if (excludeKind === 'annotation' && annotation.id === excludeId) continue;
+        if (annotation.rotationDeg % 360 !== 0) continue;
+        const x = annotation.positionX ?? 12;
+        const y = annotation.positionY ?? 12;
+        list.push({
+          left: x,
+          top: y,
+          right: x + (annotation.lengthInches ?? 48),
+          bottom: y + (annotation.widthInches ?? 48),
+        });
+      }
+      return list;
+    }
+
+    function makeDragSnapper(
+      kind: 'bed' | 'annotation',
+      lengthInches: number,
+      widthInches: number,
+      rotationDeg: number
+    ) {
+      return (id: string, x: number, y: number): { x: number; y: number } | null => {
+        if (rotationDeg % 360 !== 0) return null;
+        const result = snapToNeighbors({
+          x,
+          y,
+          width: lengthInches,
+          height: widthInches,
+          neighbors: neighborBounds(kind, id),
+        });
+        setAlignGuides(result.guides);
+        elementSnapActiveRef.current = result.guides.length > 0;
+        return { x: result.x, y: result.y };
+      };
+    }
+
     function handleBedMove(bedId: string, x: number, y: number) {
+      const alignedToNeighbor = elementSnapActiveRef.current;
+      elementSnapActiveRef.current = false;
+      setAlignGuides([]);
+      if (alignedToNeighbor) {
+        // The drop position came from edge/center alignment; grid-snapping
+        // it afterwards would break the alignment the user just saw.
+        onMoveBed(bedId, Math.max(0, x), Math.max(0, y));
+        return;
+      }
       const snappedX = snapValue(x, snap);
       const snappedY = snapValue(y, snap);
       onMoveBed(bedId, Math.max(0, snappedX), Math.max(0, snappedY));
+    }
+
+    function handleAnnotationMove(annotationId: string, x: number, y: number) {
+      const alignedToNeighbor = elementSnapActiveRef.current;
+      elementSnapActiveRef.current = false;
+      setAlignGuides([]);
+      if (alignedToNeighbor) {
+        onMoveAnnotation(annotationId, Math.max(0, x), Math.max(0, y));
+        return;
+      }
+      onMoveAnnotation(
+        annotationId,
+        Math.max(0, snapValue(x, snap)),
+        Math.max(0, snapValue(y, snap))
+      );
     }
 
     const draftLinePoints = draftPoints.flatMap((p) => [
@@ -563,8 +649,14 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                     }
                     isEditable={isEditable && !drawing}
                     onSelect={(id) => onSelect({ kind: 'annotation', id })}
-                    onMove={onMoveAnnotation}
+                    onMove={handleAnnotationMove}
                     onResize={onResizeAnnotation}
+                    onDragSnap={makeDragSnapper(
+                      'annotation',
+                      item.annotation.lengthInches ?? 48,
+                      item.annotation.widthInches ?? 48,
+                      item.annotation.rotationDeg
+                    )}
                   />
                 ) : (
                   <BedShape
@@ -579,6 +671,12 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                     onSelect={(id) => onSelect({ kind: 'bed', id })}
                     onMove={handleBedMove}
                     onResize={onResizeBed}
+                    onDragSnap={makeDragSnapper(
+                      'bed',
+                      item.bed.lengthInches ?? 96,
+                      item.bed.widthInches ?? 48,
+                      item.bed.rotationDeg
+                    )}
                   />
                 )
               )}
@@ -622,6 +720,20 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                   listening={false}
                 />
               )}
+              {alignGuides.map((guide, idx) => (
+                <Line
+                  key={`guide-${idx}`}
+                  points={
+                    guide.orientation === 'vertical'
+                      ? [guide.position * PX_PER_INCH, 0, guide.position * PX_PER_INCH, heightPx]
+                      : [0, guide.position * PX_PER_INCH, widthPx, guide.position * PX_PER_INCH]
+                  }
+                  stroke="#c97aab"
+                  strokeWidth={1.4}
+                  dash={[6, 4]}
+                  listening={false}
+                />
+              ))}
               {measuring && (
                 <Rect
                   x={0}

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -5,6 +5,7 @@ import Konva from 'konva/lib/Core';
 import 'konva/lib/shapes/Circle';
 import 'konva/lib/shapes/Line';
 import 'konva/lib/shapes/Rect';
+import 'konva/lib/shapes/Text';
 import {
   forwardRef,
   useCallback,
@@ -15,7 +16,7 @@ import {
 import { useImperativeHandle } from 'react';
 import type { KonvaEventObject } from 'konva/lib/Node';
 import type { Stage as KonvaStage } from 'konva/lib/Stage';
-import { Circle, Layer, Line, Rect, Stage } from 'react-konva/lib/ReactKonvaCore';
+import { Circle, Layer, Line, Rect, Stage, Text } from 'react-konva/lib/ReactKonvaCore';
 
 // Tighten Konva's click-vs-drag detection. The default of 0px means any
 // pointer jitter on a draggable Group fires a drag instead of a click,
@@ -36,6 +37,7 @@ import { BackgroundLayer } from './BackgroundLayer';
 import { BedShape } from './BedShape';
 import { Grid } from './Grid';
 import { VertexEditor } from './VertexEditor';
+import { distanceInches, formatInchesAsFeetInches } from './measure';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import type { DesignerMode, GridSnap } from './Toolbar';
 
@@ -146,6 +148,10 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     const [position, setPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
     const [draftPoints, setDraftPoints] = useState<BedPolygonPoint[]>([]);
     const [hoverPoint, setHoverPoint] = useState<BedPolygonPoint | null>(null);
+    // Tape measure: A is set on first click, B on the second (frozen
+    // segment); a third click starts a fresh measurement.
+    const [measureA, setMeasureA] = useState<BedPolygonPoint | null>(null);
+    const [measureB, setMeasureB] = useState<BedPolygonPoint | null>(null);
 
     // Refs used during touch gestures so handlers don't need to be
     // re-bound on every render. The pinch handler in particular runs
@@ -232,6 +238,10 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
         setDraftPoints([]);
         setHoverPoint(null);
       }
+      if (mode !== 'measuring') {
+        setMeasureA(null);
+        setMeasureB(null);
+      }
     }, [mode]);
 
     // Esc cancels in-progress drawing.
@@ -246,6 +256,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     }, [mode, onCancelPolygon]);
 
     const drawing = mode === 'drawing-polygon';
+    const measuring = mode === 'measuring';
 
     // The bed whose vertices are being reshaped, if any. Its own
     // drag/Transformer interactions are suspended while the handles own
@@ -421,7 +432,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     }
 
     function handleStageMouseMove(event: KonvaEventObject<MouseEvent>) {
-      if (!drawing) return;
+      if (!drawing && !measuring) return;
       const stage = event.target.getStage();
       if (!stage) return;
       const pointer = relativePointer(stage);
@@ -429,6 +440,24 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       const inchX = snapValue(Math.round(pointer.x / PX_PER_INCH), snap);
       const inchY = snapValue(Math.round(pointer.y / PX_PER_INCH), snap);
       setHoverPoint({ x: inchX, y: inchY });
+    }
+
+    function handleMeasureClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
+      event.cancelBubble = true;
+      const stage = event.target.getStage();
+      if (!stage) return;
+      const pointer = relativePointer(stage);
+      if (!pointer) return;
+      const point = {
+        x: snapValue(Math.round(pointer.x / PX_PER_INCH), snap),
+        y: snapValue(Math.round(pointer.y / PX_PER_INCH), snap),
+      };
+      if (!measureA || measureB) {
+        setMeasureA(point);
+        setMeasureB(null);
+      } else {
+        setMeasureB(point);
+      }
     }
 
     function handleStageWheel(event: KonvaEventObject<WheelEvent>) {
@@ -593,6 +622,75 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                   listening={false}
                 />
               )}
+              {measuring && (
+                <Rect
+                  x={0}
+                  y={0}
+                  width={widthPx}
+                  height={heightPx}
+                  fill="rgba(0,0,0,0)"
+                  onClick={handleMeasureClick}
+                  onTap={handleMeasureClick}
+                />
+              )}
+              {measuring &&
+                measureA &&
+                (() => {
+                  const target = measureB ?? hoverPoint;
+                  const ax = measureA.x * PX_PER_INCH;
+                  const ay = measureA.y * PX_PER_INCH;
+                  const segments = target ? (
+                    <>
+                      <Line
+                        points={[
+                          ax,
+                          ay,
+                          target.x * PX_PER_INCH,
+                          target.y * PX_PER_INCH,
+                        ]}
+                        stroke="#8a6230"
+                        strokeWidth={2}
+                        dash={[8, 5]}
+                        listening={false}
+                      />
+                      <Circle
+                        x={target.x * PX_PER_INCH}
+                        y={target.y * PX_PER_INCH}
+                        radius={5}
+                        fill="#8a6230"
+                        stroke="#fff"
+                        strokeWidth={2}
+                        listening={false}
+                      />
+                      <Text
+                        x={((measureA.x + target.x) / 2) * PX_PER_INCH + 10}
+                        y={((measureA.y + target.y) / 2) * PX_PER_INCH - 20}
+                        text={formatInchesAsFeetInches(distanceInches(measureA, target))}
+                        fontSize={15}
+                        fontStyle="700"
+                        fill="#5b3a1c"
+                        shadowColor="#fff"
+                        shadowBlur={6}
+                        shadowOpacity={0.95}
+                        listening={false}
+                      />
+                    </>
+                  ) : null;
+                  return (
+                    <>
+                      <Circle
+                        x={ax}
+                        y={ay}
+                        radius={5}
+                        fill="#8a6230"
+                        stroke="#fff"
+                        strokeWidth={2}
+                        listening={false}
+                      />
+                      {segments}
+                    </>
+                  );
+                })()}
             </Layer>
           </Stage>
         <div className="grn-designer-canvas__zoom" role="group" aria-label="Zoom controls">
@@ -633,6 +731,12 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
           <div className="grn-designer-canvas__draw-hint" role="status">
             Drag points to reshape · tap an edge dot to add · double-tap a point
             to remove · esc to finish
+          </div>
+        )}
+        {measuring && (
+          <div className="grn-designer-canvas__draw-hint" role="status">
+            Click two points to measure · click again to start over · esc to
+            exit
           </div>
         )}
       </div>

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -3,7 +3,11 @@ import type { BedShape } from '../../types/listing';
 import { ANNOTATION_PRESETS } from './annotationPresets';
 import { BED_SHAPES } from './bedDefaults';
 
-export type DesignerMode = 'idle' | 'drawing-polygon' | 'editing-vertices';
+export type DesignerMode =
+  | 'idle'
+  | 'drawing-polygon'
+  | 'editing-vertices'
+  | 'measuring';
 export type GridSnap = 'off' | '6' | '12';
 
 interface ToolbarProps {
@@ -20,6 +24,7 @@ interface ToolbarProps {
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
+  onToggleMeasure: () => void;
 }
 
 /**
@@ -49,8 +54,10 @@ export function Toolbar({
   canRedo,
   onUndo,
   onRedo,
+  onToggleMeasure,
 }: ToolbarProps) {
   const drawing = mode === 'drawing-polygon';
+  const measuring = mode === 'measuring';
   const [moreOpen, setMoreOpen] = useState(false);
   const moreRef = useRef<HTMLDivElement | null>(null);
 
@@ -160,6 +167,28 @@ export function Toolbar({
     </>
   );
 
+  const measureButton = (
+    <button
+      type="button"
+      className={`grn-designer-toolbar__btn ${measuring ? 'is-active' : ''}`}
+      onClick={() => {
+        onToggleMeasure();
+        setMoreOpen(false);
+      }}
+      disabled={drawing}
+      title={
+        measuring
+          ? 'Click two points to measure. Esc to exit.'
+          : 'Measure distances on the canvas'
+      }
+      aria-label={measuring ? 'Stop measuring' : 'Measure distances'}
+      aria-pressed={measuring}
+    >
+      <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">📏</span>
+      <span className="grn-designer-toolbar__btn-label">Measure</span>
+    </button>
+  );
+
   const snapField = (
     <label className="grn-designer-toolbar__field">
       <span>Snap</span>
@@ -216,6 +245,7 @@ export function Toolbar({
             <div className="grn-designer-toolbar__sheet-section">
               <h3 className="grn-designer-toolbar__sheet-heading">View</h3>
               <div className="grn-designer-toolbar__sheet-row">
+                {measureButton}
                 {snapField}
                 <button
                   type="button"
@@ -268,6 +298,7 @@ export function Toolbar({
       <div className="grn-designer-toolbar__divider" aria-hidden="true" />
 
       <div className="grn-designer-toolbar__group" role="group" aria-label="View">
+        {measureButton}
         {snapField}
         <button
           type="button"

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -16,6 +16,10 @@ interface ToolbarProps {
   gridSnap: GridSnap;
   onGridSnapChange: (snap: GridSnap) => void;
   onFitToScreen: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
 }
 
 /**
@@ -41,6 +45,10 @@ export function Toolbar({
   gridSnap,
   onGridSnapChange,
   onFitToScreen,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
 }: ToolbarProps) {
   const drawing = mode === 'drawing-polygon';
   const [moreOpen, setMoreOpen] = useState(false);
@@ -125,6 +133,33 @@ export function Toolbar({
     </button>
   ));
 
+  const undoRedoButtons = (
+    <>
+      <button
+        type="button"
+        className="grn-designer-toolbar__btn"
+        onClick={onUndo}
+        disabled={!canUndo}
+        title="Undo (Ctrl+Z)"
+        aria-label="Undo"
+      >
+        <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">↶</span>
+        <span className="grn-designer-toolbar__btn-label">Undo</span>
+      </button>
+      <button
+        type="button"
+        className="grn-designer-toolbar__btn"
+        onClick={onRedo}
+        disabled={!canRedo}
+        title="Redo (Ctrl+Shift+Z)"
+        aria-label="Redo"
+      >
+        <span className="grn-designer-toolbar__btn-emoji" aria-hidden="true">↷</span>
+        <span className="grn-designer-toolbar__btn-label">Redo</span>
+      </button>
+    </>
+  );
+
   const snapField = (
     <label className="grn-designer-toolbar__field">
       <span>Snap</span>
@@ -175,6 +210,10 @@ export function Toolbar({
               <div className="grn-designer-toolbar__sheet-grid">{annotationButtons}</div>
             </div>
             <div className="grn-designer-toolbar__sheet-section">
+              <h3 className="grn-designer-toolbar__sheet-heading">Edit</h3>
+              <div className="grn-designer-toolbar__sheet-row">{undoRedoButtons}</div>
+            </div>
+            <div className="grn-designer-toolbar__sheet-section">
               <h3 className="grn-designer-toolbar__sheet-heading">View</h3>
               <div className="grn-designer-toolbar__sheet-row">
                 {snapField}
@@ -205,6 +244,12 @@ export function Toolbar({
       role="toolbar"
       aria-label="Garden designer tools"
     >
+      <div className="grn-designer-toolbar__group" role="group" aria-label="Edit history">
+        {undoRedoButtons}
+      </div>
+
+      <div className="grn-designer-toolbar__divider" aria-hidden="true" />
+
       <div className="grn-designer-toolbar__group" role="group" aria-label="Add a bed">
         {bedButtons}
         {drawButton}

--- a/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
+++ b/apps/grn/src/components/GardenDesigner/VertexEditor.tsx
@@ -1,9 +1,11 @@
 import type { KonvaEventObject } from 'konva/lib/Node';
 import 'konva/lib/shapes/Circle';
 import 'konva/lib/shapes/Line';
+import 'konva/lib/shapes/Text';
 import { useState } from 'react';
-import { Circle, Group, Line } from 'react-konva/lib/ReactKonvaCore';
+import { Circle, Group, Line, Text } from 'react-konva/lib/ReactKonvaCore';
 import type { BedPolygonPoint, GardenBed } from '../../types/listing';
+import { distanceInches, formatInchesAsFeetInches } from './measure';
 import type { GridSnap } from './Toolbar';
 
 interface VertexEditorProps {
@@ -92,6 +94,10 @@ export function VertexEditor({ bed, pxPerInch, snap, onCommit }: VertexEditorPro
   }
 
   const outline = points.flatMap((p) => [p.x * pxPerInch, p.y * pxPerInch]);
+  const centroid = points.reduce(
+    (acc, p) => ({ x: acc.x + p.x / points.length, y: acc.y + p.y / points.length }),
+    { x: 0, y: 0 }
+  );
 
   return (
     <Group x={positionX} y={positionY} rotation={bed.rotationDeg}>
@@ -106,24 +112,50 @@ export function VertexEditor({ bed, pxPerInch, snap, onCommit }: VertexEditorPro
       {points.map((point, idx) => {
         const next = points[(idx + 1) % points.length];
         const midpoint = { x: (point.x + next.x) / 2, y: (point.y + next.y) / 2 };
+        // Push the edge-length label outward from the shape so it doesn't
+        // sit under the midpoint handle. Of the two perpendiculars, keep
+        // the one pointing away from the centroid (winding-agnostic).
+        const edgeLength = distanceInches(point, next);
+        let nx = next.y - point.y;
+        let ny = point.x - next.x;
+        if (nx * (midpoint.x - centroid.x) + ny * (midpoint.y - centroid.y) < 0) {
+          nx = -nx;
+          ny = -ny;
+        }
+        const nLen = Math.hypot(nx, ny) || 1;
         return (
-          <Circle
-            key={`mid-${idx}`}
-            x={midpoint.x * pxPerInch}
-            y={midpoint.y * pxPerInch}
-            radius={MIDPOINT_RADIUS}
-            fill="rgba(255, 255, 255, 0.9)"
-            stroke="#3a7e5a"
-            strokeWidth={1.5}
-            onMouseDown={(event) => {
-              event.cancelBubble = true;
-              handleInsertAfter(idx, midpoint);
-            }}
-            onTouchStart={(event) => {
-              event.cancelBubble = true;
-              handleInsertAfter(idx, midpoint);
-            }}
-          />
+          <Group key={`mid-${idx}`}>
+            <Circle
+              x={midpoint.x * pxPerInch}
+              y={midpoint.y * pxPerInch}
+              radius={MIDPOINT_RADIUS}
+              fill="rgba(255, 255, 255, 0.9)"
+              stroke="#3a7e5a"
+              strokeWidth={1.5}
+              onMouseDown={(event) => {
+                event.cancelBubble = true;
+                handleInsertAfter(idx, midpoint);
+              }}
+              onTouchStart={(event) => {
+                event.cancelBubble = true;
+                handleInsertAfter(idx, midpoint);
+              }}
+            />
+            {edgeLength >= 12 && (
+              <Text
+                x={midpoint.x * pxPerInch + (nx / nLen) * 16 - 18}
+                y={midpoint.y * pxPerInch + (ny / nLen) * 16 - 6}
+                text={formatInchesAsFeetInches(edgeLength)}
+                fontSize={11}
+                fontStyle="600"
+                fill="#3a7e5a"
+                shadowColor="#fff"
+                shadowBlur={4}
+                shadowOpacity={0.9}
+                listening={false}
+              />
+            )}
+          </Group>
         );
       })}
       {points.map((point, idx) => (

--- a/apps/grn/src/components/GardenDesigner/alignment.test.ts
+++ b/apps/grn/src/components/GardenDesigner/alignment.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { snapToNeighbors } from './alignment';
+
+const neighbor = { left: 100, top: 50, right: 196, bottom: 98 }; // 96×48 at (100,50)
+
+describe('snapToNeighbors', () => {
+  it('snaps a left edge to a neighbor left edge within tolerance', () => {
+    const result = snapToNeighbors({
+      x: 101.5,
+      y: 200,
+      width: 96,
+      height: 48,
+      neighbors: [neighbor],
+    });
+    expect(result.x).toBe(100);
+    expect(result.y).toBe(200);
+    expect(result.guides).toEqual([{ orientation: 'vertical', position: 100 }]);
+  });
+
+  it('snaps centers to centers', () => {
+    // Neighbor centerX = 148. Dragged width 40 -> center at x+20.
+    const result = snapToNeighbors({
+      x: 127,
+      y: 300,
+      width: 40,
+      height: 40,
+      neighbors: [neighbor],
+    });
+    expect(result.x).toBe(128);
+    expect(result.guides[0]).toEqual({ orientation: 'vertical', position: 148 });
+  });
+
+  it('snaps both axes independently', () => {
+    const result = snapToNeighbors({
+      x: 197.4, // right-edge adjacency: dragged left to neighbor right (196)
+      y: 49,
+      width: 96,
+      height: 48,
+      neighbors: [neighbor],
+    });
+    expect(result.x).toBe(196);
+    expect(result.y).toBe(50);
+    expect(result.guides).toHaveLength(2);
+  });
+
+  it('leaves position untouched outside tolerance', () => {
+    const result = snapToNeighbors({
+      x: 110,
+      y: 200,
+      width: 96,
+      height: 48,
+      neighbors: [neighbor],
+    });
+    expect(result.x).toBe(110);
+    expect(result.guides).toHaveLength(0);
+  });
+
+  it('prefers the closest line when several are in range', () => {
+    const result = snapToNeighbors({
+      x: 99,
+      y: 200,
+      width: 96,
+      height: 48,
+      neighbors: [neighbor, { left: 97, top: 0, right: 145, bottom: 20 }],
+    });
+    // 97 is 2 away, 100 is 1 away -> 100 wins.
+    expect(result.x).toBe(100);
+    expect(result.guides[0].position).toBe(100);
+  });
+
+  it('handles no neighbors', () => {
+    const result = snapToNeighbors({
+      x: 10,
+      y: 10,
+      width: 96,
+      height: 48,
+      neighbors: [],
+    });
+    expect(result).toEqual({ x: 10, y: 10, guides: [] });
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/alignment.ts
+++ b/apps/grn/src/components/GardenDesigner/alignment.ts
@@ -1,0 +1,98 @@
+// Smart alignment for drags in the layout editor: the dragged element's
+// edges and centers snap to neighbors' edges and centers, and the editor
+// draws a guide line through whatever it locked onto. All units inches.
+
+export interface ElementBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+export interface AlignmentGuide {
+  orientation: 'vertical' | 'horizontal';
+  position: number;
+}
+
+export interface SnapToNeighborsResult {
+  x: number;
+  y: number;
+  guides: AlignmentGuide[];
+}
+
+function axisCandidates(start: number, size: number): number[] {
+  return [start, start + size / 2, start + size];
+}
+
+interface AxisMatch {
+  delta: number;
+  guidePosition: number;
+}
+
+function bestAxisMatch(
+  dragged: number[],
+  neighborLines: number[],
+  tolerance: number
+): AxisMatch | null {
+  let best: AxisMatch | null = null;
+  for (const line of neighborLines) {
+    for (const candidate of dragged) {
+      const delta = line - candidate;
+      if (Math.abs(delta) > tolerance) continue;
+      if (!best || Math.abs(delta) < Math.abs(best.delta)) {
+        best = { delta, guidePosition: line };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Given the dragged element's proposed position and the bounds of its
+ * neighbors, returns the position nudged onto the nearest alignment line
+ * within tolerance (per axis, independently) plus the guide lines to draw.
+ * No match inside tolerance leaves that axis untouched.
+ */
+export function snapToNeighbors(args: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  neighbors: ElementBounds[];
+  toleranceInches?: number;
+}): SnapToNeighborsResult {
+  const { x, y, width, height, neighbors, toleranceInches = 2 } = args;
+
+  const verticalLines: number[] = [];
+  const horizontalLines: number[] = [];
+  for (const n of neighbors) {
+    verticalLines.push(...axisCandidates(n.left, n.right - n.left));
+    horizontalLines.push(...axisCandidates(n.top, n.bottom - n.top));
+  }
+
+  const guides: AlignmentGuide[] = [];
+  let nextX = x;
+  let nextY = y;
+
+  const vMatch = bestAxisMatch(
+    axisCandidates(x, width),
+    verticalLines,
+    toleranceInches
+  );
+  if (vMatch) {
+    nextX = x + vMatch.delta;
+    guides.push({ orientation: 'vertical', position: vMatch.guidePosition });
+  }
+
+  const hMatch = bestAxisMatch(
+    axisCandidates(y, height),
+    horizontalLines,
+    toleranceInches
+  );
+  if (hMatch) {
+    nextY = y + hMatch.delta;
+    guides.push({ orientation: 'horizontal', position: hMatch.guidePosition });
+  }
+
+  return { x: nextX, y: nextY, guides };
+}

--- a/apps/grn/src/components/GardenDesigner/measure.test.ts
+++ b/apps/grn/src/components/GardenDesigner/measure.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  distanceInches,
+  formatDimensions,
+  formatInchesAsFeetInches,
+  polylineLengthInches,
+} from './measure';
+
+describe('distanceInches', () => {
+  it('measures straight and diagonal distances', () => {
+    expect(distanceInches({ x: 0, y: 0 }, { x: 36, y: 0 })).toBe(36);
+    expect(distanceInches({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+});
+
+describe('formatInchesAsFeetInches', () => {
+  it('formats inches under a foot', () => {
+    expect(formatInchesAsFeetInches(7)).toBe('7"');
+    expect(formatInchesAsFeetInches(0)).toBe('0"');
+  });
+
+  it('formats whole feet without an inch part', () => {
+    expect(formatInchesAsFeetInches(96)).toBe("8'");
+    expect(formatInchesAsFeetInches(12)).toBe("1'");
+  });
+
+  it('formats mixed feet and inches, rounding to the nearest inch', () => {
+    expect(formatInchesAsFeetInches(100)).toBe('8\' 4"');
+    expect(formatInchesAsFeetInches(100.4)).toBe('8\' 4"');
+    expect(formatInchesAsFeetInches(100.6)).toBe('8\' 5"');
+  });
+
+  it('clamps negatives to zero', () => {
+    expect(formatInchesAsFeetInches(-3)).toBe('0"');
+  });
+});
+
+describe('formatDimensions', () => {
+  it('joins both axes', () => {
+    expect(formatDimensions(96, 48)).toBe("8' × 4'");
+    expect(formatDimensions(100, 7)).toBe('8\' 4" × 7"');
+  });
+});
+
+describe('polylineLengthInches', () => {
+  it('sums segment lengths and handles degenerate inputs', () => {
+    expect(
+      polylineLengthInches([
+        { x: 0, y: 0 },
+        { x: 36, y: 0 },
+        { x: 36, y: 48 },
+      ])
+    ).toBe(84);
+    expect(polylineLengthInches([{ x: 5, y: 5 }])).toBe(0);
+    expect(polylineLengthInches([])).toBe(0);
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/measure.ts
+++ b/apps/grn/src/components/GardenDesigner/measure.ts
@@ -1,0 +1,35 @@
+// Distance math + display formatting for the layout editor's dimension
+// labels and tape-measure tool. World units are inches.
+
+export interface MeasurePoint {
+  x: number;
+  y: number;
+}
+
+export function distanceInches(a: MeasurePoint, b: MeasurePoint): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+// 100 -> 8' 4", 96 -> 8', 7 -> 7". Rounded to the nearest inch — finer
+// precision is noise at garden scale.
+export function formatInchesAsFeetInches(value: number): string {
+  const inches = Math.max(0, Math.round(value));
+  const feet = Math.floor(inches / 12);
+  const rest = inches % 12;
+  if (feet === 0) return `${rest}"`;
+  if (rest === 0) return `${feet}'`;
+  return `${feet}' ${rest}"`;
+}
+
+export function formatDimensions(lengthInches: number, widthInches: number): string {
+  return `${formatInchesAsFeetInches(lengthInches)} × ${formatInchesAsFeetInches(widthInches)}`;
+}
+
+// Total length along an open polyline (fences, paths).
+export function polylineLengthInches(points: MeasurePoint[]): number {
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i += 1) {
+    total += distanceInches(points[i], points[i + 1]);
+  }
+  return total;
+}

--- a/apps/grn/src/hooks/designerHistory.test.ts
+++ b/apps/grn/src/hooks/designerHistory.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMPTY_HISTORY,
+  canRedo,
+  canUndo,
+  peekRedo,
+  peekUndo,
+  pushEntry,
+  remapEntityId,
+  steppedBack,
+  steppedForward,
+  type HistoryEntry,
+} from './designerHistory';
+
+function bedUpdate(
+  id: string,
+  x: number,
+  at: number,
+  coalesceKey?: string
+): HistoryEntry {
+  return {
+    kind: 'bed-update',
+    id,
+    before: { name: 'Bed', positionX: x - 1 },
+    after: { name: 'Bed', positionX: x },
+    at,
+    coalesceKey,
+  };
+}
+
+describe('designerHistory', () => {
+  it('starts empty with nothing to undo or redo', () => {
+    expect(canUndo(EMPTY_HISTORY)).toBe(false);
+    expect(canRedo(EMPTY_HISTORY)).toBe(false);
+    expect(peekUndo(EMPTY_HISTORY)).toBeNull();
+    expect(peekRedo(EMPTY_HISTORY)).toBeNull();
+  });
+
+  it('pushes entries and steps back and forward through them', () => {
+    let h = pushEntry(EMPTY_HISTORY, bedUpdate('a', 1, 0));
+    h = pushEntry(h, bedUpdate('a', 2, 5000));
+    expect(canUndo(h)).toBe(true);
+    expect(canRedo(h)).toBe(false);
+
+    expect(peekUndo(h)?.at).toBe(5000);
+    h = steppedBack(h);
+    expect(peekUndo(h)?.at).toBe(0);
+    expect(peekRedo(h)?.at).toBe(5000);
+
+    h = steppedForward(h);
+    expect(canRedo(h)).toBe(false);
+  });
+
+  it('drops the redo tail when a new entry is pushed after undo', () => {
+    let h = pushEntry(EMPTY_HISTORY, bedUpdate('a', 1, 0));
+    h = pushEntry(h, bedUpdate('a', 2, 5000));
+    h = steppedBack(h);
+    h = pushEntry(h, bedUpdate('a', 9, 10000));
+    expect(h.entries).toHaveLength(2);
+    expect(canRedo(h)).toBe(false);
+    expect((peekUndo(h) as { after: { positionX?: number } }).after.positionX).toBe(9);
+  });
+
+  it('coalesces rapid same-key updates into one entry keeping first before and last after', () => {
+    let h = pushEntry(EMPTY_HISTORY, bedUpdate('a', 1, 0, 'nudge'));
+    h = pushEntry(h, bedUpdate('a', 2, 200, 'nudge'));
+    h = pushEntry(h, bedUpdate('a', 3, 400, 'nudge'));
+    expect(h.entries).toHaveLength(1);
+    const entry = h.entries[0] as Extract<HistoryEntry, { kind: 'bed-update' }>;
+    expect(entry.before.positionX).toBe(0);
+    expect(entry.after.positionX).toBe(3);
+  });
+
+  it('does not coalesce across the time window, different keys, or different entities', () => {
+    let h = pushEntry(EMPTY_HISTORY, bedUpdate('a', 1, 0, 'nudge'));
+    h = pushEntry(h, bedUpdate('a', 2, 5000, 'nudge'));
+    h = pushEntry(h, bedUpdate('a', 3, 5100, 'resize'));
+    h = pushEntry(h, bedUpdate('b', 4, 5200, 'resize'));
+    expect(h.entries).toHaveLength(4);
+  });
+
+  it('caps the stack at 50 entries, dropping the oldest', () => {
+    let h = EMPTY_HISTORY;
+    for (let i = 0; i < 60; i += 1) {
+      h = pushEntry(h, bedUpdate('a', i, i * 5000));
+    }
+    expect(h.entries).toHaveLength(50);
+    expect((h.entries[0] as { after: { positionX?: number } }).after.positionX).toBe(10);
+  });
+
+  it('remaps entity ids only for the matching entity kind', () => {
+    let h = pushEntry(EMPTY_HISTORY, bedUpdate('old', 1, 0));
+    h = pushEntry(h, {
+      kind: 'annotation-update',
+      id: 'old',
+      before: { label: 'Tree' },
+      after: { label: 'Oak' },
+      at: 5000,
+    });
+    h = remapEntityId(h, 'bed', 'old', 'new');
+    expect(h.entries[0].id).toBe('new');
+    expect(h.entries[1].id).toBe('old');
+  });
+});

--- a/apps/grn/src/hooks/designerHistory.ts
+++ b/apps/grn/src/hooks/designerHistory.ts
@@ -1,0 +1,126 @@
+// Undo/redo history for the garden designer.
+//
+// Pure data + functions so the stack logic is unit-testable apart from
+// React Query. Entries describe geometry-level operations on beds and
+// annotations; the hook owns *applying* them (and recreating entities on
+// undo-of-delete, which mints new server ids — hence remapEntityId).
+
+import type {
+  UpsertGardenAnnotationRequest,
+  UpsertGardenBedRequest,
+} from '../services/api';
+
+export type HistoryEntityKind = 'bed' | 'annotation';
+
+export type HistoryEntry =
+  | {
+      kind: 'bed-update';
+      id: string;
+      before: UpsertGardenBedRequest;
+      after: UpsertGardenBedRequest;
+      at: number;
+      coalesceKey?: string;
+    }
+  | { kind: 'bed-create'; id: string; payload: UpsertGardenBedRequest; at: number }
+  | { kind: 'bed-delete'; id: string; payload: UpsertGardenBedRequest; at: number }
+  | {
+      kind: 'annotation-update';
+      id: string;
+      before: UpsertGardenAnnotationRequest;
+      after: UpsertGardenAnnotationRequest;
+      at: number;
+      coalesceKey?: string;
+    }
+  | {
+      kind: 'annotation-create';
+      id: string;
+      payload: UpsertGardenAnnotationRequest;
+      at: number;
+    }
+  | {
+      kind: 'annotation-delete';
+      id: string;
+      payload: UpsertGardenAnnotationRequest;
+      at: number;
+    };
+
+export interface DesignerHistory {
+  entries: HistoryEntry[];
+  // Number of entries currently applied; entries[index..] is the redo tail.
+  index: number;
+}
+
+const MAX_ENTRIES = 50;
+// Rapid same-key updates (arrow-key nudges, slider drags) merge into one
+// undo step so Cmd+Z doesn't replay them inch by inch.
+const COALESCE_WINDOW_MS = 1000;
+
+export const EMPTY_HISTORY: DesignerHistory = { entries: [], index: 0 };
+
+export function canUndo(history: DesignerHistory): boolean {
+  return history.index > 0;
+}
+
+export function canRedo(history: DesignerHistory): boolean {
+  return history.index < history.entries.length;
+}
+
+export function pushEntry(history: DesignerHistory, entry: HistoryEntry): DesignerHistory {
+  const applied = history.entries.slice(0, history.index);
+
+  const last = applied[applied.length - 1];
+  if (
+    last &&
+    (entry.kind === 'bed-update' || entry.kind === 'annotation-update') &&
+    entry.coalesceKey !== undefined &&
+    (last.kind === 'bed-update' || last.kind === 'annotation-update') &&
+    last.kind === entry.kind &&
+    last.id === entry.id &&
+    last.coalesceKey === entry.coalesceKey &&
+    entry.at - last.at <= COALESCE_WINDOW_MS
+  ) {
+    const merged = { ...last, after: entry.after, at: entry.at } as HistoryEntry;
+    const entries = [...applied.slice(0, -1), merged];
+    return { entries, index: entries.length };
+  }
+
+  const entries = [...applied, entry].slice(-MAX_ENTRIES);
+  return { entries, index: entries.length };
+}
+
+export function peekUndo(history: DesignerHistory): HistoryEntry | null {
+  return canUndo(history) ? history.entries[history.index - 1] : null;
+}
+
+export function peekRedo(history: DesignerHistory): HistoryEntry | null {
+  return canRedo(history) ? history.entries[history.index] : null;
+}
+
+export function steppedBack(history: DesignerHistory): DesignerHistory {
+  if (!canUndo(history)) return history;
+  return { ...history, index: history.index - 1 };
+}
+
+export function steppedForward(history: DesignerHistory): DesignerHistory {
+  if (!canRedo(history)) return history;
+  return { ...history, index: history.index + 1 };
+}
+
+// Undoing a delete (or redoing a create) recreates the entity server-side
+// under a fresh id. Every other entry referring to the old id must follow,
+// or the rest of the stack would orphan.
+export function remapEntityId(
+  history: DesignerHistory,
+  kind: HistoryEntityKind,
+  oldId: string,
+  newId: string
+): DesignerHistory {
+  return {
+    ...history,
+    entries: history.entries.map((entry) =>
+      entry.kind.startsWith(kind) && entry.id === oldId
+        ? { ...entry, id: newId }
+        : entry
+    ),
+  };
+}

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -973,8 +973,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       }
 
       if (event.key === 'Escape') {
-        // Step out of vertex editing first; a second Esc deselects.
-        if (mode === 'editing-vertices') {
+        // Step out of vertex editing / measuring first; a second Esc
+        // deselects.
+        if (mode === 'editing-vertices' || mode === 'measuring') {
           event.preventDefault();
           setMode('idle');
           return;

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -80,6 +80,7 @@ export interface UseGardenDesignerResult {
   isEditable: boolean;
   isSaving: boolean;
   addBed: (shape: BedShape) => Promise<void>;
+  duplicateSelected: () => Promise<void>;
   commitPolygon: (points: BedPolygonPoint[]) => Promise<void>;
   moveBed: (bedId: string, positionX: number, positionY: number) => void;
   resizeBed: (
@@ -887,6 +888,51 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     void stepHistory('redo');
   }, [stepHistory]);
 
+  // Clone the selected element 12 inches down-right, select the clone,
+  // and record it so Cmd+Z removes it again.
+  const duplicateSelected = useCallback(async () => {
+    if (!isEditable || historyBusyRef.current) return;
+    if (selected?.kind === 'bed' && selectedBed) {
+      const payload: UpsertGardenBedRequest = {
+        ...bedToUpsertPayload(selectedBed),
+        name: `${selectedBed.name} copy`.slice(0, 80),
+        positionX: (selectedBed.positionX ?? 12) + 12,
+        positionY: (selectedBed.positionY ?? 12) + 12,
+      };
+      const created = await createBedMutation.mutateAsync(payload);
+      record({
+        kind: 'bed-create',
+        id: created.id,
+        payload: bedToUpsertPayload(created),
+        at: Date.now(),
+      });
+      selectItem({ kind: 'bed', id: created.id });
+    } else if (selected?.kind === 'annotation' && selectedAnnotation) {
+      const payload: UpsertGardenAnnotationRequest = {
+        ...annotationToUpsertPayload(selectedAnnotation),
+        positionX: (selectedAnnotation.positionX ?? 12) + 12,
+        positionY: (selectedAnnotation.positionY ?? 12) + 12,
+      };
+      const created = await createAnnotationMutation.mutateAsync(payload);
+      record({
+        kind: 'annotation-create',
+        id: created.id,
+        payload: annotationToUpsertPayload(created),
+        at: Date.now(),
+      });
+      selectItem({ kind: 'annotation', id: created.id });
+    }
+  }, [
+    createAnnotationMutation,
+    createBedMutation,
+    isEditable,
+    record,
+    selectItem,
+    selected,
+    selectedAnnotation,
+    selectedBed,
+  ]);
+
   // Arrow-key nudging for the selected element. Rapid presses coalesce
   // into a single undo step (see designerHistory).
   const nudgeSelected = useCallback(
@@ -940,6 +986,13 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       if (isEditingText(event.target)) return;
 
       const meta = event.metaKey || event.ctrlKey;
+      if (meta && (event.key === 'd' || event.key === 'D')) {
+        if (selected) {
+          event.preventDefault();
+          void duplicateSelected();
+        }
+        return;
+      }
       if (meta && (event.key === 'z' || event.key === 'Z')) {
         event.preventDefault();
         if (event.shiftKey) {
@@ -1021,6 +1074,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     undo,
     redo,
     nudgeSelected,
+    duplicateSelected,
   ]);
 
   const uploadBackgroundImage = useCallback(
@@ -1082,6 +1136,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     isEditable,
     isSaving,
     addBed,
+    duplicateSelected,
     commitPolygon,
     moveBed,
     resizeBed,

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -1,5 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EMPTY_HISTORY,
+  canRedo as historyCanRedo,
+  canUndo as historyCanUndo,
+  peekRedo,
+  peekUndo,
+  pushEntry,
+  remapEntityId,
+  steppedBack,
+  steppedForward,
+  type DesignerHistory,
+  type HistoryEntityKind,
+  type HistoryEntry,
+} from './designerHistory';
 import {
   createMyAnnotation,
   createMyBed,
@@ -100,6 +114,10 @@ export interface UseGardenDesignerResult {
   patchCanvas: (patch: UpsertGardenCanvasRequest) => void;
   uploadBackgroundImage: (file: File) => Promise<void>;
   clearBackgroundImage: () => Promise<void>;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
 }
 
 const MOBILE_BREAKPOINT = 768;
@@ -404,6 +422,56 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     },
   });
 
+  // --- Undo/redo -----------------------------------------------------------
+  // Geometry-level history over bed/annotation mutations. Canvas settings
+  // and crop assignments are deliberately out of scope. Entries are
+  // recorded at the commit helpers below; undo/redo replays them through
+  // the raw mutations so nothing re-records.
+  const [history, setHistory] = useState<DesignerHistory>(EMPTY_HISTORY);
+  const historyBusyRef = useRef(false);
+
+  const record = useCallback((entry: HistoryEntry) => {
+    setHistory((h) => pushEntry(h, entry));
+  }, []);
+
+  const commitBedUpdate = useCallback(
+    (bed: GardenBed, payload: UpsertGardenBedRequest, coalesceKey?: string) => {
+      const before = bedToUpsertPayload(bed);
+      if (JSON.stringify(before) === JSON.stringify(payload)) return;
+      record({
+        kind: 'bed-update',
+        id: bed.id,
+        before,
+        after: payload,
+        at: Date.now(),
+        coalesceKey,
+      });
+      updateBedMutation.mutate({ bedId: bed.id, payload });
+    },
+    [record, updateBedMutation]
+  );
+
+  const commitAnnotationUpdate = useCallback(
+    (
+      annotation: GardenAnnotation,
+      payload: UpsertGardenAnnotationRequest,
+      coalesceKey?: string
+    ) => {
+      const before = annotationToUpsertPayload(annotation);
+      if (JSON.stringify(before) === JSON.stringify(payload)) return;
+      record({
+        kind: 'annotation-update',
+        id: annotation.id,
+        before,
+        after: payload,
+        at: Date.now(),
+        coalesceKey,
+      });
+      updateAnnotationMutation.mutate({ annotationId: annotation.id, payload });
+    },
+    [record, updateAnnotationMutation]
+  );
+
   const beds = useMemo(() => bedsQuery.data ?? [], [bedsQuery.data]);
   const annotations = useMemo(
     () => annotationsQuery.data ?? [],
@@ -473,9 +541,15 @@ export function useGardenDesigner(): UseGardenDesignerResult {
             ? defaultRectPolygonPoints(defaults.lengthInches, defaults.widthInches)
             : null,
       });
+      record({
+        kind: 'bed-create',
+        id: created.id,
+        payload: bedToUpsertPayload(created),
+        at: Date.now(),
+      });
       selectItem({ kind: 'bed', id: created.id });
     },
-    [beds.length, canvasQuery.data, createBedMutation, isEditable, selectItem]
+    [beds.length, canvasQuery.data, createBedMutation, isEditable, record, selectItem]
   );
 
   const commitPolygon = useCallback(
@@ -499,10 +573,16 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         rotationDeg: 0,
         points: normalized,
       });
+      record({
+        kind: 'bed-create',
+        id: created.id,
+        payload: bedToUpsertPayload(created),
+        at: Date.now(),
+      });
       selectItem({ kind: 'bed', id: created.id });
       setMode('idle');
     },
-    [beds.length, createBedMutation, isEditable, selectItem]
+    [beds.length, createBedMutation, isEditable, record, selectItem]
   );
 
   const moveBed = useCallback(
@@ -510,9 +590,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       const bed = beds.find((b) => b.id === bedId);
       if (!bed) return;
       const payload = bedToUpsertPayload({ ...bed, positionX, positionY });
-      updateBedMutation.mutate({ bedId, payload });
+      commitBedUpdate(bed, payload);
     },
-    [beds, updateBedMutation]
+    [beds, commitBedUpdate]
   );
 
   const resizeBed = useCallback(
@@ -538,9 +618,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         rotationDeg: next.rotationDeg,
         points: next.points,
       });
-      updateBedMutation.mutate({ bedId, payload });
+      commitBedUpdate(bed, payload);
     },
-    [beds, updateBedMutation]
+    [beds, commitBedUpdate]
   );
 
   const patchBed = useCallback(
@@ -548,9 +628,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       const bed = beds.find((b) => b.id === bedId);
       if (!bed) return;
       const payload = bedToUpsertPayload({ ...bed, ...patch });
-      updateBedMutation.mutate({ bedId, payload });
+      commitBedUpdate(bed, payload);
     },
-    [beds, updateBedMutation]
+    [beds, commitBedUpdate]
   );
 
   // Vertex edits arrive as the full reshaped point list (in the bed's
@@ -567,20 +647,29 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         points,
       });
       const payload = bedToUpsertPayload({ ...bed, ...geometry });
-      updateBedMutation.mutate({ bedId, payload });
+      commitBedUpdate(bed, payload);
     },
-    [beds, updateBedMutation]
+    [beds, commitBedUpdate]
   );
 
   const deleteBed = useCallback(
     async (bedId: string) => {
       if (!isEditable) return;
+      const bed = beds.find((b) => b.id === bedId);
       await deleteBedMutation.mutateAsync(bedId);
+      if (bed) {
+        record({
+          kind: 'bed-delete',
+          id: bedId,
+          payload: bedToUpsertPayload(bed),
+          at: Date.now(),
+        });
+      }
       if (selected?.kind === 'bed' && selected.id === bedId) {
         selectItem(null);
       }
     },
-    [deleteBedMutation, isEditable, selected, selectItem]
+    [beds, deleteBedMutation, isEditable, record, selected, selectItem]
   );
 
   const addAnnotation = useCallback(
@@ -609,9 +698,15 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         color: preset.defaultColor,
         points,
       });
+      record({
+        kind: 'annotation-create',
+        id: created.id,
+        payload: annotationToUpsertPayload(created),
+        at: Date.now(),
+      });
       selectItem({ kind: 'annotation', id: created.id });
     },
-    [canvasQuery.data, createAnnotationMutation, isEditable, selectItem]
+    [canvasQuery.data, createAnnotationMutation, isEditable, record, selectItem]
   );
 
   const moveAnnotation = useCallback(
@@ -623,9 +718,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         positionX,
         positionY,
       });
-      updateAnnotationMutation.mutate({ annotationId, payload });
+      commitAnnotationUpdate(annotation, payload);
     },
-    [annotations, updateAnnotationMutation]
+    [annotations, commitAnnotationUpdate]
   );
 
   const resizeAnnotation = useCallback(
@@ -651,9 +746,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         rotationDeg: next.rotationDeg,
         points: next.points,
       });
-      updateAnnotationMutation.mutate({ annotationId, payload });
+      commitAnnotationUpdate(annotation, payload);
     },
-    [annotations, updateAnnotationMutation]
+    [annotations, commitAnnotationUpdate]
   );
 
   const patchAnnotation = useCallback(
@@ -661,20 +756,29 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       const annotation = annotations.find((a) => a.id === annotationId);
       if (!annotation) return;
       const payload = annotationToUpsertPayload({ ...annotation, ...patch });
-      updateAnnotationMutation.mutate({ annotationId, payload });
+      commitAnnotationUpdate(annotation, payload);
     },
-    [annotations, updateAnnotationMutation]
+    [annotations, commitAnnotationUpdate]
   );
 
   const deleteAnnotation = useCallback(
     async (annotationId: string) => {
       if (!isEditable) return;
+      const annotation = annotations.find((a) => a.id === annotationId);
       await deleteAnnotationMutation.mutateAsync(annotationId);
+      if (annotation) {
+        record({
+          kind: 'annotation-delete',
+          id: annotationId,
+          payload: annotationToUpsertPayload(annotation),
+          at: Date.now(),
+        });
+      }
       if (selected?.kind === 'annotation' && selected.id === annotationId) {
         selectItem(null);
       }
     },
-    [deleteAnnotationMutation, isEditable, selected, selectItem]
+    [annotations, deleteAnnotationMutation, isEditable, record, selected, selectItem]
   );
 
   const patchCanvas = useCallback(
@@ -684,9 +788,141 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     [updateCanvasMutation]
   );
 
+  // Applies one history entry in the given direction through the raw
+  // mutations (so nothing re-records). Recreating an entity returns an id
+  // remap that the caller must fold back into the stack.
+  const applyEntry = useCallback(
+    async (
+      entry: HistoryEntry,
+      direction: 'undo' | 'redo'
+    ): Promise<{ kind: HistoryEntityKind; oldId: string; newId: string } | null> => {
+      switch (entry.kind) {
+        case 'bed-update':
+          await updateBedMutation.mutateAsync({
+            bedId: entry.id,
+            payload: direction === 'undo' ? entry.before : entry.after,
+          });
+          return null;
+        case 'annotation-update':
+          await updateAnnotationMutation.mutateAsync({
+            annotationId: entry.id,
+            payload: direction === 'undo' ? entry.before : entry.after,
+          });
+          return null;
+        case 'bed-create':
+        case 'bed-delete': {
+          const recreate =
+            (entry.kind === 'bed-create') === (direction === 'redo');
+          if (!recreate) {
+            await deleteBedMutation.mutateAsync(entry.id);
+            if (selected?.kind === 'bed' && selected.id === entry.id) {
+              setSelected(null);
+            }
+            return null;
+          }
+          const created = await createBedMutation.mutateAsync(entry.payload);
+          return { kind: 'bed', oldId: entry.id, newId: created.id };
+        }
+        case 'annotation-create':
+        case 'annotation-delete': {
+          const recreate =
+            (entry.kind === 'annotation-create') === (direction === 'redo');
+          if (!recreate) {
+            await deleteAnnotationMutation.mutateAsync(entry.id);
+            if (selected?.kind === 'annotation' && selected.id === entry.id) {
+              setSelected(null);
+            }
+            return null;
+          }
+          const created = await createAnnotationMutation.mutateAsync(entry.payload);
+          return { kind: 'annotation', oldId: entry.id, newId: created.id };
+        }
+      }
+    },
+    [
+      createAnnotationMutation,
+      createBedMutation,
+      deleteAnnotationMutation,
+      deleteBedMutation,
+      selected,
+      updateAnnotationMutation,
+      updateBedMutation,
+    ]
+  );
+
+  const stepHistory = useCallback(
+    async (direction: 'undo' | 'redo') => {
+      if (historyBusyRef.current || !isEditable) return;
+      const entry = direction === 'undo' ? peekUndo(history) : peekRedo(history);
+      if (!entry) return;
+      historyBusyRef.current = true;
+      setHistory(direction === 'undo' ? steppedBack : steppedForward);
+      try {
+        const remap = await applyEntry(entry, direction);
+        if (remap) {
+          setHistory((h) => remapEntityId(h, remap.kind, remap.oldId, remap.newId));
+          setSelected((prev) =>
+            prev && prev.id === remap.oldId ? { ...prev, id: remap.newId } : prev
+          );
+        }
+      } catch {
+        // The mutation failed (and its optimistic update rolled back), so
+        // put the pointer back where it was. If the user managed to push a
+        // new entry in the same instant, the pointer is already correct.
+        setHistory((h) =>
+          direction === 'undo' ? steppedForward(h) : steppedBack(h)
+        );
+      } finally {
+        historyBusyRef.current = false;
+      }
+    },
+    [applyEntry, history, isEditable]
+  );
+
+  const undo = useCallback(() => {
+    void stepHistory('undo');
+  }, [stepHistory]);
+
+  const redo = useCallback(() => {
+    void stepHistory('redo');
+  }, [stepHistory]);
+
+  // Arrow-key nudging for the selected element. Rapid presses coalesce
+  // into a single undo step (see designerHistory).
+  const nudgeSelected = useCallback(
+    (dx: number, dy: number) => {
+      if (!isEditable) return;
+      if (selected?.kind === 'bed' && selectedBed) {
+        const payload = bedToUpsertPayload({
+          ...selectedBed,
+          positionX: Math.max(0, (selectedBed.positionX ?? 12) + dx),
+          positionY: Math.max(0, (selectedBed.positionY ?? 12) + dy),
+        });
+        commitBedUpdate(selectedBed, payload, 'nudge');
+      } else if (selected?.kind === 'annotation' && selectedAnnotation) {
+        const payload = annotationToUpsertPayload({
+          ...selectedAnnotation,
+          positionX: Math.max(0, (selectedAnnotation.positionX ?? 12) + dx),
+          positionY: Math.max(0, (selectedAnnotation.positionY ?? 12) + dy),
+        });
+        commitAnnotationUpdate(selectedAnnotation, payload, 'nudge');
+      }
+    },
+    [
+      commitAnnotationUpdate,
+      commitBedUpdate,
+      isEditable,
+      selected,
+      selectedAnnotation,
+      selectedBed,
+    ]
+  );
+
   // Keyboard shortcuts:
   //   Esc           - deselect (when not in drawing-polygon mode; the
   //                   Canvas owns Esc-to-cancel for that mode)
+  //   Cmd/Ctrl+Z    - undo; with Shift (or Ctrl+Y) - redo
+  //   Arrow keys    - nudge the selected element 1 inch (Shift = 12)
   //   Delete /
   //   Backspace     - prompt for confirmation, then delete the selected
   //                   bed or annotation. Skipped when focus is in a text
@@ -702,6 +938,39 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     function onKeyDown(event: KeyboardEvent) {
       if (mode === 'drawing-polygon') return;
       if (isEditingText(event.target)) return;
+
+      const meta = event.metaKey || event.ctrlKey;
+      if (meta && (event.key === 'z' || event.key === 'Z')) {
+        event.preventDefault();
+        if (event.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+        return;
+      }
+      if (meta && (event.key === 'y' || event.key === 'Y')) {
+        event.preventDefault();
+        redo();
+        return;
+      }
+
+      if (
+        selected &&
+        (event.key === 'ArrowUp' ||
+          event.key === 'ArrowDown' ||
+          event.key === 'ArrowLeft' ||
+          event.key === 'ArrowRight')
+      ) {
+        event.preventDefault();
+        const step = event.shiftKey ? 12 : 1;
+        const dx =
+          event.key === 'ArrowLeft' ? -step : event.key === 'ArrowRight' ? step : 0;
+        const dy =
+          event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0;
+        nudgeSelected(dx, dy);
+        return;
+      }
 
       if (event.key === 'Escape') {
         // Step out of vertex editing first; a second Esc deselects.
@@ -740,7 +1009,18 @@ export function useGardenDesigner(): UseGardenDesignerResult {
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [mode, selected, selectedBed, selectedAnnotation, isEditable, deleteBed, deleteAnnotation]);
+  }, [
+    mode,
+    selected,
+    selectedBed,
+    selectedAnnotation,
+    isEditable,
+    deleteBed,
+    deleteAnnotation,
+    undo,
+    redo,
+    nudgeSelected,
+  ]);
 
   const uploadBackgroundImage = useCallback(
     async (file: File) => {
@@ -815,5 +1095,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     patchCanvas,
     uploadBackgroundImage,
     clearBackgroundImage,
+    undo,
+    redo,
+    canUndo: historyCanUndo(history),
+    canRedo: historyCanRedo(history),
   };
 }

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -216,6 +216,9 @@ export function GardenDesignerPage() {
                     designer.patchBed(designer.selectedBed.id, patch);
                   }
                 }}
+                onDuplicate={() => {
+                  void designer.duplicateSelected();
+                }}
                 onDelete={() => {
                   if (designer.selectedBed) {
                     void designer.deleteBed(designer.selectedBed.id);
@@ -236,6 +239,9 @@ export function GardenDesignerPage() {
                   if (designer.selectedAnnotation) {
                     designer.patchAnnotation(designer.selectedAnnotation.id, patch);
                   }
+                }}
+                onDuplicate={() => {
+                  void designer.duplicateSelected();
                 }}
                 onDelete={() => {
                   if (designer.selectedAnnotation) {

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -165,6 +165,10 @@ export function GardenDesignerPage() {
               gridSnap={designer.snap}
               onGridSnapChange={designer.setSnap}
               onFitToScreen={() => canvasRef.current?.fitToScreen()}
+              canUndo={designer.canUndo}
+              canRedo={designer.canRedo}
+              onUndo={designer.undo}
+              onRedo={designer.redo}
             />
 
             <DesignerCanvas

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -169,6 +169,9 @@ export function GardenDesignerPage() {
               canRedo={designer.canRedo}
               onUndo={designer.undo}
               onRedo={designer.redo}
+              onToggleMeasure={() =>
+                designer.setMode(designer.mode === 'measuring' ? 'idle' : 'measuring')
+              }
             />
 
             <DesignerCanvas

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -3048,6 +3048,32 @@ body {
   padding-top: 0.85rem;
 }
 
+.grn-designer-inspector__footer-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.grn-designer-inspector__duplicate {
+  border: 1px solid rgba(91, 140, 74, 0.45);
+  color: var(--og-color-soil);
+  background: transparent;
+  border-radius: var(--og-radius-sm);
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.grn-designer-inspector__duplicate:hover:not(:disabled),
+.grn-designer-inspector__duplicate:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  outline: none;
+}
+
+.grn-designer-inspector__duplicate:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Pin the footer to the bottom of the sheet so Delete is always within
    thumb reach without scrolling. */
 .grn-designer-inspector--sheet .grn-designer-inspector__footer {

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,7 +449,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -747,7 +746,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -1236,7 +1234,6 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.2.tgz",
       "integrity": "sha512-tH4WddhIJQPGhdOlQJJrPbHF0HWnQO43ivyMVK9iauPFtWmmI4wZn1NiTjV1YDbrOWyJvbcE20WpugP2CB96hA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "^3.973.6",
@@ -2963,7 +2960,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3325,7 +3321,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -3374,7 +3369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -6385,8 +6379,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@stripe/stripe-js": {
       "version": "7.9.0",
@@ -6562,7 +6555,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -6742,7 +6736,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6826,7 +6819,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -7230,7 +7222,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7342,7 +7333,6 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.4.tgz",
       "integrity": "sha512-BeeLmYMz+J9BLsKHOW/iMrewyG9GwlkmIyqYRcfByo6RHNOz5BFgKn+ASo0RtbMX+duBK1llNWcjfdTbGMcTBw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.94",
         "@aws-amplify/api": "6.3.25",
@@ -7450,7 +7440,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7943,7 +7932,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8065,7 +8055,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8824,7 +8813,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8934,15 +8922,13 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
@@ -9037,6 +9023,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9297,7 +9284,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9478,7 +9464,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9543,6 +9528,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9558,6 +9544,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9647,7 +9634,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9657,7 +9643,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9686,7 +9671,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-konva": {
       "version": "19.2.3",
@@ -10485,7 +10471,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10692,7 +10677,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11122,7 +11106,6 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -11256,7 +11239,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Wave 1 of the best-in-class designer program: the editor fundamentals.

## Undo/redo
- Every geometry edit on beds and annotations (move, resize, vertex reshape, create, delete, inspector patches) records into a 50-entry history. **Cmd/Ctrl+Z** undoes, **Shift+Cmd/Ctrl+Z** / **Ctrl+Y** redoes; toolbar Undo/Redo buttons on desktop and in the mobile More sheet.
- `designerHistory.ts` is a pure, unit-tested stack with redo-tail truncation, 1-second coalescing for rapid same-key updates, and entity-id remapping (undoing a delete recreates the row under a new id; the rest of the stack and the selection follow).
- Undo/redo replays through the raw mutations so nothing re-records. Canvas settings and crop assignments are intentionally out of scope.

## Keyboard nudging
- Arrow keys move the selected element 1", Shift+arrows 12", clamped at the canvas origin, coalesced into a single undo step.

## Dimension labels + tape measure
- Selected elements show a live size label beneath their bounding box (lines read as run length, circles as diameter) that tracks drags and Transformer gestures without rotating/stretching with the shape.
- Vertex editing labels every edge with its length, pushed outward from the midpoint handles.
- New **Measure** tool (toolbar 📏): click-click distance measurement with a live dashed line and ft/in readout; Esc exits.

## Smart alignment + duplicate
- Drags snap edges and centers to unrotated neighbors within 2", drawing a dashed guide line through the match; an aligned drop bypasses grid snapping so what you saw is what persists.
- **Cmd/Ctrl+D** and inspector Duplicate buttons clone the selected element offset 12", select the clone, and record it as undoable.

## Budget note
This wave (and the two that follow) lives in the lazy GardenDesignerPage chunk, which crossed the 1 MiB *total* JS budget by ~0.6 KB. As discussed, `MAX_TOTAL_BYTES` is raised to 1.2 MiB with a comment documenting the designer feature program; the main/vendor caps that actually guard initial-load performance are unchanged.

## Scope note
From the original list, marquee **multi-select** is the one piece deliberately deferred — group-drag semantics in Konva plus batched undo entries deserve their own focused PR rather than a rushed tail on this one. Duplicate + alignment guides cover most of the repetition pain in the meantime.

## Testing
- 350 tests pass (new: designerHistory 7, measure 4, alignment 6); lint 0 errors; typecheck clean; build + perf budget pass.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b)_