### PR TITLE
GRN: illustrated front-elevation garden pyramid with crop showcase

### DIFF
--- a/apps/grn/src/components/Planner/GardenPyramid.test.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { PyramidTier } from '../CropPlanner/gardenPyramid';
+import { GardenPyramid, type PyramidCropVisual } from './GardenPyramid';
+
+function crop(id: string, label: string): PyramidCropVisual {
+  return { id, label, iconKey: 'tomato', accent: '#c1452f' };
+}
+
+const EMPTY: Record<PyramidTier, PyramidCropVisual[]> = {
+  1: [],
+  2: [],
+  3: [],
+  4: [],
+  5: [],
+};
+
+function renderPyramid(args?: {
+  cropsByTier?: Partial<Record<PyramidTier, PyramidCropVisual[]>>;
+  activeTier?: PyramidTier;
+  onSelectTier?: (tier: PyramidTier) => void;
+}) {
+  return render(
+    <GardenPyramid
+      cropsByTier={{ ...EMPTY, ...args?.cropsByTier }}
+      activeTier={args?.activeTier ?? 1}
+      onSelectTier={args?.onSelectTier ?? (() => {})}
+    />
+  );
+}
+
+describe('GardenPyramid (isometric)', () => {
+  it('renders all five terraces as labelled buttons', () => {
+    renderPyramid({ cropsByTier: { 1: [crop('a', 'Potato')] } });
+    expect(screen.getByTestId('pyramid-band-foundation')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-workhorse')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-fresh')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-flavor')).toBeInTheDocument();
+    expect(screen.getByTestId('pyramid-band-joy')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /layer 1, foundation: 1 crop planned/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /layer 5, joy: nothing here yet/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the crop count on covered tiers and + on empty ones', () => {
+    renderPyramid({
+      cropsByTier: { 2: [crop('a', 'Tomato'), crop('b', 'Pepper')] },
+    });
+    expect(screen.getByTestId('pyramid-count-workhorse')).toHaveTextContent('2');
+    expect(screen.getByTestId('pyramid-count-fresh')).toHaveTextContent('+');
+  });
+
+  it('collapses crops beyond the ledge capacity into a +N chip', () => {
+    const many = Array.from({ length: 9 }, (_, i) => crop(`c${i}`, `Crop ${i}`));
+    renderPyramid({ cropsByTier: { 1: many } });
+    // Foundation holds 6 silhouettes; the remaining 3 collapse.
+    expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+
+  it('selects a tier on click', async () => {
+    const onSelectTier = vi.fn();
+    renderPyramid({ onSelectTier });
+    await userEvent.click(screen.getByTestId('pyramid-band-flavor'));
+    expect(onSelectTier).toHaveBeenCalledWith(4);
+  });
+
+  it('selects a tier with the keyboard', async () => {
+    const onSelectTier = vi.fn();
+    renderPyramid({ onSelectTier });
+    const joy = screen.getByTestId('pyramid-band-joy');
+    (joy as unknown as HTMLElement).focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onSelectTier).toHaveBeenCalledWith(5);
+  });
+
+  it('marks the active tier as pressed', () => {
+    renderPyramid({ activeTier: 3 });
+    expect(screen.getByTestId('pyramid-band-fresh')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('pyramid-band-joy')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('previews ghost suggestions on empty tiers', () => {
+    renderPyramid();
+    // Foundation is empty, so its curated suggestions stand as ghosts
+    // (svg <title> tooltips carry the names).
+    expect(screen.getByText('Potatoes', { selector: 'title' })).toBeInTheDocument();
+    expect(screen.getByText('Sweet potatoes', { selector: 'title' })).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/Planner/GardenPyramid.test.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.test.tsx
@@ -54,11 +54,21 @@ describe('GardenPyramid (isometric)', () => {
     expect(screen.getByTestId('pyramid-count-fresh')).toHaveTextContent('+');
   });
 
-  it('collapses crops beyond the ledge capacity into a +N chip', () => {
+  it('shows a few silhouettes on the shoulders with a +N chip when resting', () => {
     const many = Array.from({ length: 9 }, (_, i) => crop(`c${i}`, `Crop ${i}`));
-    renderPyramid({ cropsByTier: { 1: many } });
-    // Foundation holds 6 silhouettes; the remaining 3 collapse.
-    expect(screen.getByText('+3')).toBeInTheDocument();
+    // Foundation is NOT the active tier, so it rests: 4 on the
+    // shoulders, the remaining 5 collapse.
+    renderPyramid({ cropsByTier: { 1: many }, activeTier: 3 });
+    expect(screen.getByText('+5')).toBeInTheDocument();
+    expect(screen.getAllByText(/^Crop \d$/, { selector: 'title' })).toHaveLength(4);
+  });
+
+  it('showcases the full planting of the active tier', () => {
+    const many = Array.from({ length: 9 }, (_, i) => crop(`c${i}`, `Crop ${i}`));
+    renderPyramid({ cropsByTier: { 1: many }, activeTier: 1 });
+    // All nine stand across the band; no overflow chip.
+    expect(screen.getAllByText(/^Crop \d$/, { selector: 'title' })).toHaveLength(9);
+    expect(screen.queryByText(/^\+\d+$/)).not.toBeInTheDocument();
   });
 
   it('selects a tier on click', async () => {

--- a/apps/grn/src/components/Planner/GardenPyramid.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.tsx
@@ -1,6 +1,25 @@
-import { PYRAMID_TIERS, type PyramidTier } from '../CropPlanner/gardenPyramid';
-import { CropIcon } from '../CropPlanner/cropIcons';
-import type { CropIconKey } from '../CropPlanner/cropIconPaths';
+import type { KeyboardEvent } from 'react';
+import { PYRAMID_TIERS, type PyramidTier, type PyramidTierMeta } from '../CropPlanner/gardenPyramid';
+import { CROP_ICON_PATHS, type CropIconKey } from '../CropPlanner/cropIconPaths';
+import {
+  projectFootprint,
+  scaleFootprint,
+  smoothClosedPath,
+  toPath,
+} from '../GardenMasterplan/iso';
+import { SCENE, mixHex, mute, shade, tint } from '../GardenMasterplan/palette';
+import {
+  badgeAnchor,
+  groundRing,
+  labelAnchor,
+  ledgeAnchors,
+  ledgeCapacity,
+  pyramidMetrics,
+  tierBaseZ,
+  tierFootprint,
+  tierTopZ,
+  tierWalls,
+} from './pyramidGeometry';
 
 export interface PyramidCropVisual {
   id: string;
@@ -17,110 +36,240 @@ interface GardenPyramidProps {
   onSelectTier: (tier: PyramidTier) => void;
 }
 
-// Stepped widths give the stacked bands a clear pyramid silhouette — widest at
-// the Foundation, narrowest at Joy. Indexed by level (1-5).
-const BAND_WIDTH: Record<PyramidTier, string> = {
-  1: '100%',
-  2: '88%',
-  3: '76%',
-  4: '64%',
-  5: '52%',
-};
-
-// How many crop icons to show inline before collapsing into a "+N" pill.
-const MAX_VISIBLE_ICONS = 6;
+const GHOST_COLOR = '#a39c8a';
 
 /**
- * The Garden Pyramid hero. Renders the five layers top (Joy) to bottom
- * (Foundation) as selectable bands. Each band shows the vector icons of the
- * crops the grower has placed there; empty layers preview faded suggestion
- * icons so the gardener can see what belongs.
+ * The Garden Pyramid hero, drawn as an isometric terraced hill in the
+ * same flat-shaded illustration language as the garden masterplan. Each
+ * tier is a selectable terrace: planted crops stand on its front ledge as
+ * silhouettes, empty tiers preview faded suggestions. Hovering lifts a
+ * terrace while the others recede; the active terrace keeps a dashed
+ * survey ring.
  */
 export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenPyramidProps) {
-  // Render narrowest (top) to widest (bottom): Joy → Foundation.
-  const topDown = [...PYRAMID_TIERS].reverse();
+  const metrics = pyramidMetrics();
+  const ring = groundRing();
 
   return (
-    <div className="grn-pyramid" role="list" aria-label="Garden pyramid layers">
-      {topDown.map((tier) => {
-        const crops = cropsByTier[tier.level] ?? [];
-        const count = crops.length;
-        const covered = count > 0;
-        const isActive = activeTier === tier.level;
-        const visible = crops.slice(0, MAX_VISIBLE_ICONS);
-        const overflow = count - visible.length;
-
-        return (
-          <button
+    <div className="grn-iso-pyramid">
+      <svg
+        className="mp-scene grn-iso-pyramid__svg"
+        viewBox={metrics.viewBox}
+        role="group"
+        aria-label="Garden pyramid layers"
+      >
+        <g aria-hidden="true">
+          <path
+            d={smoothClosedPath(
+              projectFootprint(ring, 0).map((p) => ({ x: p.x + 9, y: p.y + 7 }))
+            )}
+            fill={SCENE.groundShadow}
+          />
+          <path d={smoothClosedPath(projectFootprint(ring, 0))} fill={SCENE.lawn} />
+          <path
+            d={smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.9), 0))}
+            fill={SCENE.lawnLight}
+            opacity={0.6}
+          />
+          <path
+            d={smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.72), 0))}
+            fill="none"
+            stroke={SCENE.contour}
+            strokeWidth={1}
+            strokeDasharray="2 8"
+            strokeLinecap="round"
+          />
+        </g>
+        {PYRAMID_TIERS.map((tier) => (
+          <TierStep
             key={tier.key}
-            type="button"
-            role="listitem"
-            data-testid={`pyramid-band-${tier.key}`}
-            className={`grn-pyramid__band ${isActive ? 'is-active' : ''} ${
-              covered ? 'is-covered' : 'is-empty'
-            }`.trim()}
-            style={{
-              width: BAND_WIDTH[tier.level],
-              ['--tier-accent' as string]: tier.accent,
-            }}
-            aria-pressed={isActive}
-            aria-label={`Layer ${tier.level}, ${tier.name}: ${
-              covered
-                ? `${count} crop${count === 1 ? '' : 's'} planned`
-                : 'nothing here yet'
-            }`}
-            onClick={() => onSelectTier(tier.level)}
-          >
-            <span className="grn-pyramid__level" aria-hidden="true">
-              {tier.level}
-            </span>
+            tier={tier}
+            crops={cropsByTier[tier.level] ?? []}
+            isActive={activeTier === tier.level}
+            labelColumnX={metrics.labelColumnX}
+            onSelect={() => onSelectTier(tier.level)}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
 
-            <span className="grn-pyramid__band-main">
-              <span className="grn-pyramid__band-text">
-                <span className="grn-pyramid__band-name">{tier.name}</span>
-                <span className="grn-pyramid__band-tagline">{tier.tagline}</span>
-              </span>
+interface TierStepProps {
+  tier: PyramidTierMeta;
+  crops: PyramidCropVisual[];
+  isActive: boolean;
+  labelColumnX: number;
+  onSelect: () => void;
+}
 
-              <span className="grn-pyramid__crops" aria-hidden="true">
-                {covered ? (
-                  <>
-                    {visible.map((crop) => (
-                      <span
-                        key={crop.id}
-                        className="grn-pyramid__crop-icon"
-                        title={crop.label}
-                      >
-                        <CropIcon iconKey={crop.iconKey} color={crop.accent} size="1.5rem" />
-                      </span>
-                    ))}
-                    {overflow > 0 ? (
-                      <span className="grn-pyramid__crop-more">+{overflow}</span>
-                    ) : null}
-                  </>
-                ) : (
-                  tier.suggestions.slice(0, 4).map((suggestion) => (
-                    <span
-                      key={suggestion.name}
-                      className="grn-pyramid__crop-icon is-ghost"
-                      title={suggestion.name}
-                    >
-                      <CropIcon iconKey={suggestion.iconKey} size="1.4rem" />
-                    </span>
-                  ))
-                )}
-              </span>
-            </span>
+function TierStep({ tier, crops, isActive, labelColumnX, onSelect }: TierStepProps) {
+  const count = crops.length;
+  const covered = count > 0;
 
-            <span
-              className={`grn-pyramid__band-count ${covered ? 'is-covered' : 'is-empty'}`.trim()}
-              data-testid={`pyramid-count-${tier.key}`}
-              aria-hidden="true"
-            >
-              {covered ? count : '+'}
-            </span>
-          </button>
+  const base = mute(tier.accent, 0.22);
+  const body = covered ? base : mixHex(base, SCENE.paper, 0.5);
+
+  const footprint = tierFootprint(tier.level);
+  const topZ = tierTopZ(tier.level);
+  const top = projectFootprint(footprint, topZ);
+  const walls = tierWalls(tier.level);
+
+  // Front lip of the terrace: west -> south -> east corners of the top
+  // face. The square's corners project to north (top), east (right),
+  // south (bottom), west (left) in that array order.
+  const [, east, south, west] = top;
+  const lip = [west, south, east];
+
+  const capacity = ledgeCapacity(tier.level);
+  const standing = covered
+    ? crops.slice(0, capacity)
+    : tier.suggestions.slice(0, Math.min(4, capacity)).map((s) => ({
+        id: s.name,
+        label: s.name,
+        iconKey: s.iconKey,
+        accent: GHOST_COLOR,
+      }));
+  const overflow = covered ? count - standing.length : 0;
+  const anchors = ledgeAnchors(tier.level, standing.length);
+
+  const label = labelAnchor(tier.level);
+  const badge = badgeAnchor(tier.level);
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  }
+
+  return (
+    <g
+      className={`mp-el grn-iso-pyramid__tier ${isActive ? 'mp-el--selected' : ''} ${
+        covered ? 'is-covered' : 'is-empty'
+      }`.trim()}
+      data-testid={`pyramid-band-${tier.key}`}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isActive}
+      aria-label={`Layer ${tier.level}, ${tier.name}: ${
+        covered ? `${count} crop${count === 1 ? '' : 's'} planned` : 'nothing here yet'
+      }`}
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
+    >
+      <path d={toPath(walls.right)} fill={shade(body, 0.18)} />
+      <path d={toPath(walls.left)} fill={shade(body, 0.34)} />
+      <path d={toPath(top)} fill={tint(body, 0.24)} />
+      <path
+        d={toPath(lip, false)}
+        fill="none"
+        stroke={tint(body, 0.45)}
+        strokeWidth={1.4}
+        strokeLinejoin="round"
+      />
+      {!covered && (
+        <path
+          d={toPath(projectFootprint(scaleFootprint(footprint, 0.86), topZ))}
+          fill="none"
+          stroke={shade(body, 0.3)}
+          strokeWidth={1}
+          strokeDasharray="4 5"
+          strokeLinecap="round"
+        />
+      )}
+
+      {standing.map((crop, idx) => {
+        const anchor = anchors[idx];
+        if (!anchor) return null;
+        const p = projectFootprint([anchor], topZ)[0];
+        const k = 1.5;
+        return (
+          <g key={crop.id} className={`mp-crop ${covered ? '' : 'is-ghost'}`.trim()}>
+            <title>{crop.label}</title>
+            {covered && (
+              <ellipse cx={p.x} cy={p.y + 1} rx={10} ry={3.4} fill={SCENE.elementShadowSoft} />
+            )}
+            <path
+              d={CROP_ICON_PATHS[crop.iconKey]}
+              fill={covered ? mute(crop.accent, 0.18) : GHOST_COLOR}
+              opacity={covered ? 1 : 0.45}
+              transform={`translate(${p.x - 12 * k} ${p.y - 23 * k}) scale(${k})`}
+            />
+          </g>
         );
       })}
-    </div>
+      {overflow > 0 && (
+        <text
+          className="mp-label mp-label--count"
+          x={south.x + 16}
+          y={south.y + 2}
+          aria-hidden="true"
+        >
+          +{overflow}
+        </text>
+      )}
+
+      <g className="grn-iso-pyramid__side-label" aria-hidden="true">
+        <text
+          className="grn-iso-pyramid__name"
+          x={labelColumnX}
+          y={label.y - 3}
+          textAnchor="end"
+        >
+          {tier.name}
+        </text>
+        <text
+          className="grn-iso-pyramid__caption"
+          x={labelColumnX}
+          y={label.y + 9.5}
+          textAnchor="end"
+        >
+          Layer {tier.level}
+        </text>
+        <line
+          className="grn-iso-pyramid__leader"
+          x1={labelColumnX + 8}
+          y1={label.y + 3}
+          x2={label.x - 8}
+          y2={label.y + 3}
+        />
+      </g>
+
+      <g
+        className="grn-iso-pyramid__badge"
+        data-testid={`pyramid-count-${tier.key}`}
+        aria-hidden="true"
+      >
+        <circle
+          cx={badge.x + 26}
+          cy={badge.y + 2}
+          r={11}
+          fill={covered ? mute(tier.accent, 0.18) : 'rgba(91, 58, 28, 0.1)'}
+        />
+        <text
+          className={`grn-iso-pyramid__count ${covered ? 'is-covered' : 'is-empty'}`.trim()}
+          x={badge.x + 26}
+          y={badge.y + 6}
+          textAnchor="middle"
+        >
+          {covered ? count : '+'}
+        </text>
+      </g>
+
+      {isActive && (
+        // Survey ring drawn on the surface this terrace stands on, so it
+        // hugs the selected step instead of floating at its (mostly
+        // covered) top plane.
+        <path
+          className="mp-el__ring"
+          d={toPath(projectFootprint(scaleFootprint(footprint, 1.07), tierBaseZ(tier.level)))}
+          fill="none"
+          stroke={SCENE.selection}
+          strokeWidth={1.8}
+          strokeDasharray="5 4"
+        />
+      )}
+    </g>
   );
 }

--- a/apps/grn/src/components/Planner/GardenPyramid.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.tsx
@@ -1,24 +1,22 @@
-import type { KeyboardEvent } from 'react';
-import { PYRAMID_TIERS, type PyramidTier, type PyramidTierMeta } from '../CropPlanner/gardenPyramid';
-import { CROP_ICON_PATHS, type CropIconKey } from '../CropPlanner/cropIconPaths';
+import { useState, type KeyboardEvent } from 'react';
 import {
-  projectFootprint,
-  scaleFootprint,
-  smoothClosedPath,
-  toPath,
-} from '../GardenMasterplan/iso';
+  PYRAMID_TIERS,
+  type PyramidTier,
+  type PyramidTierMeta,
+} from '../CropPlanner/gardenPyramid';
+import { CROP_ICON_PATHS, type CropIconKey } from '../CropPlanner/cropIconPaths';
+import { smoothClosedPath, toPath } from '../GardenMasterplan/iso';
 import { SCENE, mixHex, mute, shade, tint } from '../GardenMasterplan/palette';
 import {
-  badgeAnchor,
-  groundRing,
-  labelAnchor,
-  ledgeAnchors,
-  ledgeCapacity,
+  RELIEF,
+  SHOULDER_CAPACITY,
+  bandRect,
+  lawnRing,
+  ledgeQuads,
   pyramidMetrics,
-  tierBaseZ,
-  tierFootprint,
-  tierTopZ,
-  tierWalls,
+  showcaseCapacity,
+  sideQuad,
+  standPoints,
 } from './pyramidGeometry';
 
 export interface PyramidCropVisual {
@@ -37,18 +35,104 @@ interface GardenPyramidProps {
 }
 
 const GHOST_COLOR = '#a39c8a';
+const ICON_SCALE = 1.15;
+
+// Light text for the deep bands, dark text for the pale gold one —
+// picked per band from the same family as its fill, like the masterplan
+// labels.
+function bandInk(base: string): { title: string; subtitle: string } {
+  const [r, g, b] = [1, 3, 5].map((i) => parseInt(base.slice(i, i + 2), 16));
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  if (luminance > 0.6) {
+    return { title: shade(base, 0.72), subtitle: shade(base, 0.55) };
+  }
+  return { title: tint(base, 0.85), subtitle: tint(base, 0.62) };
+}
+
+interface StandingCrop {
+  id: string;
+  label: string;
+  iconKey: CropIconKey;
+  fill: string;
+  ghost: boolean;
+}
+
+function StandingCropRow({
+  crops,
+  points,
+  withShadows,
+}: {
+  crops: StandingCrop[];
+  points: { x: number; y: number }[];
+  withShadows: boolean;
+}) {
+  return (
+    <>
+      {crops.map((crop, idx) => {
+        const p = points[idx];
+        if (!p) return null;
+        return (
+          <g
+            key={crop.id}
+            className={`mp-crop ${crop.ghost ? 'is-ghost' : ''}`.trim()}
+            style={{ ['--crop-index' as string]: idx }}
+          >
+            <title>{crop.label}</title>
+            {withShadows && !crop.ghost && (
+              <ellipse cx={p.x} cy={p.y + 1} rx={9} ry={2.8} fill={SCENE.elementShadowSoft} />
+            )}
+            <path
+              d={CROP_ICON_PATHS[crop.iconKey]}
+              fill={crop.fill}
+              opacity={crop.ghost ? 0.45 : 1}
+              transform={`translate(${p.x - 12 * ICON_SCALE} ${p.y - 23 * ICON_SCALE}) scale(${ICON_SCALE})`}
+            />
+          </g>
+        );
+      })}
+    </>
+  );
+}
 
 /**
- * The Garden Pyramid hero, drawn as an isometric terraced hill in the
- * same flat-shaded illustration language as the garden masterplan. Each
- * tier is a selectable terrace: planted crops stand on its front ledge as
- * silhouettes, empty tiers preview faded suggestions. Hovering lifts a
- * terrace while the others recede; the active terrace keeps a dashed
- * survey ring.
+ * The Garden Pyramid hero: the classic stepped-triangle elevation,
+ * rendered in the masterplan's flat-shaded illustration style. Each band
+ * is a selectable terrace with its name and tagline in place; the
+ * grower's crops stand on the exposed ledges as vector silhouettes, and
+ * hovering or selecting a band steps its full planting forward across
+ * the band's width. Empty bands preview faded suggestions.
  */
 export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenPyramidProps) {
   const metrics = pyramidMetrics();
-  const ring = groundRing();
+  const [hoverTier, setHoverTier] = useState<PyramidTier | null>(null);
+  const lawn = lawnRing();
+
+  // The band whose full planting is showcased: hover wins (preview),
+  // otherwise the selected band.
+  const showcaseTier =
+    hoverTier !== null && (cropsByTier[hoverTier]?.length ?? 0) > 0
+      ? hoverTier
+      : (cropsByTier[activeTier]?.length ?? 0) > 0
+        ? activeTier
+        : null;
+
+  const showcaseCrops =
+    showcaseTier !== null
+      ? (cropsByTier[showcaseTier] ?? []).map((crop) => ({
+          id: crop.id,
+          label: crop.label,
+          iconKey: crop.iconKey,
+          fill: mute(crop.accent, 0.18),
+          ghost: false,
+        }))
+      : [];
+  const showcaseMax = showcaseTier !== null ? showcaseCapacity(showcaseTier) : 0;
+  const showcaseVisible = showcaseCrops.slice(0, showcaseMax);
+  const showcaseOverflow = showcaseCrops.length - showcaseVisible.length;
+  const showcasePoints =
+    showcaseTier !== null
+      ? standPoints(showcaseTier, showcaseVisible.length, 'full')
+      : [];
 
   return (
     <div className="grn-iso-pyramid">
@@ -60,81 +144,111 @@ export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenP
       >
         <g aria-hidden="true">
           <path
-            d={smoothClosedPath(
-              projectFootprint(ring, 0).map((p) => ({ x: p.x + 9, y: p.y + 7 }))
-            )}
+            d={smoothClosedPath(lawn.map((p) => ({ x: p.x + 8, y: p.y + 6 })))}
             fill={SCENE.groundShadow}
           />
-          <path d={smoothClosedPath(projectFootprint(ring, 0))} fill={SCENE.lawn} />
+          <path d={smoothClosedPath(lawn)} fill={SCENE.lawn} />
           <path
-            d={smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.9), 0))}
+            d={smoothClosedPath(
+              lawn.map((p) => ({ x: p.x * 0.92 + 330 * 0.08, y: p.y * 0.94 + 408 * 0.06 }))
+            )}
             fill={SCENE.lawnLight}
             opacity={0.6}
           />
-          <path
-            d={smoothClosedPath(projectFootprint(scaleFootprint(ring, 0.72), 0))}
-            fill="none"
-            stroke={SCENE.contour}
-            strokeWidth={1}
-            strokeDasharray="2 8"
-            strokeLinecap="round"
-          />
         </g>
         {PYRAMID_TIERS.map((tier) => (
-          <TierStep
+          <PyramidBand
             key={tier.key}
             tier={tier}
             crops={cropsByTier[tier.level] ?? []}
             isActive={activeTier === tier.level}
-            labelColumnX={metrics.labelColumnX}
+            isShowcased={showcaseTier === tier.level}
+            // The showcased planting below stands in front of this band's
+            // lower edge; quiet the tagline there so the two never fight.
+            taglineQuieted={showcaseTier !== null && tier.level === showcaseTier + 1}
             onSelect={() => onSelectTier(tier.level)}
+            onHover={(hovering) =>
+              setHoverTier((current) =>
+                hovering ? tier.level : current === tier.level ? null : current
+              )
+            }
           />
         ))}
+        {showcaseTier !== null && (
+          <g className="grn-iso-pyramid__showcase" aria-hidden="true" key={showcaseTier}>
+            <StandingCropRow crops={showcaseVisible} points={showcasePoints} withShadows />
+            {showcaseOverflow > 0 && (
+              <text
+                className="mp-label mp-label--count"
+                x={bandRect(showcaseTier).x + bandRect(showcaseTier).w + RELIEF.dx + 4}
+                y={bandRect(showcaseTier).y - 8}
+              >
+                +{showcaseOverflow}
+              </text>
+            )}
+          </g>
+        )}
       </svg>
     </div>
   );
 }
 
-interface TierStepProps {
+interface PyramidBandProps {
   tier: PyramidTierMeta;
   crops: PyramidCropVisual[];
   isActive: boolean;
-  labelColumnX: number;
+  isShowcased: boolean;
+  taglineQuieted: boolean;
   onSelect: () => void;
+  onHover: (hovering: boolean) => void;
 }
 
-function TierStep({ tier, crops, isActive, labelColumnX, onSelect }: TierStepProps) {
+function PyramidBand({
+  tier,
+  crops,
+  isActive,
+  isShowcased,
+  taglineQuieted,
+  onSelect,
+  onHover,
+}: PyramidBandProps) {
   const count = crops.length;
   const covered = count > 0;
 
   const base = mute(tier.accent, 0.22);
   const body = covered ? base : mixHex(base, SCENE.paper, 0.5);
+  const ink = bandInk(body);
 
-  const footprint = tierFootprint(tier.level);
-  const topZ = tierTopZ(tier.level);
-  const top = projectFootprint(footprint, topZ);
-  const walls = tierWalls(tier.level);
+  const band = bandRect(tier.level);
+  const ledges = ledgeQuads(tier.level);
+  const side = sideQuad(tier.level);
 
-  // Front lip of the terrace: west -> south -> east corners of the top
-  // face. The square's corners project to north (top), east (right),
-  // south (bottom), west (left) in that array order.
-  const [, east, south, west] = top;
-  const lip = [west, south, east];
-
-  const capacity = ledgeCapacity(tier.level);
-  const standing = covered
-    ? crops.slice(0, capacity)
-    : tier.suggestions.slice(0, Math.min(4, capacity)).map((s) => ({
+  // Resting-state silhouettes on the shoulders. Hidden while this band's
+  // full planting is showcased (the showcase row replaces them), kept
+  // for empty bands so ghost suggestions always preview what belongs.
+  const resting: StandingCrop[] = covered
+    ? crops.slice(0, SHOULDER_CAPACITY).map((crop) => ({
+        id: crop.id,
+        label: crop.label,
+        iconKey: crop.iconKey,
+        fill: mute(crop.accent, 0.18),
+        ghost: false,
+      }))
+    : tier.suggestions.slice(0, SHOULDER_CAPACITY).map((s) => ({
         id: s.name,
         label: s.name,
         iconKey: s.iconKey,
-        accent: GHOST_COLOR,
+        fill: GHOST_COLOR,
+        ghost: true,
       }));
-  const overflow = covered ? count - standing.length : 0;
-  const anchors = ledgeAnchors(tier.level, standing.length);
+  const restingPoints = standPoints(tier.level, resting.length, 'shoulders');
+  const restingOverflow = covered ? count - resting.length : 0;
+  const hideResting = isShowcased && covered;
 
-  const label = labelAnchor(tier.level);
-  const badge = badgeAnchor(tier.level);
+  // Copy layout inside the band: the two widest bands fit a tagline.
+  const showTagline = tier.level <= 3;
+  const nameY = band.y + (showTagline ? 27 : band.h / 2 + 5);
+  const badgeCx = band.x + band.w - 24;
 
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -157,84 +271,61 @@ function TierStep({ tier, crops, isActive, labelColumnX, onSelect }: TierStepPro
       }`}
       onClick={onSelect}
       onKeyDown={handleKeyDown}
+      onPointerEnter={() => onHover(true)}
+      onPointerLeave={() => onHover(false)}
     >
-      <path d={toPath(walls.right)} fill={shade(body, 0.18)} />
-      <path d={toPath(walls.left)} fill={shade(body, 0.34)} />
-      <path d={toPath(top)} fill={tint(body, 0.24)} />
-      <path
-        d={toPath(lip, false)}
-        fill="none"
-        stroke={tint(body, 0.45)}
-        strokeWidth={1.4}
-        strokeLinejoin="round"
-      />
+      <path d={toPath(side)} fill={shade(body, 0.3)} />
+      <rect x={band.x} y={band.y} width={band.w} height={band.h} fill={body} />
+      {ledges.map((quad, idx) => (
+        <path key={idx} d={toPath(quad)} fill={tint(body, 0.28)} />
+      ))}
       {!covered && (
-        <path
-          d={toPath(projectFootprint(scaleFootprint(footprint, 0.86), topZ))}
+        <rect
+          x={band.x + 7}
+          y={band.y + 7}
+          width={band.w - 14}
+          height={band.h - 14}
           fill="none"
-          stroke={shade(body, 0.3)}
+          stroke={shade(body, 0.28)}
           strokeWidth={1}
           strokeDasharray="4 5"
           strokeLinecap="round"
         />
       )}
 
-      {standing.map((crop, idx) => {
-        const anchor = anchors[idx];
-        if (!anchor) return null;
-        const p = projectFootprint([anchor], topZ)[0];
-        const k = 1.5;
-        return (
-          <g key={crop.id} className={`mp-crop ${covered ? '' : 'is-ghost'}`.trim()}>
-            <title>{crop.label}</title>
-            {covered && (
-              <ellipse cx={p.x} cy={p.y + 1} rx={10} ry={3.4} fill={SCENE.elementShadowSoft} />
-            )}
-            <path
-              d={CROP_ICON_PATHS[crop.iconKey]}
-              fill={covered ? mute(crop.accent, 0.18) : GHOST_COLOR}
-              opacity={covered ? 1 : 0.45}
-              transform={`translate(${p.x - 12 * k} ${p.y - 23 * k}) scale(${k})`}
-            />
-          </g>
-        );
-      })}
-      {overflow > 0 && (
+      <text
+        className="grn-iso-pyramid__name"
+        x={band.x + 18}
+        y={nameY}
+        fill={ink.title}
+      >
+        {tier.name}
+      </text>
+      {showTagline && (
         <text
-          className="mp-label mp-label--count"
-          x={south.x + 16}
-          y={south.y + 2}
-          aria-hidden="true"
+          className={`grn-iso-pyramid__tagline ${taglineQuieted ? 'is-quiet' : ''}`.trim()}
+          x={band.x + 18}
+          y={band.y + 45}
+          fill={ink.subtitle}
         >
-          +{overflow}
+          {tier.tagline}
         </text>
       )}
 
-      <g className="grn-iso-pyramid__side-label" aria-hidden="true">
-        <text
-          className="grn-iso-pyramid__name"
-          x={labelColumnX}
-          y={label.y - 3}
-          textAnchor="end"
-        >
-          {tier.name}
-        </text>
-        <text
-          className="grn-iso-pyramid__caption"
-          x={labelColumnX}
-          y={label.y + 9.5}
-          textAnchor="end"
-        >
-          Layer {tier.level}
-        </text>
-        <line
-          className="grn-iso-pyramid__leader"
-          x1={labelColumnX + 8}
-          y1={label.y + 3}
-          x2={label.x - 8}
-          y2={label.y + 3}
-        />
-      </g>
+      {!hideResting && (
+        <g aria-hidden="true">
+          <StandingCropRow crops={resting} points={restingPoints} withShadows={false} />
+          {restingOverflow > 0 && (
+            <text
+              className="mp-label mp-label--count"
+              x={band.x + band.w + RELIEF.dx + 4}
+              y={band.y - 4}
+            >
+              +{restingOverflow}
+            </text>
+          )}
+        </g>
+      )}
 
       <g
         className="grn-iso-pyramid__badge"
@@ -242,15 +333,15 @@ function TierStep({ tier, crops, isActive, labelColumnX, onSelect }: TierStepPro
         aria-hidden="true"
       >
         <circle
-          cx={badge.x + 26}
-          cy={badge.y + 2}
-          r={11}
-          fill={covered ? mute(tier.accent, 0.18) : 'rgba(91, 58, 28, 0.1)'}
+          cx={badgeCx}
+          cy={band.y + band.h / 2}
+          r={12}
+          fill={covered ? shade(body, 0.28) : 'rgba(91, 58, 28, 0.12)'}
         />
         <text
           className={`grn-iso-pyramid__count ${covered ? 'is-covered' : 'is-empty'}`.trim()}
-          x={badge.x + 26}
-          y={badge.y + 6}
+          x={badgeCx}
+          y={band.y + band.h / 2 + 4}
           textAnchor="middle"
         >
           {covered ? count : '+'}
@@ -258,12 +349,13 @@ function TierStep({ tier, crops, isActive, labelColumnX, onSelect }: TierStepPro
       </g>
 
       {isActive && (
-        // Survey ring drawn on the surface this terrace stands on, so it
-        // hugs the selected step instead of floating at its (mostly
-        // covered) top plane.
-        <path
+        <rect
           className="mp-el__ring"
-          d={toPath(projectFootprint(scaleFootprint(footprint, 1.07), tierBaseZ(tier.level)))}
+          x={band.x - 5}
+          y={band.y - RELIEF.dy - 5}
+          width={band.w + RELIEF.dx + 10}
+          height={band.h + RELIEF.dy + 10}
+          rx={7}
           fill="none"
           stroke={SCENE.selection}
           strokeWidth={1.8}

--- a/apps/grn/src/components/Planner/pyramidGeometry.test.ts
+++ b/apps/grn/src/components/Planner/pyramidGeometry.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Z_PER_INCH } from '../GardenMasterplan/iso';
+import type { PyramidTier } from '../CropPlanner/gardenPyramid';
+import {
+  LEDGE,
+  STEP_HEIGHT,
+  TIER_SIDES,
+  ledgeAnchors,
+  ledgeCapacity,
+  pyramidMetrics,
+  tierBaseZ,
+  tierFootprint,
+  tierTopZ,
+  tierWalls,
+} from './pyramidGeometry';
+
+const ALL_TIERS: PyramidTier[] = [1, 2, 3, 4, 5];
+
+describe('tier dimensions', () => {
+  it('shrinks each tier by one ledge per side', () => {
+    for (let level = 2 as PyramidTier; level <= 5; level += 1) {
+      expect(TIER_SIDES[level as PyramidTier]).toBe(
+        TIER_SIDES[(level - 1) as PyramidTier] - LEDGE * 2
+      );
+    }
+  });
+
+  it('stacks tiers one step apart', () => {
+    for (const level of ALL_TIERS) {
+      expect(tierBaseZ(level)).toBe((level - 1) * STEP_HEIGHT);
+      expect(tierTopZ(level)).toBe(level * STEP_HEIGHT);
+    }
+  });
+
+  it('centers every footprint on the pyramid axis', () => {
+    for (const level of ALL_TIERS) {
+      const fp = tierFootprint(level);
+      const cx = fp.reduce((s, p) => s + p.x, 0) / fp.length;
+      const cy = fp.reduce((s, p) => s + p.y, 0) / fp.length;
+      expect(cx).toBeCloseTo(0);
+      expect(cy).toBeCloseTo(0);
+    }
+  });
+});
+
+describe('tierWalls', () => {
+  it('builds two quads spanning exactly one step of height', () => {
+    for (const level of ALL_TIERS) {
+      const walls = tierWalls(level);
+      for (const quad of [walls.right, walls.left]) {
+        expect(quad).toHaveLength(4);
+        // Top corners sit one step above their base counterparts.
+        expect(quad[3].y).toBeCloseTo(quad[0].y - STEP_HEIGHT * Z_PER_INCH);
+        expect(quad[2].y).toBeCloseTo(quad[1].y - STEP_HEIGHT * Z_PER_INCH);
+      }
+    }
+  });
+});
+
+describe('ledgeAnchors', () => {
+  it('returns the requested number of anchors inside the tier footprint', () => {
+    for (const level of ALL_TIERS) {
+      const half = TIER_SIDES[level] / 2;
+      const anchors = ledgeAnchors(level, 5);
+      expect(anchors).toHaveLength(5);
+      for (const a of anchors) {
+        expect(Math.abs(a.x)).toBeLessThanOrEqual(half);
+        expect(Math.abs(a.y)).toBeLessThanOrEqual(half);
+      }
+    }
+  });
+
+  it('orders anchors back-to-front for billboard painting', () => {
+    const anchors = ledgeAnchors(1, 6);
+    for (let i = 1; i < anchors.length; i += 1) {
+      expect(anchors[i].x + anchors[i].y).toBeGreaterThanOrEqual(
+        anchors[i - 1].x + anchors[i - 1].y
+      );
+    }
+  });
+
+  it('returns nothing for zero crops', () => {
+    expect(ledgeAnchors(3, 0)).toEqual([]);
+  });
+});
+
+describe('ledgeCapacity', () => {
+  it('never shrinks below 2 or above 6 and narrows with the tiers', () => {
+    let previous = Infinity;
+    for (const level of ALL_TIERS) {
+      const capacity = ledgeCapacity(level);
+      expect(capacity).toBeGreaterThanOrEqual(2);
+      expect(capacity).toBeLessThanOrEqual(6);
+      expect(capacity).toBeLessThanOrEqual(previous);
+      previous = capacity;
+    }
+  });
+});
+
+describe('pyramidMetrics', () => {
+  it('produces a viewBox that contains the base footprint', () => {
+    const m = pyramidMetrics();
+    const [minX, minY, width, height] = m.viewBox.split(' ').map(Number);
+    expect(width).toBeGreaterThan(0);
+    expect(height).toBeGreaterThan(0);
+    expect(minX).toBeLessThan(0);
+    expect(minY).toBeLessThan(0);
+    expect(m.labelColumnX).toBeGreaterThan(minX);
+  });
+});

--- a/apps/grn/src/components/Planner/pyramidGeometry.test.ts
+++ b/apps/grn/src/components/Planner/pyramidGeometry.test.ts
@@ -1,110 +1,133 @@
 import { describe, expect, it } from 'vitest';
-import { Z_PER_INCH } from '../GardenMasterplan/iso';
 import type { PyramidTier } from '../CropPlanner/gardenPyramid';
 import {
-  LEDGE,
-  STEP_HEIGHT,
-  TIER_SIDES,
-  ledgeAnchors,
-  ledgeCapacity,
+  ALL_TIERS,
+  BAND_WIDTHS,
+  BASE_Y,
+  CENTER_X,
+  RELIEF,
+  SHOULDER_CAPACITY,
+  bandRect,
+  lawnRing,
+  ledgeQuads,
   pyramidMetrics,
-  tierBaseZ,
-  tierFootprint,
-  tierTopZ,
-  tierWalls,
+  showcaseCapacity,
+  sideQuad,
+  standPoints,
 } from './pyramidGeometry';
 
-const ALL_TIERS: PyramidTier[] = [1, 2, 3, 4, 5];
+describe('bandRect', () => {
+  it('keeps every band centered on the pyramid axis', () => {
+    for (const level of ALL_TIERS) {
+      const band = bandRect(level);
+      expect(band.x + band.w / 2).toBeCloseTo(CENTER_X);
+      expect(band.w).toBe(BAND_WIDTHS[level]);
+    }
+  });
 
-describe('tier dimensions', () => {
-  it('shrinks each tier by one ledge per side', () => {
+  it('stacks bands bottom-up into a triangle silhouette', () => {
+    const base = bandRect(1);
+    expect(base.y + base.h).toBe(BASE_Y);
     for (let level = 2 as PyramidTier; level <= 5; level += 1) {
-      expect(TIER_SIDES[level as PyramidTier]).toBe(
-        TIER_SIDES[(level - 1) as PyramidTier] - LEDGE * 2
-      );
-    }
-  });
-
-  it('stacks tiers one step apart', () => {
-    for (const level of ALL_TIERS) {
-      expect(tierBaseZ(level)).toBe((level - 1) * STEP_HEIGHT);
-      expect(tierTopZ(level)).toBe(level * STEP_HEIGHT);
-    }
-  });
-
-  it('centers every footprint on the pyramid axis', () => {
-    for (const level of ALL_TIERS) {
-      const fp = tierFootprint(level);
-      const cx = fp.reduce((s, p) => s + p.x, 0) / fp.length;
-      const cy = fp.reduce((s, p) => s + p.y, 0) / fp.length;
-      expect(cx).toBeCloseTo(0);
-      expect(cy).toBeCloseTo(0);
+      const below = bandRect((level - 1) as PyramidTier);
+      const band = bandRect(level as PyramidTier);
+      // Each band sits flush on the one beneath it and is narrower.
+      expect(band.y + band.h).toBe(below.y);
+      expect(band.w).toBeLessThan(below.w);
     }
   });
 });
 
-describe('tierWalls', () => {
-  it('builds two quads spanning exactly one step of height', () => {
+describe('relief quads', () => {
+  it('exposes two shoulder ledges on lower bands and one full ledge on top', () => {
     for (const level of ALL_TIERS) {
-      const walls = tierWalls(level);
-      for (const quad of [walls.right, walls.left]) {
+      const quads = ledgeQuads(level);
+      expect(quads).toHaveLength(level === 5 ? 1 : 2);
+      for (const quad of quads) {
         expect(quad).toHaveLength(4);
-        // Top corners sit one step above their base counterparts.
-        expect(quad[3].y).toBeCloseTo(quad[0].y - STEP_HEIGHT * Z_PER_INCH);
-        expect(quad[2].y).toBeCloseTo(quad[1].y - STEP_HEIGHT * Z_PER_INCH);
+        // The back edge is skewed up-right by the relief offset.
+        expect(quad[2].y).toBeCloseTo(quad[1].y - RELIEF.dy);
+        expect(quad[2].x).toBeCloseTo(quad[1].x + RELIEF.dx);
       }
+    }
+  });
+
+  it('builds the side return along the band right edge', () => {
+    for (const level of ALL_TIERS) {
+      const band = bandRect(level);
+      const quad = sideQuad(level);
+      expect(quad[0]).toEqual({ x: band.x + band.w, y: band.y });
+      expect(quad[3]).toEqual({ x: band.x + band.w, y: band.y + band.h });
     }
   });
 });
 
-describe('ledgeAnchors', () => {
-  it('returns the requested number of anchors inside the tier footprint', () => {
+describe('standPoints', () => {
+  it('puts showcased crops along the full band top, inside its width', () => {
     for (const level of ALL_TIERS) {
-      const half = TIER_SIDES[level] / 2;
-      const anchors = ledgeAnchors(level, 5);
-      expect(anchors).toHaveLength(5);
-      for (const a of anchors) {
-        expect(Math.abs(a.x)).toBeLessThanOrEqual(half);
-        expect(Math.abs(a.y)).toBeLessThanOrEqual(half);
+      const band = bandRect(level);
+      const points = standPoints(level, 5, 'full');
+      expect(points).toHaveLength(5);
+      for (const p of points) {
+        expect(p.y).toBe(band.y);
+        expect(p.x).toBeGreaterThan(band.x);
+        expect(p.x).toBeLessThan(band.x + band.w);
       }
     }
   });
 
-  it('orders anchors back-to-front for billboard painting', () => {
-    const anchors = ledgeAnchors(1, 6);
-    for (let i = 1; i < anchors.length; i += 1) {
-      expect(anchors[i].x + anchors[i].y).toBeGreaterThanOrEqual(
-        anchors[i - 1].x + anchors[i - 1].y
-      );
+  it('keeps resting crops on the shoulders, clear of the band above', () => {
+    for (let level = 1 as PyramidTier; level <= 4; level += 1) {
+      const above = bandRect((level + 1) as PyramidTier);
+      const points = standPoints(level as PyramidTier, 4, 'shoulders');
+      expect(points).toHaveLength(4);
+      for (const p of points) {
+        const onLeftShoulder = p.x < above.x;
+        const onRightShoulder = p.x > above.x + above.w;
+        expect(onLeftShoulder || onRightShoulder).toBe(true);
+      }
     }
   });
 
   it('returns nothing for zero crops', () => {
-    expect(ledgeAnchors(3, 0)).toEqual([]);
+    expect(standPoints(3, 0, 'full')).toEqual([]);
+    expect(standPoints(3, 0, 'shoulders')).toEqual([]);
   });
 });
 
-describe('ledgeCapacity', () => {
-  it('never shrinks below 2 or above 6 and narrows with the tiers', () => {
-    let previous = Infinity;
+describe('capacities', () => {
+  it('showcases at least as many crops as the resting shoulders', () => {
     for (const level of ALL_TIERS) {
-      const capacity = ledgeCapacity(level);
-      expect(capacity).toBeGreaterThanOrEqual(2);
-      expect(capacity).toBeLessThanOrEqual(6);
-      expect(capacity).toBeLessThanOrEqual(previous);
-      previous = capacity;
+      // Wider bands hold strictly more; the narrow top band at least
+      // matches its resting capacity.
+      if (level < 5) {
+        expect(showcaseCapacity(level)).toBeGreaterThan(SHOULDER_CAPACITY);
+      } else {
+        expect(showcaseCapacity(level)).toBeGreaterThanOrEqual(SHOULDER_CAPACITY);
+      }
     }
   });
+
+  it('gives wider bands more showcase room', () => {
+    expect(showcaseCapacity(1)).toBeGreaterThan(showcaseCapacity(5));
+  });
 });
 
-describe('pyramidMetrics', () => {
-  it('produces a viewBox that contains the base footprint', () => {
+describe('scene', () => {
+  it('produces a fixed viewBox containing the pyramid and lawn', () => {
     const m = pyramidMetrics();
     const [minX, minY, width, height] = m.viewBox.split(' ').map(Number);
-    expect(width).toBeGreaterThan(0);
-    expect(height).toBeGreaterThan(0);
-    expect(minX).toBeLessThan(0);
-    expect(minY).toBeLessThan(0);
-    expect(m.labelColumnX).toBeGreaterThan(minX);
+    expect(minX).toBe(0);
+    expect(minY).toBe(0);
+    const base = bandRect(1);
+    expect(width).toBeGreaterThan(base.x + base.w);
+    expect(height).toBeGreaterThan(BASE_Y);
+  });
+
+  it('draws the lawn wider than the base band', () => {
+    const xs = lawnRing().map((p) => p.x);
+    const base = bandRect(1);
+    expect(Math.min(...xs)).toBeLessThan(base.x);
+    expect(Math.max(...xs)).toBeGreaterThan(base.x + base.w);
   });
 });

--- a/apps/grn/src/components/Planner/pyramidGeometry.ts
+++ b/apps/grn/src/components/Planner/pyramidGeometry.ts
@@ -1,191 +1,177 @@
-// Geometry for the isometric Garden Pyramid: a five-step terraced
-// "ziggurat" drawn with the same projection and flat-shading rules as the
-// garden masterplan. All layout math lives here (component-free) so the
-// GardenPyramid component stays a pure illustration and the math is unit
-// testable.
+// Geometry for the Garden Pyramid hero: a front-elevation stepped
+// pyramid (the classic food-pyramid silhouette) rendered with the
+// masterplan's flat-shaded relief. All layout math lives here
+// (component-free) so the GardenPyramid component stays a pure
+// illustration and the math is unit testable.
 //
-// World units are inches, centered on the pyramid's axis at (0, 0).
-// Tier 1 (Foundation) is the widest, ground-level step; each tier above
-// is inset by a fixed ledge and raised one step.
+// Unlike the masterplan this is NOT an isometric projection — the
+// pyramid metaphor lives in the triangular front profile, so the bands
+// are drawn face-on in screen space, with a small skewed "relief" on
+// each band's top ledge and right side to keep the hand-crafted depth.
 
-import {
-  ISO_COS,
-  ISO_SIN,
-  PX_PER_INCH,
-  Z_PER_INCH,
-  project,
-  rectFootprint,
-  type ScreenPoint,
-  type WorldPoint,
-} from '../GardenMasterplan/iso';
+import type { ScreenPoint } from '../GardenMasterplan/iso';
 import type { PyramidTier } from '../CropPlanner/gardenPyramid';
 
-export const STEP_HEIGHT = 27; // inches per terrace step
-export const LEDGE = 22; // exposed terrace band per side, in inches
+export const ALL_TIERS: readonly PyramidTier[] = [1, 2, 3, 4, 5];
 
-// Side length of each tier's square, widest to narrowest.
-export const TIER_SIDES: Record<PyramidTier, number> = {
-  1: 240,
-  2: 240 - LEDGE * 2,
-  3: 240 - LEDGE * 4,
-  4: 240 - LEDGE * 6,
-  5: 240 - LEDGE * 8,
+// Band sizes, widest to narrowest. Heights taper slightly so the base
+// reads heavier — the hierarchy is the message.
+export const BAND_WIDTHS: Record<PyramidTier, number> = {
+  1: 480,
+  2: 384,
+  3: 288,
+  4: 192,
+  5: 96,
 };
 
-export function tierFootprint(level: PyramidTier): WorldPoint[] {
-  const half = TIER_SIDES[level] / 2;
-  return rectFootprint({ x: -half, y: -half, length: half * 2, width: half * 2 });
+export const BAND_HEIGHTS: Record<PyramidTier, number> = {
+  1: 64,
+  2: 58,
+  3: 54,
+  4: 50,
+  5: 46,
+};
+
+// Skew of the ledge/side relief, in screen px.
+export const RELIEF = { dx: 9, dy: 6 } as const;
+
+export const CENTER_X = 330;
+export const BASE_Y = 400;
+
+export interface BandRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
 }
 
-export function tierBaseZ(level: PyramidTier): number {
-  return (level - 1) * STEP_HEIGHT;
-}
-
-export function tierTopZ(level: PyramidTier): number {
-  return level * STEP_HEIGHT;
-}
-
-// Walls of one step between two heights. Like iso.extrude but with an
-// explicit base elevation, since tiers stack on each other rather than on
-// the ground. Footprints are axis-aligned squares, so the two visible
-// walls are always the +x (right) and +y (left) faces.
-export interface TierWalls {
-  right: ScreenPoint[];
-  left: ScreenPoint[];
-}
-
-export function tierWalls(level: PyramidTier): TierWalls {
-  const half = TIER_SIDES[level] / 2;
-  const z0 = tierBaseZ(level);
-  const z1 = tierTopZ(level);
-  // Corners: E = (h, -h), S = (h, h), W = (-h, h).
-  const e = { x: half, y: -half };
-  const s = { x: half, y: half };
-  const w = { x: -half, y: half };
-  return {
-    right: [
-      project(e.x, e.y, z0),
-      project(s.x, s.y, z0),
-      project(s.x, s.y, z1),
-      project(e.x, e.y, z1),
-    ],
-    left: [
-      project(s.x, s.y, z0),
-      project(w.x, w.y, z0),
-      project(w.x, w.y, z1),
-      project(s.x, s.y, z1),
-    ],
-  };
-}
-
-// Evenly spaced stand-points for crop silhouettes along the front ledge
-// of a tier: the two camera-facing edges of its top face, walked from the
-// west corner around the south corner to the east corner, inset from the
-// outer rim so icons sit on the terrace band. Returned back-to-front so
-// upright billboards overlap correctly.
-export function ledgeAnchors(level: PyramidTier, count: number): WorldPoint[] {
-  if (count <= 0) return [];
-  const half = TIER_SIDES[level] / 2;
-  const inset = Math.min(LEDGE / 2, half / 2);
-  const r = half - inset;
-  // Polyline W' -> S' -> E' along the inset front edges.
-  const corner = 10; // keep icons off the very tips
-  const start = { x: -r + corner, y: r };
-  const mid = { x: r, y: r };
-  const end = { x: r, y: -r + corner };
-  const leg1 = Math.hypot(mid.x - start.x, mid.y - start.y);
-  const leg2 = Math.hypot(end.x - mid.x, end.y - mid.y);
-  const total = leg1 + leg2;
-
-  const anchors: WorldPoint[] = [];
-  for (let i = 0; i < count; i += 1) {
-    // Center the run along the polyline.
-    const t = count === 1 ? 0.5 : 0.5 + (i / (count - 1) - 0.5) * 0.9;
-    const dist = t * total;
-    if (dist <= leg1) {
-      const k = leg1 === 0 ? 0 : dist / leg1;
-      anchors.push({ x: start.x + (mid.x - start.x) * k, y: start.y + (mid.y - start.y) * k });
-    } else {
-      const k = leg2 === 0 ? 0 : (dist - leg1) / leg2;
-      anchors.push({ x: mid.x + (end.x - mid.x) * k, y: mid.y + (end.y - mid.y) * k });
-    }
+export function bandRect(level: PyramidTier): BandRect {
+  const w = BAND_WIDTHS[level];
+  let y = BASE_Y;
+  for (let l = 1 as PyramidTier; l <= level; l += 1) {
+    y -= BAND_HEIGHTS[l as PyramidTier];
   }
-  return anchors.sort((a, b) => a.x + a.y - (b.x + b.y));
+  return { x: CENTER_X - w / 2, y, w, h: BAND_HEIGHTS[level] };
 }
 
-// How many silhouettes fit on a tier's front ledge before "+N" kicks in.
-// Narrower (higher) tiers hold fewer.
-export function ledgeCapacity(level: PyramidTier): number {
-  const half = TIER_SIDES[level] / 2;
-  const frontLength = (half - LEDGE / 2) * 4; // both front edges, inset
-  return Math.max(2, Math.min(6, Math.floor(frontLength / 42)));
+function parallelogram(x0: number, x1: number, y: number): ScreenPoint[] {
+  return [
+    { x: x0, y },
+    { x: x1, y },
+    { x: x1 + RELIEF.dx, y: y - RELIEF.dy },
+    { x: x0 + RELIEF.dx, y: y - RELIEF.dy },
+  ];
 }
 
-// Anchor points for the side labels (west corner of each terrace top) and
-// the count badges (east corner), in screen space.
-export function labelAnchor(level: PyramidTier): ScreenPoint {
-  const half = TIER_SIDES[level] / 2;
-  return project(-half, half, tierTopZ(level));
+// The lit top ledges of a band: the exposed left/right shoulders beside
+// the band above, or the full top for the topmost band.
+export function ledgeQuads(level: PyramidTier): ScreenPoint[][] {
+  const band = bandRect(level);
+  if (level === 5) {
+    return [parallelogram(band.x, band.x + band.w, band.y)];
+  }
+  const above = bandRect((level + 1) as PyramidTier);
+  return [
+    parallelogram(band.x, above.x, band.y),
+    parallelogram(above.x + above.w, band.x + band.w, band.y),
+  ];
 }
 
-export function badgeAnchor(level: PyramidTier): ScreenPoint {
-  const half = TIER_SIDES[level] / 2;
-  return project(half, -half, tierTopZ(level));
+// The shaded right-side return of a band.
+export function sideQuad(level: PyramidTier): ScreenPoint[] {
+  const band = bandRect(level);
+  const xr = band.x + band.w;
+  return [
+    { x: xr, y: band.y },
+    { x: xr + RELIEF.dx, y: band.y - RELIEF.dy },
+    { x: xr + RELIEF.dx, y: band.y + band.h - RELIEF.dy },
+    { x: xr, y: band.y + band.h },
+  ];
+}
+
+// --- Crop stand points -------------------------------------------------------
+// Crops stand with their feet on a band's top edge. Two modes:
+//
+// - 'shoulders': the resting state. Silhouettes stand only on the
+//   exposed ledges beside the band above, so they never crowd the upper
+//   band's copy.
+// - 'full': the showcase state for the hovered/selected band. The whole
+//   planting steps forward across the band's full width, drawn in front
+//   of the hill.
+
+const STAND_MARGIN = 18;
+const SHOWCASE_SPACING = { min: 17, max: 30 } as const;
+
+function spread(x0: number, x1: number, count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [(x0 + x1) / 2];
+  const usable = x1 - x0;
+  const spacing = Math.min(SHOWCASE_SPACING.max, usable / (count - 1));
+  const start = (x0 + x1) / 2 - (spacing * (count - 1)) / 2;
+  return Array.from({ length: count }, (_, i) => start + spacing * i);
+}
+
+// Two silhouettes per shoulder in the resting state; the top band's
+// full ledge holds the same four.
+export const SHOULDER_CAPACITY = 4;
+
+export function showcaseCapacity(level: PyramidTier): number {
+  const band = bandRect(level);
+  const usable = band.w - STAND_MARGIN * 2;
+  return Math.max(4, Math.floor(usable / SHOWCASE_SPACING.min) + 1);
+}
+
+export function standPoints(
+  level: PyramidTier,
+  count: number,
+  mode: 'shoulders' | 'full'
+): ScreenPoint[] {
+  if (count <= 0) return [];
+  const band = bandRect(level);
+  const y = band.y;
+
+  if (mode === 'full' || level === 5) {
+    const xs = spread(band.x + STAND_MARGIN, band.x + band.w - STAND_MARGIN, count);
+    return xs.map((x) => ({ x, y }));
+  }
+
+  const above = bandRect((level + 1) as PyramidTier);
+  const leftCount = Math.ceil(count / 2);
+  const rightCount = count - leftCount;
+  const left = spread(band.x + STAND_MARGIN, above.x - 8, leftCount);
+  const right = spread(above.x + above.w + 8, band.x + band.w - STAND_MARGIN, rightCount);
+  return [...left, ...right].map((x) => ({ x, y }));
 }
 
 // --- Scene metrics -----------------------------------------------------------
-
-const LABEL_COLUMN = 168; // reserved width for the leader-line labels
-const BADGE_GUTTER = 64;
-const PAD_TOP = 56;
-const PAD_BOTTOM = 64;
 
 export interface PyramidMetrics {
   width: number;
   height: number;
   viewBox: string;
-  /** x where label text right-aligns (leader lines run from here). */
-  labelColumnX: number;
 }
 
 export function pyramidMetrics(): PyramidMetrics {
-  const baseHalf = TIER_SIDES[1] / 2;
-  // Widest extent comes from the base square's west/east corners.
-  const halfWidth = baseHalf * 2 * ISO_COS * PX_PER_INCH;
-  // Lowest point: base south corner at z=0; highest: keep simple and use
-  // the base north corner (z=0) vs top tier's north corner and take the
-  // higher (smaller y).
-  const south = baseHalf * 2 * ISO_SIN * PX_PER_INCH;
-  const baseNorth = -south;
-  const topHalf = TIER_SIDES[5] / 2;
-  const topNorth = -topHalf * 2 * ISO_SIN * PX_PER_INCH - tierTopZ(5) * Z_PER_INCH;
-  const north = Math.min(baseNorth, topNorth);
-
-  const minX = -halfWidth - LABEL_COLUMN;
-  const maxX = halfWidth + BADGE_GUTTER;
-  const minY = north - PAD_TOP;
-  const maxY = south + PAD_BOTTOM;
-  return {
-    width: maxX - minX,
-    height: maxY - minY,
-    viewBox: `${Math.round(minX)} ${Math.round(minY)} ${Math.round(maxX - minX)} ${Math.round(maxY - minY)}`,
-    labelColumnX: -halfWidth - 28,
-  };
+  // Fixed frame: the pyramid plus lawn, headroom for standing crops on
+  // the top band, and the ground shadow below.
+  return { width: 680, height: 472, viewBox: '0 0 680 472' };
 }
 
-// Organic lawn blob under the pyramid, same hand-drawn wobble as the
-// masterplan ground plate. The radius covers the base square's *diagonal*
-// corners (half·√2), not just its sides, so no corner pokes past the lawn.
-export function groundRing(margin = 26): WorldPoint[] {
-  const half = (TIER_SIDES[1] / 2) * Math.SQRT2 + margin;
-  const points: WorldPoint[] = [];
+// Organic lawn blob beneath the pyramid, in screen space, with the same
+// hand-drawn wobble as the masterplan ground plate.
+export function lawnRing(): ScreenPoint[] {
+  const cx = CENTER_X;
+  const cy = BASE_Y + 8;
+  const rx = BAND_WIDTHS[1] / 2 + 64;
+  const ry = 42;
+  const points: ScreenPoint[] = [];
   const segments = 14;
   for (let i = 0; i < segments; i += 1) {
     const angle = (i / segments) * Math.PI * 2;
     const wobble = 1 + Math.sin(i * 2.7) * 0.06;
     points.push({
-      x: Math.cos(angle) * half * wobble,
-      y: Math.sin(angle) * half * wobble,
+      x: cx + Math.cos(angle) * rx * wobble,
+      y: cy + Math.sin(angle) * ry * wobble,
     });
   }
   return points;

--- a/apps/grn/src/components/Planner/pyramidGeometry.ts
+++ b/apps/grn/src/components/Planner/pyramidGeometry.ts
@@ -1,0 +1,192 @@
+// Geometry for the isometric Garden Pyramid: a five-step terraced
+// "ziggurat" drawn with the same projection and flat-shading rules as the
+// garden masterplan. All layout math lives here (component-free) so the
+// GardenPyramid component stays a pure illustration and the math is unit
+// testable.
+//
+// World units are inches, centered on the pyramid's axis at (0, 0).
+// Tier 1 (Foundation) is the widest, ground-level step; each tier above
+// is inset by a fixed ledge and raised one step.
+
+import {
+  ISO_COS,
+  ISO_SIN,
+  PX_PER_INCH,
+  Z_PER_INCH,
+  project,
+  rectFootprint,
+  type ScreenPoint,
+  type WorldPoint,
+} from '../GardenMasterplan/iso';
+import type { PyramidTier } from '../CropPlanner/gardenPyramid';
+
+export const STEP_HEIGHT = 27; // inches per terrace step
+export const LEDGE = 22; // exposed terrace band per side, in inches
+
+// Side length of each tier's square, widest to narrowest.
+export const TIER_SIDES: Record<PyramidTier, number> = {
+  1: 240,
+  2: 240 - LEDGE * 2,
+  3: 240 - LEDGE * 4,
+  4: 240 - LEDGE * 6,
+  5: 240 - LEDGE * 8,
+};
+
+export function tierFootprint(level: PyramidTier): WorldPoint[] {
+  const half = TIER_SIDES[level] / 2;
+  return rectFootprint({ x: -half, y: -half, length: half * 2, width: half * 2 });
+}
+
+export function tierBaseZ(level: PyramidTier): number {
+  return (level - 1) * STEP_HEIGHT;
+}
+
+export function tierTopZ(level: PyramidTier): number {
+  return level * STEP_HEIGHT;
+}
+
+// Walls of one step between two heights. Like iso.extrude but with an
+// explicit base elevation, since tiers stack on each other rather than on
+// the ground. Footprints are axis-aligned squares, so the two visible
+// walls are always the +x (right) and +y (left) faces.
+export interface TierWalls {
+  right: ScreenPoint[];
+  left: ScreenPoint[];
+}
+
+export function tierWalls(level: PyramidTier): TierWalls {
+  const half = TIER_SIDES[level] / 2;
+  const z0 = tierBaseZ(level);
+  const z1 = tierTopZ(level);
+  // Corners: E = (h, -h), S = (h, h), W = (-h, h).
+  const e = { x: half, y: -half };
+  const s = { x: half, y: half };
+  const w = { x: -half, y: half };
+  return {
+    right: [
+      project(e.x, e.y, z0),
+      project(s.x, s.y, z0),
+      project(s.x, s.y, z1),
+      project(e.x, e.y, z1),
+    ],
+    left: [
+      project(s.x, s.y, z0),
+      project(w.x, w.y, z0),
+      project(w.x, w.y, z1),
+      project(s.x, s.y, z1),
+    ],
+  };
+}
+
+// Evenly spaced stand-points for crop silhouettes along the front ledge
+// of a tier: the two camera-facing edges of its top face, walked from the
+// west corner around the south corner to the east corner, inset from the
+// outer rim so icons sit on the terrace band. Returned back-to-front so
+// upright billboards overlap correctly.
+export function ledgeAnchors(level: PyramidTier, count: number): WorldPoint[] {
+  if (count <= 0) return [];
+  const half = TIER_SIDES[level] / 2;
+  const inset = Math.min(LEDGE / 2, half / 2);
+  const r = half - inset;
+  // Polyline W' -> S' -> E' along the inset front edges.
+  const corner = 10; // keep icons off the very tips
+  const start = { x: -r + corner, y: r };
+  const mid = { x: r, y: r };
+  const end = { x: r, y: -r + corner };
+  const leg1 = Math.hypot(mid.x - start.x, mid.y - start.y);
+  const leg2 = Math.hypot(end.x - mid.x, end.y - mid.y);
+  const total = leg1 + leg2;
+
+  const anchors: WorldPoint[] = [];
+  for (let i = 0; i < count; i += 1) {
+    // Center the run along the polyline.
+    const t = count === 1 ? 0.5 : 0.5 + (i / (count - 1) - 0.5) * 0.9;
+    const dist = t * total;
+    if (dist <= leg1) {
+      const k = leg1 === 0 ? 0 : dist / leg1;
+      anchors.push({ x: start.x + (mid.x - start.x) * k, y: start.y + (mid.y - start.y) * k });
+    } else {
+      const k = leg2 === 0 ? 0 : (dist - leg1) / leg2;
+      anchors.push({ x: mid.x + (end.x - mid.x) * k, y: mid.y + (end.y - mid.y) * k });
+    }
+  }
+  return anchors.sort((a, b) => a.x + a.y - (b.x + b.y));
+}
+
+// How many silhouettes fit on a tier's front ledge before "+N" kicks in.
+// Narrower (higher) tiers hold fewer.
+export function ledgeCapacity(level: PyramidTier): number {
+  const half = TIER_SIDES[level] / 2;
+  const frontLength = (half - LEDGE / 2) * 4; // both front edges, inset
+  return Math.max(2, Math.min(6, Math.floor(frontLength / 42)));
+}
+
+// Anchor points for the side labels (west corner of each terrace top) and
+// the count badges (east corner), in screen space.
+export function labelAnchor(level: PyramidTier): ScreenPoint {
+  const half = TIER_SIDES[level] / 2;
+  return project(-half, half, tierTopZ(level));
+}
+
+export function badgeAnchor(level: PyramidTier): ScreenPoint {
+  const half = TIER_SIDES[level] / 2;
+  return project(half, -half, tierTopZ(level));
+}
+
+// --- Scene metrics -----------------------------------------------------------
+
+const LABEL_COLUMN = 168; // reserved width for the leader-line labels
+const BADGE_GUTTER = 64;
+const PAD_TOP = 56;
+const PAD_BOTTOM = 64;
+
+export interface PyramidMetrics {
+  width: number;
+  height: number;
+  viewBox: string;
+  /** x where label text right-aligns (leader lines run from here). */
+  labelColumnX: number;
+}
+
+export function pyramidMetrics(): PyramidMetrics {
+  const baseHalf = TIER_SIDES[1] / 2;
+  // Widest extent comes from the base square's west/east corners.
+  const halfWidth = baseHalf * 2 * ISO_COS * PX_PER_INCH;
+  // Lowest point: base south corner at z=0; highest: keep simple and use
+  // the base north corner (z=0) vs top tier's north corner and take the
+  // higher (smaller y).
+  const south = baseHalf * 2 * ISO_SIN * PX_PER_INCH;
+  const baseNorth = -south;
+  const topHalf = TIER_SIDES[5] / 2;
+  const topNorth = -topHalf * 2 * ISO_SIN * PX_PER_INCH - tierTopZ(5) * Z_PER_INCH;
+  const north = Math.min(baseNorth, topNorth);
+
+  const minX = -halfWidth - LABEL_COLUMN;
+  const maxX = halfWidth + BADGE_GUTTER;
+  const minY = north - PAD_TOP;
+  const maxY = south + PAD_BOTTOM;
+  return {
+    width: maxX - minX,
+    height: maxY - minY,
+    viewBox: `${Math.round(minX)} ${Math.round(minY)} ${Math.round(maxX - minX)} ${Math.round(maxY - minY)}`,
+    labelColumnX: -halfWidth - 28,
+  };
+}
+
+// Organic lawn blob under the pyramid, same hand-drawn wobble as the
+// masterplan ground plate. The radius covers the base square's *diagonal*
+// corners (half·√2), not just its sides, so no corner pokes past the lawn.
+export function groundRing(margin = 26): WorldPoint[] {
+  const half = (TIER_SIDES[1] / 2) * Math.SQRT2 + margin;
+  const points: WorldPoint[] = [];
+  const segments = 14;
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    const wobble = 1 + Math.sin(i * 2.7) * 0.06;
+    points.push({
+      x: Math.cos(angle) * half * wobble,
+      y: Math.sin(angle) * half * wobble,
+    });
+  }
+  return points;
+}

--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -140,7 +140,9 @@ describe('PlannerPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Flavor' })).toBeInTheDocument();
     // The grower's basil should appear in the Flavor layer's crop list.
-    expect(screen.getByText('Basil')).toBeInTheDocument();
+    // (Scoped to span chips — the pyramid silhouette also carries an svg
+    // <title>Basil</title> tooltip.)
+    expect(screen.getByText('Basil', { selector: 'span' })).toBeInTheDocument();
   });
 
   it('surfaces crops it cannot place in a "Not yet placed" section', async () => {

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1697,153 +1697,76 @@ body {
   background: rgba(79, 56, 37, 0.14);
 }
 
-/* ── The pyramid ─────────────────────────────────────────────────── */
+/* ── The pyramid (isometric terraces) ────────────────────────────── */
+/* Reuses the masterplan's .mp-scene/.mp-el hover-dim/lift/ring system so
+   the planner and the garden map share one interaction vocabulary. */
 
-.grn-pyramid {
+.grn-iso-pyramid {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.grn-pyramid__band {
-  --tier-accent: var(--og-color-moss);
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  min-height: 4.1rem;
-  padding: 0.55rem 1rem;
-  border: 1px solid transparent;
-  border-radius: var(--og-radius-md);
-  background: linear-gradient(135deg, var(--tier-accent), color-mix(in srgb, var(--tier-accent) 78%, #000));
-  color: #fff7ec;
-  cursor: pointer;
-  text-align: left;
-  box-shadow: 0 4px 12px rgba(38, 23, 15, 0.12);
-  transition: transform 140ms ease, box-shadow 140ms ease, filter 140ms ease;
-}
-
-.grn-pyramid__band.is-empty {
-  background: rgba(79, 56, 37, 0.08);
-  color: rgba(79, 56, 37, 0.7);
-  box-shadow: none;
-  border-color: rgba(79, 56, 37, 0.16);
-  border-style: dashed;
-}
-
-.grn-pyramid__band:hover {
-  transform: translateY(-1px);
-  filter: brightness(1.04);
-  box-shadow: 0 8px 18px rgba(38, 23, 15, 0.18);
-}
-
-.grn-pyramid__band.is-active {
-  outline: 3px solid var(--tier-accent);
-  outline-offset: 2px;
-}
-
-.grn-pyramid__band:focus-visible {
-  outline: 3px solid var(--og-color-soil);
-  outline-offset: 2px;
-}
-
-.grn-pyramid__level {
-  flex-shrink: 0;
-  display: grid;
-  place-items: center;
-  width: 1.8rem;
-  height: 1.8rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.25);
-  font-family: var(--og-font-display);
-  font-weight: 700;
-  font-size: 1rem;
-}
-
-.grn-pyramid__band.is-empty .grn-pyramid__level {
-  background: rgba(79, 56, 37, 0.12);
-}
-
-.grn-pyramid__band-main {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  min-width: 0;
-  flex: 1;
-}
-
-.grn-pyramid__band-text {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.grn-pyramid__crops {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-}
-
-.grn-pyramid__crop-icon {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  width: 1.85rem;
-  height: 1.85rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 1px 3px rgba(38, 23, 15, 0.18);
 }
 
-.grn-pyramid__crop-icon.is-ghost {
-  background: rgba(79, 56, 37, 0.06);
-  box-shadow: none;
-  opacity: 0.5;
+.grn-iso-pyramid__svg {
+  display: block;
+  width: 100%;
+  max-width: 980px;
+  height: auto;
+  overflow: visible;
 }
 
-.grn-pyramid__crop-more {
-  display: inline-flex;
-  align-items: center;
-  height: 1.85rem;
-  padding: 0 0.55rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.28);
-  font-size: 0.8rem;
-  font-weight: 700;
+.grn-iso-pyramid__tier:focus-visible {
+  outline: none;
 }
 
-.grn-pyramid__band-name {
+.grn-iso-pyramid__name {
   font-family: var(--og-font-display);
+  font-size: 14px;
+  font-weight: 600;
+  fill: var(--og-color-soil);
+}
+
+.grn-iso-pyramid__tier.is-empty .grn-iso-pyramid__name {
+  fill: rgba(79, 56, 37, 0.55);
+}
+
+.grn-iso-pyramid__caption {
+  font-family: var(--og-font-body);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  fill: rgba(79, 56, 37, 0.5);
+}
+
+.grn-iso-pyramid__leader {
+  stroke: rgba(86, 96, 64, 0.35);
+  stroke-width: 1;
+  stroke-dasharray: 1 4;
+  stroke-linecap: round;
+}
+
+.grn-iso-pyramid__count {
+  font-family: var(--og-font-body);
+  font-size: 12px;
   font-weight: 700;
-  font-size: 1rem;
-  line-height: 1.2;
+  fill: #fffdf8;
 }
 
-.grn-pyramid__band-tagline {
-  font-size: 0.78rem;
-  opacity: 0.85;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.grn-iso-pyramid__count.is-empty {
+  fill: rgba(79, 56, 37, 0.6);
 }
 
-.grn-pyramid__band-count {
-  flex-shrink: 0;
-  display: grid;
-  place-items: center;
-  min-width: 1.9rem;
-  height: 1.9rem;
-  padding: 0 0.5rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.28);
-  font-weight: 700;
-  font-size: 0.9rem;
+.mp-crop.is-ghost {
+  pointer-events: none;
 }
 
-.grn-pyramid__band-count.is-empty {
-  background: rgba(79, 56, 37, 0.12);
-  color: rgba(79, 56, 37, 0.7);
+@media (max-width: 640px) {
+  /* On phones the SVG scales below legible text size; terraces stay
+     tappable (each carries a full aria-label) and the tier detail card
+     below names the selection. */
+  .grn-iso-pyramid__side-label {
+    display: none;
+  }
 }
 
 /* ── Tier detail panel ───────────────────────────────────────────── */

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1697,7 +1697,7 @@ body {
   background: rgba(79, 56, 37, 0.14);
 }
 
-/* ── The pyramid (isometric terraces) ────────────────────────────── */
+/* ── The pyramid (illustrated front elevation) ───────────────────── */
 /* Reuses the masterplan's .mp-scene/.mp-el hover-dim/lift/ring system so
    the planner and the garden map share one interaction vocabulary. */
 
@@ -1709,7 +1709,7 @@ body {
 .grn-iso-pyramid__svg {
   display: block;
   width: 100%;
-  max-width: 980px;
+  max-width: 880px;
   height: auto;
   overflow: visible;
 }
@@ -1720,29 +1720,21 @@ body {
 
 .grn-iso-pyramid__name {
   font-family: var(--og-font-display);
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  fill: var(--og-color-soil);
+  letter-spacing: 0.01em;
 }
 
-.grn-iso-pyramid__tier.is-empty .grn-iso-pyramid__name {
-  fill: rgba(79, 56, 37, 0.55);
-}
-
-.grn-iso-pyramid__caption {
+.grn-iso-pyramid__tagline {
   font-family: var(--og-font-body);
-  font-size: 9.5px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  fill: rgba(79, 56, 37, 0.5);
+  font-size: 11px;
+  transition: opacity 160ms var(--easing-out);
 }
 
-.grn-iso-pyramid__leader {
-  stroke: rgba(86, 96, 64, 0.35);
-  stroke-width: 1;
-  stroke-dasharray: 1 4;
-  stroke-linecap: round;
+/* Quieted while the showcased planting of the band below stands in
+   front of this band's lower edge. */
+.grn-iso-pyramid__tagline.is-quiet {
+  opacity: 0;
 }
 
 .grn-iso-pyramid__count {
@@ -1760,12 +1752,40 @@ body {
   pointer-events: none;
 }
 
+/* The showcased planting steps forward crop by crop. */
+.grn-iso-pyramid__showcase .mp-crop {
+  animation: grn-crop-pop 240ms var(--easing-out) backwards;
+  animation-delay: calc(var(--crop-index, 0) * 22ms);
+}
+
+@keyframes grn-crop-pop {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 640px) {
-  /* On phones the SVG scales below legible text size; terraces stay
-     tappable (each carries a full aria-label) and the tier detail card
-     below names the selection. */
-  .grn-iso-pyramid__side-label {
+  /* Scaled down on phones, the band names need a larger viewBox size to
+     stay legible; taglines drop out (the tier detail card repeats them). */
+  .grn-iso-pyramid__name {
+    font-size: 24px;
+  }
+  .grn-iso-pyramid__tagline {
     display: none;
+  }
+  .grn-iso-pyramid__count {
+    font-size: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grn-iso-pyramid__showcase .mp-crop {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## What

Applies the masterplan's illustrated visual language to the planner page: the Garden Pyramid hero is redrawn as the **classic stepped-triangle elevation** in flat-shaded relief, replacing the plain stacked HTML bands.

> Design note: the first iteration on this branch was a fully isometric ziggurat. Review found the tilted view diluted the pyramid metaphor — the meaning lives in the triangular silhouette and the visibly-wider base — so the final version keeps the masterplan craft but draws the pyramid face-on.

## Experience

- Five stepped bands in muted tier accents forming a true triangle on an organic lawn, with skewed ledge/side relief for the hand-illustrated depth. Names and taglines live inside the bands, count badges at each band's edge.
- **The grower's real crop silhouettes stand on the pyramid.** A few rest on each band's exposed shoulders; **hovering or selecting a band steps its full planting forward** across the band's width with a staggered pop-in (`+N` only past physical capacity). The tagline of the band above quiets while a showcase row stands in front of it.
- Empty bands wash out with a dashed inset ring and faded ghost suggestions previewing what belongs there.
- Hover lifts a band while the others recede; the active band keeps a dashed survey ring — same `.mp-scene`/`.mp-el` CSS system as the garden masterplan, `prefers-reduced-motion` honored.
- Click or Enter/Space selects; every band carries a full aria-label. On phones, band names scale up and taglines drop out (the tier detail card repeats them).

## Implementation

- `Planner/pyramidGeometry.ts` — component-free elevation math: band rects, relief quads, shoulder/full-width stand points, capacities, lawn ring. Unit-tested.
- `Planner/GardenPyramid.tsx` — pure SVG illustration; **same props, testids (`pyramid-band-*`, `pyramid-count-*`), and aria contracts as before**, so `PlannerPage` is untouched except one test query scoped tighter (silhouettes carry svg `<title>` tooltips).
- Old band CSS replaced; showcase pop-in animation added.

## Verification

- `eslint`, `tsc --noEmit`, `npm run build` all clean
- 349/349 tests pass (geometry invariants, showcase/resting behavior, interaction/a11y; existing PlannerPage suite passes with contracts preserved)
- Visually verified in-browser: thriving state with a 9-crop showcase row, partially-planted state with ghosts + selection ring, empty plot, and the tagline-quieting fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)