### PR TITLE
GRN: public garden share links — owner controls and read-only masterplan page

### DIFF
--- a/apps/grn/src/App.tsx
+++ b/apps/grn/src/App.tsx
@@ -1,6 +1,13 @@
 import { lazy, Suspense } from 'react';
+import { Route, Routes } from 'react-router-dom';
 import { useAuth } from './hooks/useAuth';
 import { PlantLoader } from './components/branding/PlantLoader';
+
+// Public page, lazy-loaded so visitors don't pay for the app shell and
+// signed-in users don't pay for it at all.
+const SharedGardenPage = lazy(() =>
+  import('./pages/SharedGardenPage').then((m) => ({ default: m.SharedGardenPage }))
+);
 
 // Lazy-load the entire authenticated tree (shell + useUser + onboarding +
 // every page) so the main bundle stays under the perf:budget cap.
@@ -32,7 +39,9 @@ function FullPageLoader() {
   );
 }
 
-function App() {
+// The auth gate wraps everything except explicitly public pages: shared
+// garden links must open for visitors without bouncing them to login.
+function AuthGate() {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
@@ -48,6 +57,22 @@ function App() {
     <Suspense fallback={<FullPageLoader />}>
       <AuthenticatedRoot />
     </Suspense>
+  );
+}
+
+function App() {
+  return (
+    <Routes>
+      <Route
+        path="/shared/:token"
+        element={
+          <Suspense fallback={<FullPageLoader />}>
+            <SharedGardenPage />
+          </Suspense>
+        }
+      />
+      <Route path="*" element={<AuthGate />} />
+    </Routes>
   );
 }
 

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -8,6 +8,7 @@ import type {
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import { GARDEN_TEMPLATES } from '../GardenDesigner/gardenTemplates';
 import { downloadScenePng, downloadSceneSvg } from './exportScene';
+import { SharePopover } from './SharePopover';
 import { sceneMetrics } from './footprints';
 import { GardenReviewPanel } from './GardenReviewPanel';
 import { IsoScene } from './IsoScene';
@@ -242,6 +243,7 @@ export function GardenMasterplan({
             >
               ✨ Review
             </button>
+            <SharePopover />
           </div>
         )}
 

--- a/apps/grn/src/components/GardenMasterplan/SharePopover.tsx
+++ b/apps/grn/src/components/GardenMasterplan/SharePopover.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createMyGardenShare,
+  getMyGardenShare,
+  revokeMyGardenShare,
+} from '../../services/api';
+
+type ShareState =
+  | { status: 'loading' }
+  | { status: 'inactive' }
+  | { status: 'active'; url: string }
+  | { status: 'error' };
+
+/**
+ * "Share" control for the masterplan: a button that opens a small popover
+ * for creating, copying, and revoking the public read-only garden link.
+ */
+export function SharePopover() {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<ShareState>({ status: 'loading' });
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  const shareUrl = useCallback(
+    (token: string) => `${window.location.origin}/shared/${token}`,
+    []
+  );
+
+  // Lazily look up the current link when the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getMyGardenShare()
+      .then((link) => {
+        if (!cancelled) setState({ status: 'active', url: shareUrl(link.token) });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const statusCode =
+          error && typeof error === 'object' && 'statusCode' in error
+            ? (error as { statusCode?: number }).statusCode
+            : undefined;
+        setState(statusCode === 404 ? { status: 'inactive' } : { status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, shareUrl]);
+
+  // Dismiss on outside click or Esc, like the toolbar's More sheet.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  async function handleCreate() {
+    setBusy(true);
+    try {
+      const link = await createMyGardenShare();
+      setState({ status: 'active', url: shareUrl(link.token) });
+    } catch {
+      setState({ status: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRevoke() {
+    setBusy(true);
+    try {
+      await revokeMyGardenShare();
+      setState({ status: 'inactive' });
+      setCopied(false);
+    } catch {
+      setState({ status: 'error' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCopy(url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="mp-share" ref={rootRef}>
+      <button
+        type="button"
+        className="mp-explorer__export-btn"
+        onClick={() => {
+          if (!open) setState({ status: 'loading' });
+          setOpen((value) => !value);
+        }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        title="Share a public read-only link to this garden"
+      >
+        ↗ Share
+      </button>
+      {open && (
+        <div className="mp-share__panel" role="dialog" aria-label="Share this garden">
+          <p className="mp-share__explain">
+            Anyone with the link can view a read-only masterplan — your notes
+            and private crops stay hidden.
+          </p>
+          {state.status === 'loading' && <p className="mp-share__status">Checking…</p>}
+          {state.status === 'error' && (
+            <p className="mp-share__status">Something went wrong. Try again.</p>
+          )}
+          {state.status === 'inactive' && (
+            <button
+              type="button"
+              className="mp-panel__action"
+              onClick={() => {
+                void handleCreate();
+              }}
+              disabled={busy}
+            >
+              {busy ? 'Creating…' : 'Create share link'}
+            </button>
+          )}
+          {state.status === 'active' && (
+            <>
+              <div className="mp-share__link-row">
+                <input
+                  className="mp-share__url"
+                  type="text"
+                  readOnly
+                  value={state.url}
+                  aria-label="Public garden link"
+                  onFocus={(event) => event.target.select()}
+                />
+                <button
+                  type="button"
+                  className="mp-share__copy"
+                  onClick={() => {
+                    void handleCopy(state.url);
+                  }}
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+              <button
+                type="button"
+                className="mp-share__revoke"
+                onClick={() => {
+                  void handleRevoke();
+                }}
+                disabled={busy}
+              >
+                {busy ? 'Turning off…' : 'Turn off sharing'}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/grn/src/pages/SharedGardenPage.test.tsx
+++ b/apps/grn/src/pages/SharedGardenPage.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SharedGardenPage } from './SharedGardenPage';
+import { ApiError, type SharedGardenSnapshot } from '../services/api';
+
+vi.mock('../services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/api')>();
+  return {
+    ...actual,
+    fetchSharedGarden: vi.fn(),
+  };
+});
+
+import { fetchSharedGarden } from '../services/api';
+
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  // jsdom lacks matchMedia; PlantLoader queries prefers-reduced-motion.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+});
+
+beforeEach(() => {
+  vi.mocked(fetchSharedGarden).mockReset();
+});
+
+const snapshot: SharedGardenSnapshot = {
+  canvas: { widthInches: 360, heightInches: 240, northOffsetDeg: 0 },
+  beds: [
+    {
+      id: 'bed-1',
+      name: 'Herb spiral',
+      bedType: 'raised',
+      shape: 'rect',
+      sunExposure: 'full_sun',
+      soilType: null,
+      lengthInches: 96,
+      widthInches: 48,
+      positionX: 24,
+      positionY: 24,
+      rotationDeg: 0,
+      points: null,
+      color: null,
+      sortOrder: 0,
+    },
+  ],
+  annotations: [],
+  crops: [{ bedId: 'bed-1', cropName: 'Tomato', plantCount: 4 }],
+};
+
+function renderPage(token = 'a'.repeat(32)) {
+  return render(
+    <MemoryRouter initialEntries={[`/shared/${token}`]}>
+      <Routes>
+        <Route path="/shared/:token" element={<SharedGardenPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('SharedGardenPage', () => {
+  it('renders the shared masterplan with its beds', async () => {
+    vi.mocked(fetchSharedGarden).mockResolvedValue(snapshot);
+    renderPage();
+    expect(
+      await screen.findByRole('button', { name: /herb spiral/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/a shared garden/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/made with the good roots network garden designer/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows a friendly not-found state for dead links', async () => {
+    vi.mocked(fetchSharedGarden).mockRejectedValue(new ApiError('nope', 404));
+    renderPage();
+    expect(
+      await screen.findByText(/doesn’t exist or was turned off/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/ask the gardener for a fresh link/i)).toBeInTheDocument();
+  });
+
+  it('shows a retry message on other errors', async () => {
+    vi.mocked(fetchSharedGarden).mockRejectedValue(new ApiError('boom', 500));
+    renderPage();
+    expect(
+      await screen.findByText(/couldn’t load this garden right now/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/pages/SharedGardenPage.tsx
+++ b/apps/grn/src/pages/SharedGardenPage.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { PlantLoader } from '../components/branding/PlantLoader';
+import { sceneMetrics } from '../components/GardenMasterplan/footprints';
+import { IsoScene } from '../components/GardenMasterplan/IsoScene';
+import { useMapViewport } from '../components/GardenMasterplan/useMapViewport';
+import {
+  fetchSharedGarden,
+  type SharedGardenSnapshot,
+} from '../services/api';
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../types/listing';
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'not-found' }
+  | { status: 'error' }
+  | { status: 'ready'; snapshot: SharedGardenSnapshot };
+
+// The public payload is privacy-trimmed; widen it back to the full local
+// types with neutral placeholders so the masterplan renderer can be
+// reused untouched.
+function toGardenBed(bed: SharedGardenSnapshot['beds'][number]): GardenBed {
+  return {
+    ...bed,
+    userId: '',
+    description: null,
+    locationNotes: null,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function toGardenAnnotation(
+  annotation: SharedGardenSnapshot['annotations'][number]
+): GardenAnnotation {
+  return {
+    ...annotation,
+    userId: '',
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function toCropItem(
+  crop: SharedGardenSnapshot['crops'][number],
+  index: number
+): GrowerCropItem {
+  return {
+    id: `shared-crop-${index}`,
+    userId: '',
+    canonicalId: null,
+    cropName: crop.cropName,
+    varietyId: null,
+    status: 'growing',
+    visibility: 'public',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: crop.bedId,
+    bedName: null,
+    plantingDate: null,
+    expectedHarvestDate: null,
+    plantCount: crop.plantCount,
+    spacingInches: null,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+/**
+ * Public, read-only view of a shared garden — no auth shell, no editing.
+ * Reachable at /shared/{token} for anyone holding the link.
+ */
+export function SharedGardenPage() {
+  const { token } = useParams<{ token: string }>();
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  useEffect(() => {
+    // A missing token renders not-found below without touching state.
+    if (!token) return undefined;
+    let cancelled = false;
+    fetchSharedGarden(token)
+      .then((snapshot) => {
+        if (!cancelled) setState({ status: 'ready', snapshot });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const statusCode =
+          error && typeof error === 'object' && 'statusCode' in error
+            ? (error as { statusCode?: number }).statusCode
+            : undefined;
+        setState(statusCode === 404 ? { status: 'not-found' } : { status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (state.status === 'loading' && token) {
+    return (
+      <div className="grn-shared-page">
+        <div className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Opening the garden…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status !== 'ready' || !token) {
+    const notFound = state.status === 'not-found' || !token;
+    return (
+      <div className="grn-shared-page">
+        <div className="grn-page-status">
+          <h1 className="grn-shared-page__title">
+            {notFound
+              ? 'This garden link doesn’t exist or was turned off.'
+              : 'We couldn’t load this garden right now.'}
+          </h1>
+          <p>
+            {notFound
+              ? 'Ask the gardener for a fresh link.'
+              : 'Try refreshing the page in a moment.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <SharedGardenView snapshot={state.snapshot} />;
+}
+
+function SharedGardenView({ snapshot }: { snapshot: SharedGardenSnapshot }) {
+  const canvas: GardenCanvas = useMemo(
+    () => ({
+      id: 'shared',
+      userId: '',
+      widthInches: snapshot.canvas.widthInches,
+      heightInches: snapshot.canvas.heightInches,
+      backgroundImageKey: null,
+      backgroundImageUrl: null,
+      backgroundOpacity: 0,
+      northOffsetDeg: snapshot.canvas.northOffsetDeg,
+      createdAt: '',
+      updatedAt: '',
+    }),
+    [snapshot.canvas]
+  );
+
+  const beds = useMemo(() => snapshot.beds.map(toGardenBed), [snapshot.beds]);
+  const annotations = useMemo(
+    () => snapshot.annotations.map(toGardenAnnotation),
+    [snapshot.annotations]
+  );
+  const cropsByBedId = useMemo(() => {
+    const map = new Map<string, GrowerCropItem[]>();
+    snapshot.crops.forEach((crop, index) => {
+      const item = toCropItem(crop, index);
+      const existing = map.get(crop.bedId);
+      if (existing) {
+        existing.push(item);
+      } else {
+        map.set(crop.bedId, [item]);
+      }
+    });
+    return map;
+  }, [snapshot.crops]);
+
+  const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
+  const {
+    containerRef,
+    containerHandlers,
+    contentStyle,
+    zoomIn,
+    zoomOut,
+    fitToScreen,
+    shouldIgnoreClick,
+  } = useMapViewport(metrics.width, metrics.height);
+
+  return (
+    <div className="grn-shared-page">
+      <header className="grn-shared-page__header">
+        <h1 className="grn-shared-page__title">A shared garden</h1>
+        <p className="grn-shared-page__subtitle">
+          Made with the Good Roots Network garden designer
+        </p>
+      </header>
+      <div className="mp-explorer grn-shared-page__map">
+        <div
+          ref={containerRef}
+          className="mp-explorer__viewport"
+          {...containerHandlers}
+        >
+          <div className="mp-explorer__content" style={contentStyle}>
+            <IsoScene
+              canvas={canvas}
+              beds={beds}
+              annotations={annotations}
+              cropsByBedId={cropsByBedId}
+              selected={null}
+              onSelect={() => {}}
+              shouldIgnoreClick={shouldIgnoreClick}
+            />
+          </div>
+          <div className="mp-explorer__zoom" role="group" aria-label="Map zoom controls">
+            <button
+              type="button"
+              className="mp-explorer__zoom-btn"
+              onClick={zoomIn}
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+            <button
+              type="button"
+              className="mp-explorer__zoom-btn"
+              onClick={zoomOut}
+              aria-label="Zoom out"
+            >
+              −
+            </button>
+            <button
+              type="button"
+              className="mp-explorer__zoom-btn mp-explorer__zoom-btn--fit"
+              onClick={fitToScreen}
+              aria-label="Fit garden to screen"
+            >
+              ⊡
+            </button>
+          </div>
+          <p className="mp-explorer__hint" aria-hidden="true">
+            Drag to explore · scroll to zoom
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -1240,4 +1240,82 @@ export async function updateRequest(
   return mapRequestWriteResponse(response);
 }
 
+// --- Garden sharing ---------------------------------------------------------
+// The owner manages one public link; anyone with the token reads a
+// privacy-trimmed snapshot without authentication.
+
+export interface GardenShareLink {
+  token: string;
+  createdAt: string;
+}
+
+export interface SharedGardenBed {
+  id: string;
+  name: string;
+  bedType: BedType;
+  shape: BedShape;
+  sunExposure: SunExposure | null;
+  soilType: string | null;
+  lengthInches: number | null;
+  widthInches: number | null;
+  positionX: number | null;
+  positionY: number | null;
+  rotationDeg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
+  sortOrder: number;
+}
+
+export interface SharedGardenAnnotation {
+  id: string;
+  label: string;
+  icon: string | null;
+  shape: AnnotationShape;
+  positionX: number | null;
+  positionY: number | null;
+  lengthInches: number | null;
+  widthInches: number | null;
+  rotationDeg: number;
+  points: BedPolygonPoint[] | null;
+  color: string | null;
+  sortOrder: number;
+}
+
+export interface SharedGardenSnapshot {
+  canvas: {
+    widthInches: number;
+    heightInches: number;
+    northOffsetDeg: number;
+  };
+  beds: SharedGardenBed[];
+  annotations: SharedGardenAnnotation[];
+  crops: Array<{ bedId: string; cropName: string; plantCount: number | null }>;
+}
+
+export async function getMyGardenShare(): Promise<GardenShareLink> {
+  return apiFetch<GardenShareLink>('/garden/share');
+}
+
+export async function createMyGardenShare(): Promise<GardenShareLink> {
+  return apiFetch<GardenShareLink>('/garden/share', { method: 'POST' });
+}
+
+export async function revokeMyGardenShare(): Promise<void> {
+  await apiFetch<void>('/garden/share', { method: 'DELETE' });
+}
+
+/**
+ * Public fetch for the shared-garden page: no Amplify session, no auth
+ * header — visitors are anonymous by design.
+ */
+export async function fetchSharedGarden(token: string): Promise<SharedGardenSnapshot> {
+  const response = await fetch(`${getApiEndpoint()}/shared-gardens/${encodeURIComponent(token)}`, {
+    headers: { 'X-Correlation-Id': uuidv4() },
+  });
+  if (!response.ok) {
+    throw new ApiError('Shared garden not found', response.status);
+  }
+  return (await response.json()) as SharedGardenSnapshot;
+}
+
 export default apiFetch;

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -4272,3 +4272,111 @@ body {
   justify-content: flex-end;
   gap: 0.6rem;
 }
+
+/* ==========================================================================
+   Shared garden (public read-only page) + share popover
+   ========================================================================== */
+
+.grn-shared-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--og-color-paper, #fdfaf1);
+}
+
+.grn-shared-page__header {
+  padding: 1.1rem 1.4rem 0.4rem;
+}
+
+.grn-shared-page__title {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--og-color-soil);
+}
+
+.grn-shared-page__subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(79, 56, 37, 0.7);
+}
+
+.grn-shared-page__map {
+  flex: 1;
+  min-height: 70vh;
+}
+
+.mp-share {
+  position: relative;
+}
+
+.mp-share__panel {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  width: 19rem;
+  background: #fff;
+  border: 1px solid rgba(91, 58, 28, 0.16);
+  border-radius: var(--og-radius-md, 12px);
+  box-shadow: 0 10px 30px rgba(58, 43, 26, 0.18);
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.6rem;
+  z-index: 8;
+}
+
+.mp-share__explain {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(79, 56, 37, 0.8);
+}
+
+.mp-share__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(79, 56, 37, 0.7);
+}
+
+.mp-share__link-row {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.mp-share__url {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.78rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid rgba(91, 58, 28, 0.2);
+  border-radius: var(--og-radius-sm);
+  color: var(--og-color-soil);
+  background: rgba(253, 250, 241, 0.7);
+}
+
+.mp-share__copy {
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--og-radius-sm);
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  padding: 0.4rem 0.7rem;
+  cursor: pointer;
+}
+
+.mp-share__revoke {
+  font: inherit;
+  font-size: 0.82rem;
+  border: 1px solid rgba(173, 32, 27, 0.4);
+  color: #8b1f1a;
+  background: transparent;
+  border-radius: var(--og-radius-sm);
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+}
+
+.mp-share__revoke:disabled,
+.mp-share__copy:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}

--- a/postman/collections/Good Roots Network API/Garden Sharing/Create Garden Share Link.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Sharing/Create Garden Share Link.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+name: Create Garden Share Link
+description: |-
+  Create (or idempotently return) the caller's public garden share link.
+  Captures the token for the public shared-garden requests that follow.
+method: POST
+url: '{{baseUrl}}/garden/share'
+order: 1600
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200 or 201", function () {
+          pm.expect([200, 201]).to.include(pm.response.code);
+      });
+
+      pm.test("Response carries a 32-char hex token and createdAt", function () {
+          const response = pm.response.json();
+          pm.expect(response).to.have.property("token");
+          pm.expect(response.token).to.match(/^[0-9a-f]{32}$/);
+          pm.expect(response).to.have.property("createdAt");
+      });
+
+      const response = pm.response.json();
+      if (response.token) {
+          pm.collectionVariables.set("gardenShareToken", response.token);
+      }

--- a/postman/collections/Good Roots Network API/Garden Sharing/Get Shared Garden (Public).request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Sharing/Get Shared Garden (Public).request.yaml
@@ -1,0 +1,40 @@
+$kind: http-request
+name: Get Shared Garden (Public)
+description: |-
+  Public, unauthenticated read of a shared garden by token. Asserts the
+  privacy contract: geometry and crop names only, no user identity or
+  free-text fields.
+method: GET
+url: '{{baseUrl}}/shared-gardens/{{gardenShareToken}}'
+order: 1610
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Snapshot has canvas, beds, annotations, crops", function () {
+          const response = pm.response.json();
+          pm.expect(response).to.have.property("canvas");
+          pm.expect(response.canvas).to.have.property("widthInches");
+          pm.expect(response.canvas).to.have.property("heightInches");
+          pm.expect(Array.isArray(response.beds)).to.be.true;
+          pm.expect(Array.isArray(response.annotations)).to.be.true;
+          pm.expect(Array.isArray(response.crops)).to.be.true;
+      });
+
+      pm.test("No user identity or private text leaks", function () {
+          const response = pm.response.json();
+          const raw = pm.response.text();
+          pm.expect(raw).to.not.include("userId");
+          response.beds.forEach((bed) => {
+              pm.expect(bed).to.not.have.property("description");
+              pm.expect(bed).to.not.have.property("locationNotes");
+          });
+          response.crops.forEach((crop) => {
+              pm.expect(crop).to.not.have.property("notes");
+              pm.expect(crop).to.not.have.property("surplusEnabled");
+          });
+      });

--- a/postman/collections/Good Roots Network API/Garden Sharing/Get Shared Garden (Unknown Token).request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Sharing/Get Shared Garden (Unknown Token).request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+name: Get Shared Garden (Unknown Token)
+description: |-
+  Unknown, malformed, and revoked tokens all return a constant 404 so the
+  endpoint cannot be used to enumerate users.
+method: GET
+url: '{{baseUrl}}/shared-gardens/00000000000000000000000000000000'
+order: 1620
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 404", function () {
+          pm.response.to.have.status(404);
+      });
+
+      pm.test("Error body does not reveal token state", function () {
+          const response = pm.response.json();
+          pm.expect(response).to.have.property("error", "Garden not found");
+      });

--- a/postman/collections/Good Roots Network API/Garden Sharing/Revoke Garden Share Link.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Sharing/Revoke Garden Share Link.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+name: Revoke Garden Share Link
+description: |-
+  Revoke the caller's share link. Idempotent: revoking when no link is
+  active still returns 204.
+method: DELETE
+url: '{{baseUrl}}/garden/share'
+order: 1630
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 204", function () {
+          pm.response.to.have.status(204);
+      });

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -1098,3 +1098,21 @@ create table if not exists gardener_tier_promotions (
 
 create index if not exists idx_gardener_tier_promotions_user
   on gardener_tier_promotions(user_id, promoted_at desc);
+-- Public read-only sharing for the garden masterplan. One link per user;
+-- revoking keeps the row (so analytics/history survive) and re-sharing
+-- mints a fresh token rather than resurrecting the leaked one.
+
+create table if not exists garden_share_links (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  token text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  constraint garden_share_links_user_unique unique (user_id),
+  constraint garden_share_links_token_unique unique (token)
+);
+
+create index if not exists idx_garden_share_links_token
+  on garden_share_links (token)
+  where revoked_at is null;

--- a/services/grn-api/db/migrations/0036_garden_share_links.sql
+++ b/services/grn-api/db/migrations/0036_garden_share_links.sql
@@ -1,0 +1,18 @@
+-- Public read-only sharing for the garden masterplan. One link per user;
+-- revoking keeps the row (so analytics/history survive) and re-sharing
+-- mints a fresh token rather than resurrecting the leaked one.
+
+create table if not exists garden_share_links (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  token text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  constraint garden_share_links_user_unique unique (user_id),
+  constraint garden_share_links_token_unique unique (token)
+);
+
+create index if not exists idx_garden_share_links_token
+  on garden_share_links (token)
+  where revoked_at is null;

--- a/services/grn-api/openapi/paths/garden.yaml
+++ b/services/grn-api/openapi/paths/garden.yaml
@@ -270,3 +270,74 @@
         $ref: '../schemas/_responses.yaml#/ErrorResponse'
       '503':
         $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+# ── Garden sharing ───────────────────────────────────────
+/garden/share:
+  get:
+    tags: [Garden, Idempotent]
+    summary: Get the caller's active garden share link
+    operationId: getMyGardenShareLink
+    responses:
+      '200':
+        description: Active share link
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenShareLink'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  post:
+    tags: [Garden]
+    summary: Create (or return) the caller's garden share link
+    description: |-
+      Idempotent: an active link is returned unchanged; a revoked or
+      missing one gets a freshly minted token so a previously leaked URL
+      stays dead.
+    operationId: createMyGardenShareLink
+    responses:
+      '200':
+        description: Existing active share link
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenShareLink'
+      '201':
+        description: Newly created share link
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/GardenShareLink'
+  delete:
+    tags: [Garden]
+    summary: Revoke the caller's garden share link
+    operationId: revokeMyGardenShareLink
+    responses:
+      '204':
+        description: Link revoked (or no link existed)
+
+/shared-gardens/{token}:
+  get:
+    tags: [Garden, Public, Idempotent]
+    summary: Public read-only view of a shared garden
+    description: |-
+      Unauthenticated. Returns a privacy-trimmed snapshot of the garden:
+      canvas dimensions, bed and annotation geometry, and the names of
+      non-private crops. No user identity, free-text notes, or contact
+      data. Unknown and revoked tokens both return a constant 404.
+    operationId: getSharedGarden
+    parameters:
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{32}$'
+    responses:
+      '200':
+        description: Shared garden snapshot
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/garden.yaml#/SharedGardenResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'

--- a/services/grn-api/openapi/schemas/garden.yaml
+++ b/services/grn-api/openapi/schemas/garden.yaml
@@ -409,3 +409,78 @@ BackgroundUploadIntentResponse:
       description: "Persist this on the canvas via PUT /garden once the upload completes."
     expires_in_seconds:
       type: integer
+
+GardenShareLink:
+  type: object
+  required: [token, createdAt]
+  properties:
+    token:
+      type: string
+      description: 32-char hex token addressing the public view
+    createdAt:
+      type: string
+      format: date-time
+
+SharedGardenResponse:
+  type: object
+  required: [canvas, beds, annotations, crops]
+  properties:
+    canvas:
+      type: object
+      required: [widthInches, heightInches, northOffsetDeg]
+      properties:
+        widthInches:
+          type: integer
+        heightInches:
+          type: integer
+        northOffsetDeg:
+          type: integer
+    beds:
+      type: array
+      items:
+        type: object
+        required: [id, name, bedType, shape, rotationDeg, sortOrder]
+        description: "Bed geometry without user identity or free-text notes"
+        properties:
+          id: { type: string }
+          name: { type: string }
+          bedType: { type: string, enum: [in_ground, raised, mound] }
+          shape: { type: string, enum: [rect, circle, polygon] }
+          sunExposure: { type: string, nullable: true }
+          soilType: { type: string, nullable: true }
+          lengthInches: { type: integer, nullable: true }
+          widthInches: { type: integer, nullable: true }
+          positionX: { type: integer, nullable: true }
+          positionY: { type: integer, nullable: true }
+          rotationDeg: { type: integer }
+          points: { type: array, nullable: true, items: { type: object } }
+          color: { type: string, nullable: true }
+          sortOrder: { type: integer }
+    annotations:
+      type: array
+      items:
+        type: object
+        required: [id, label, shape, rotationDeg, sortOrder]
+        properties:
+          id: { type: string }
+          label: { type: string }
+          icon: { type: string, nullable: true }
+          shape: { type: string, enum: [rect, circle, polygon, line] }
+          positionX: { type: integer, nullable: true }
+          positionY: { type: integer, nullable: true }
+          lengthInches: { type: integer, nullable: true }
+          widthInches: { type: integer, nullable: true }
+          rotationDeg: { type: integer }
+          points: { type: array, nullable: true, items: { type: object } }
+          color: { type: string, nullable: true }
+          sortOrder: { type: integer }
+    crops:
+      type: array
+      description: "Non-private crops by name only"
+      items:
+        type: object
+        required: [bedId, cropName]
+        properties:
+          bedId: { type: string }
+          cropName: { type: string }
+          plantCount: { type: integer, nullable: true }

--- a/services/grn-api/src/api/handlers/garden_share.rs
+++ b/services/grn-api/src/api/handlers/garden_share.rs
@@ -1,0 +1,445 @@
+use crate::auth::extract_auth_context;
+use crate::db;
+use lambda_http::{Body, Request, Response};
+use serde::Serialize;
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+// Public read-only sharing of the garden masterplan.
+//
+// Authenticated owners manage one link via /me/garden/share; anyone with
+// the token reads a privacy-trimmed snapshot via GET /shared-gardens/{token}
+// (allow-listed as a public route in the authorizer). Revoking keeps the
+// row and re-sharing mints a fresh token, so a leaked URL stays dead.
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShareLinkResponse {
+    pub token: String,
+    pub created_at: String,
+}
+
+// The public payload deliberately carries no user identity and none of the
+// free-text fields where people write personal details (descriptions,
+// location notes). Sun and soil stay: they're horticultural context, and
+// sharing the garden is an explicit act by the owner.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedGardenResponse {
+    pub canvas: SharedCanvas,
+    pub beds: Vec<SharedBed>,
+    pub annotations: Vec<SharedAnnotation>,
+    pub crops: Vec<SharedCrop>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedCanvas {
+    pub width_inches: i32,
+    pub height_inches: i32,
+    pub north_offset_deg: i32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedBed {
+    pub id: String,
+    pub name: String,
+    pub bed_type: String,
+    pub shape: String,
+    pub sun_exposure: Option<String>,
+    pub soil_type: Option<String>,
+    pub length_inches: Option<i32>,
+    pub width_inches: Option<i32>,
+    pub position_x: Option<i32>,
+    pub position_y: Option<i32>,
+    pub rotation_deg: i32,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
+    pub sort_order: i32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedAnnotation {
+    pub id: String,
+    pub label: String,
+    pub icon: Option<String>,
+    pub shape: String,
+    pub position_x: Option<i32>,
+    pub position_y: Option<i32>,
+    pub length_inches: Option<i32>,
+    pub width_inches: Option<i32>,
+    pub rotation_deg: i32,
+    pub points: Option<serde_json::Value>,
+    pub color: Option<String>,
+    pub sort_order: i32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedCrop {
+    pub bed_id: String,
+    pub crop_name: String,
+    pub plant_count: Option<i32>,
+}
+
+const DEFAULT_CANVAS_WIDTH_INCHES: i32 = 360;
+const DEFAULT_CANVAS_HEIGHT_INCHES: i32 = 240;
+
+pub async fn get_my_share_link(
+    request: &Request,
+    _correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    let user_id = parse_user_id(&auth.user_id)?;
+
+    let client = db::connect().await?;
+    let row = client
+        .query_opt(
+            "select token, created_at from garden_share_links
+             where user_id = $1 and revoked_at is null",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    row.map_or_else(
+        || error_response(404, "No active share link"),
+        |row| json_response(200, &row_to_share_link(&row)),
+    )
+}
+
+pub async fn create_my_share_link(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    let user_id = parse_user_id(&auth.user_id)?;
+
+    let client = db::connect().await?;
+
+    // Idempotent: an active link is returned as-is; a revoked (or absent)
+    // one gets a freshly minted token.
+    if let Some(existing) = client
+        .query_opt(
+            "select token, created_at from garden_share_links
+             where user_id = $1 and revoked_at is null",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?
+    {
+        return json_response(200, &row_to_share_link(&existing));
+    }
+
+    let token = Uuid::new_v4().simple().to_string();
+    let row = client
+        .query_one(
+            "insert into garden_share_links (user_id, token)
+             values ($1, $2)
+             on conflict (user_id) do update
+               set token = excluded.token,
+                   revoked_at = null,
+                   updated_at = now()
+             returning token, created_at",
+            &[&user_id, &token],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        "Created garden share link"
+    );
+
+    json_response(201, &row_to_share_link(&row))
+}
+
+pub async fn revoke_my_share_link(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let auth = extract_auth_context(request)?;
+    let user_id = parse_user_id(&auth.user_id)?;
+
+    let client = db::connect().await?;
+    client
+        .execute(
+            "update garden_share_links set revoked_at = now(), updated_at = now()
+             where user_id = $1 and revoked_at is null",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        "Revoked garden share link"
+    );
+
+    Response::builder()
+        .status(204)
+        .body(Body::Empty)
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+pub async fn get_shared_garden(
+    token: &str,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    // Reject malformed tokens before touching the database; the constant
+    // 404 below never distinguishes unknown from revoked.
+    if !is_valid_token(token) {
+        return error_response(404, "Garden not found");
+    }
+
+    let client = db::connect().await?;
+    let Some(owner_row) = client
+        .query_opt(
+            "select user_id from garden_share_links
+             where token = $1 and revoked_at is null",
+            &[&token],
+        )
+        .await
+        .map_err(|e| db_error(&e))?
+    else {
+        return error_response(404, "Garden not found");
+    };
+    let user_id: Uuid = owner_row.get("user_id");
+
+    let canvas_row = client
+        .query_opt(
+            "select width_inches, height_inches, north_offset_deg
+             from garden_canvases where user_id = $1",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+    let canvas = canvas_row.map_or(
+        SharedCanvas {
+            width_inches: DEFAULT_CANVAS_WIDTH_INCHES,
+            height_inches: DEFAULT_CANVAS_HEIGHT_INCHES,
+            north_offset_deg: 0,
+        },
+        |row| SharedCanvas {
+            width_inches: row.get("width_inches"),
+            height_inches: row.get("height_inches"),
+            north_offset_deg: row.get("north_offset_deg"),
+        },
+    );
+
+    let bed_rows = client
+        .query(
+            "select id, name, bed_type::text as bed_type, shape, sun_exposure::text as sun_exposure,
+                    soil_type, length_inches, width_inches, position_x, position_y,
+                    rotation_deg, points, color, sort_order
+             from garden_beds
+             where user_id = $1 and archived_at is null
+             order by sort_order asc, created_at asc",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let annotation_rows = client
+        .query(
+            "select id, label, icon, shape, position_x, position_y,
+                    length_inches, width_inches, rotation_deg, points, color, sort_order
+             from garden_annotations
+             where user_id = $1 and archived_at is null
+             order by sort_order asc, created_at asc",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    // Private crops never leave the account; local/public crops appear by
+    // name only — no surplus, pricing, or contact data.
+    let crop_rows = client
+        .query(
+            "select bed_id, crop_name, plant_count
+             from grower_crop_library
+             where user_id = $1
+               and bed_id is not null
+               and deleted_at is null
+               and visibility in ('local', 'public')",
+            &[&user_id],
+        )
+        .await
+        .map_err(|e| db_error(&e))?;
+
+    let response = SharedGardenResponse {
+        canvas,
+        beds: bed_rows.iter().map(row_to_shared_bed).collect(),
+        annotations: annotation_rows
+            .iter()
+            .map(row_to_shared_annotation)
+            .collect(),
+        crops: crop_rows.iter().map(row_to_shared_crop).collect(),
+    };
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        bed_count = response.beds.len(),
+        annotation_count = response.annotations.len(),
+        "Served shared garden"
+    );
+
+    json_response(200, &response)
+}
+
+// Tokens are uuid v4 simple format: exactly 32 lowercase hex characters.
+fn is_valid_token(token: &str) -> bool {
+    token.len() == 32
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+fn row_to_share_link(row: &Row) -> ShareLinkResponse {
+    ShareLinkResponse {
+        token: row.get("token"),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+    }
+}
+
+fn row_to_shared_bed(row: &Row) -> SharedBed {
+    SharedBed {
+        id: row.get::<_, Uuid>("id").to_string(),
+        name: row.get("name"),
+        bed_type: row.get("bed_type"),
+        shape: row.get("shape"),
+        sun_exposure: row.get("sun_exposure"),
+        soil_type: row.get("soil_type"),
+        length_inches: row.get("length_inches"),
+        width_inches: row.get("width_inches"),
+        position_x: row.get("position_x"),
+        position_y: row.get("position_y"),
+        rotation_deg: row.get("rotation_deg"),
+        points: row.get("points"),
+        color: row.get("color"),
+        sort_order: row.get("sort_order"),
+    }
+}
+
+fn row_to_shared_annotation(row: &Row) -> SharedAnnotation {
+    SharedAnnotation {
+        id: row.get::<_, Uuid>("id").to_string(),
+        label: row.get("label"),
+        icon: row.get("icon"),
+        shape: row.get("shape"),
+        position_x: row.get("position_x"),
+        position_y: row.get("position_y"),
+        length_inches: row.get("length_inches"),
+        width_inches: row.get("width_inches"),
+        rotation_deg: row.get("rotation_deg"),
+        points: row.get("points"),
+        color: row.get("color"),
+        sort_order: row.get("sort_order"),
+    }
+}
+
+fn row_to_shared_crop(row: &Row) -> SharedCrop {
+    SharedCrop {
+        bed_id: row.get::<_, Uuid>("bed_id").to_string(),
+        crop_name: row.get("crop_name"),
+        plant_count: row.get("plant_count"),
+    }
+}
+
+fn parse_user_id(raw: &str) -> Result<Uuid, lambda_http::Error> {
+    Uuid::parse_str(raw).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|e| lambda_http::Error::from(format!("Failed to serialize response: {e}")))?;
+
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn error_response(status: u16, message: &str) -> Result<Response<Body>, lambda_http::Error> {
+    json_response(status, &serde_json::json!({ "error": message }))
+}
+
+fn db_error(error: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database query error: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn serialized_keys(json: &serde_json::Value) -> Vec<String> {
+        json.as_object()
+            .map(|object| object.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn token_validation_accepts_uuid_simple_format() {
+        let token = Uuid::new_v4().simple().to_string();
+        assert!(is_valid_token(&token));
+    }
+
+    #[test]
+    fn token_validation_rejects_malformed_input() {
+        assert!(!is_valid_token(""));
+        assert!(!is_valid_token("short"));
+        assert!(!is_valid_token(&"a".repeat(33)));
+        assert!(!is_valid_token("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"));
+        assert!(!is_valid_token("'; drop table garden_share_links;"));
+        assert!(!is_valid_token("AbCdEf0123456789abcdef0123456789"));
+    }
+
+    #[test]
+    fn shared_bed_payload_carries_no_identity_or_private_text() {
+        let bed = SharedBed {
+            id: "bed-1".to_string(),
+            name: "Herb spiral".to_string(),
+            bed_type: "raised".to_string(),
+            shape: "rect".to_string(),
+            sun_exposure: Some("full_sun".to_string()),
+            soil_type: None,
+            length_inches: Some(96),
+            width_inches: Some(48),
+            position_x: Some(24),
+            position_y: Some(24),
+            rotation_deg: 0,
+            points: None,
+            color: None,
+            sort_order: 0,
+        };
+        let keys = serialized_keys(&serde_json::to_value(&bed).unwrap_or_default());
+        assert!(keys.iter().any(|k| k == "lengthInches"));
+        assert!(!keys.iter().any(|k| k == "userId"));
+        assert!(!keys.iter().any(|k| k == "description"));
+        assert!(!keys.iter().any(|k| k == "locationNotes"));
+    }
+
+    #[test]
+    fn shared_crop_payload_is_name_and_count_only() {
+        let crop = SharedCrop {
+            bed_id: "bed-1".to_string(),
+            crop_name: "Tomato".to_string(),
+            plant_count: Some(4),
+        };
+        let keys = serialized_keys(&serde_json::to_value(&crop).unwrap_or_default());
+        assert_eq!(keys.len(), 3);
+        assert!(!keys.iter().any(|k| k == "userId"));
+        assert!(!keys.iter().any(|k| k == "surplusEnabled"));
+        assert!(!keys.iter().any(|k| k == "notes"));
+    }
+}

--- a/services/grn-api/src/api/handlers/mod.rs
+++ b/services/grn-api/src/api/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod crop;
 pub mod feed;
 pub mod garden_canvas;
 pub mod garden_review;
+pub mod garden_share;
 pub mod listing;
 pub mod listing_discovery;
 pub mod reminder;

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -1,6 +1,7 @@
 use crate::handlers::{
     agent_task, ai_copilot, analytics, annotation, bed, billing, catalog, claim, claim_read, crop,
-    feed, garden_canvas, garden_review, listing, listing_discovery, reminder, request, user,
+    feed, garden_canvas, garden_review, garden_share, listing, listing_discovery, reminder,
+    request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -264,6 +265,21 @@ async fn route_garden_designer_request(
     if request_path == "/garden/background-upload-url" {
         return Some(match event.method().as_str() {
             "POST" => garden_canvas::create_background_upload_url(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    if request_path == "/garden/share" {
+        return Some(match event.method().as_str() {
+            "GET" => garden_share::get_my_share_link(event, correlation_id).await,
+            "POST" => garden_share::create_my_share_link(event, correlation_id).await,
+            "DELETE" => garden_share::revoke_my_share_link(event, correlation_id).await,
+            _ => method_not_allowed(),
+        });
+    }
+    // Public, token-addressed view (allow-listed in the authorizer).
+    if let Some(token) = request_path.strip_prefix("/shared-gardens/") {
+        return Some(match event.method().as_str() {
+            "GET" => garden_share::get_shared_garden(token, correlation_id).await,
             _ => method_not_allowed(),
         });
     }

--- a/services/grn-api/src/auth/authorizer.rs
+++ b/services/grn-api/src/auth/authorizer.rs
@@ -200,6 +200,14 @@ fn is_public_route(event: &ApiGatewayCustomAuthorizerRequestTypeRequest) -> bool
         {
             true
         }
+        // Read-only shared-garden views are addressed by an unguessable
+        // token; the handler returns a privacy-trimmed payload and a
+        // constant 404 for unknown or revoked tokens.
+        Some("GET")
+            if path.starts_with("/api/shared-gardens/") || path.starts_with("/shared-gardens/") =>
+        {
+            true
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
Wave 4b — the last feature of the designer program: public read-only garden share links. Stacked on #348.

## Backend

- **Migration 0036** (`garden_share_links`, mirrored into ddl.sql): one link per user, unique unguessable token, `revoked_at` kept on revoke so re-sharing mints a *fresh* token — a leaked URL stays dead.
- **Owner endpoints**: `POST /garden/share` (idempotent create-or-return), `GET /garden/share`, `DELETE /garden/share` (204).
- **Public endpoint**: `GET /shared-gardens/{token}`, allow-listed in the authorizer's `is_public_route()`. Token format is validated before any DB hit; unknown, malformed, and revoked tokens all return a constant 404 (no user enumeration).
- **Privacy contract** (unit-tested at the serialization layer): no user identity anywhere in the public payload; bed descriptions and location notes never leave the account; only `local`/`public`-visibility crops appear, by name + count only — no surplus, pricing, or contact data. Sun/soil stay (horticultural, not personal — and sharing is an explicit act).
- OpenAPI paths + schemas; Postman contract tests for create, public read (including the privacy assertions), constant-404, and revoke.

## Frontend

- **↗ Share popover** on the masterplan: create the link, copy the URL, or turn sharing off.
- **Public page** at `/shared/{token}`, routed *outside* the auth shell (visitors are not bounced to login) and lazy-loaded so neither audience pays for the other's bundle. Renders the full isometric masterplan read-only with pan/zoom; explicit loading / dead-link / error states.

## Testing
- Backend: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (incl. token-validation and privacy-serialization tests) — pass.
- Frontend: 466 tests pass (3 new for the public page); lint 0 errors; typecheck clean; build + perf budget pass (1,085,396 / 1,228,800).

## Merge order
#350 (reach → main) → #348 (AI review) → this.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b)_