### PR TITLE
GRN: marquee multi-select — group move, nudge, and delete with batched undo

### DIFF
--- a/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/AnnotationShape.tsx
@@ -25,8 +25,11 @@ interface AnnotationShapeProps {
   annotation: GardenAnnotation;
   pxPerInch: number;
   isSelected: boolean;
+  /** Member of the multi-selection (stroke highlight only; the
+   * Transformer stays on the primary selection). */
+  isGroupSelected?: boolean;
   isEditable: boolean;
-  onSelect: (annotationId: string) => void;
+  onSelect: (annotationId: string, shiftKey: boolean) => void;
   onMove: (annotationId: string, positionX: number, positionY: number) => void;
   /** Smart-alignment hook: given the in-flight drag position (inches),
    * returns the position nudged onto neighbor alignment lines. */
@@ -69,6 +72,7 @@ export function AnnotationShape({
   annotation,
   pxPerInch,
   isSelected,
+  isGroupSelected = false,
   isEditable,
   onSelect,
   onMove,
@@ -98,7 +102,7 @@ export function AnnotationShape({
 
   const fill = annotation.color ? applyAlpha(annotation.color, '22') : FALLBACK_FILL;
   const stroke = annotation.color ?? FALLBACK_STROKE;
-  const accent = isSelected ? '#3a7e5a' : stroke;
+  const accent = isSelected || isGroupSelected ? '#3a7e5a' : stroke;
   const strokeWidth = isSelected ? 3 : 2;
   const dashPattern = annotation.shape === 'line' ? undefined : [6, 4];
 
@@ -276,8 +280,8 @@ export function AnnotationShape({
         x={positionX}
         y={positionY}
         rotation={annotation.rotationDeg}
-        onMouseDown={() => onSelect(annotation.id)}
-        onTouchStart={() => onSelect(annotation.id)}
+        onMouseDown={(event) => onSelect(annotation.id, Boolean(event.evt.shiftKey))}
+        onTouchStart={() => onSelect(annotation.id, false)}
         onTransform={handleTransform}
         onTransformEnd={handleTransformEnd}
         {...dragProps}

--- a/apps/grn/src/components/GardenDesigner/BedShape.tsx
+++ b/apps/grn/src/components/GardenDesigner/BedShape.tsx
@@ -29,9 +29,12 @@ interface BedShapeProps {
   bed: GardenBed;
   pxPerInch: number;
   isSelected: boolean;
+  /** Member of the multi-selection (stroke highlight only; the
+   * Transformer stays on the primary selection). */
+  isGroupSelected?: boolean;
   isEditable: boolean;
   crops: GrowerCropItem[];
-  onSelect: (bedId: string) => void;
+  onSelect: (bedId: string, shiftKey: boolean) => void;
   onMove: (bedId: string, positionX: number, positionY: number) => void;
   /** Smart-alignment hook: given the in-flight drag position (inches),
    * returns the position nudged onto neighbor alignment lines. */
@@ -86,6 +89,7 @@ export function BedShape({
   bed,
   pxPerInch,
   isSelected,
+  isGroupSelected = false,
   isEditable,
   crops,
   onSelect,
@@ -122,7 +126,7 @@ export function BedShape({
   const fill = fillForBed(bed.bedType, bed.color);
   const stroke = strokeForBed(bed.bedType, bed.color);
   const strokeWidth = isSelected ? 4 : style.strokeWidth;
-  const accent = isSelected ? '#3a7e5a' : stroke;
+  const accent = isSelected || isGroupSelected ? '#3a7e5a' : stroke;
 
   // Wire up the Transformer to the group whenever this bed becomes the
   // selection. Detach it when not selected or not editable so we don't
@@ -300,8 +304,8 @@ export function BedShape({
       x={positionX}
       y={positionY}
       rotation={bed.rotationDeg}
-      onMouseDown={() => onSelect(bed.id)}
-      onTouchStart={() => onSelect(bed.id)}
+      onMouseDown={(event) => onSelect(bed.id, Boolean(event.evt.shiftKey))}
+      onTouchStart={() => onSelect(bed.id, false)}
       onTransform={handleTransform}
       onTransformEnd={handleTransformEnd}
       {...dragProps}

--- a/apps/grn/src/components/GardenDesigner/Canvas.tsx
+++ b/apps/grn/src/components/GardenDesigner/Canvas.tsx
@@ -38,13 +38,15 @@ import { BedShape } from './BedShape';
 import { Grid } from './Grid';
 import { VertexEditor } from './VertexEditor';
 import {
+  marqueeIntersects,
   snapToNeighbors,
   type AlignmentGuide,
   type ElementBounds,
+  type MarqueeRect,
 } from './alignment';
 import { formatInchesAsFeet } from './calibration';
 import { distanceInches, formatInchesAsFeetInches } from './measure';
-import type { SelectedItem } from '../../hooks/useGardenDesigner';
+import type { SelectedItem, SelectedRef } from '../../hooks/useGardenDesigner';
 import type { DesignerMode, GridSnap } from './Toolbar';
 
 interface DesignerCanvasProps {
@@ -87,6 +89,10 @@ interface DesignerCanvasProps {
   onUpdateBedPoints: (bedId: string, points: BedPolygonPoint[]) => void;
   onCalibrationCaptured: (drawnLengthInches: number) => void;
   onCancelCalibration: () => void;
+  groupSelection: SelectedRef[];
+  onToggleSelected: (item: SelectedRef) => void;
+  onMarqueeSelect: (items: SelectedRef[]) => void;
+  onMoveGroup: (anchor: SelectedRef, positionX: number, positionY: number) => void;
 }
 
 export interface DesignerCanvasHandle {
@@ -141,6 +147,10 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       onUpdateBedPoints,
       onCalibrationCaptured,
       onCancelCalibration,
+      groupSelection,
+      onToggleSelected,
+      onMarqueeSelect,
+      onMoveGroup,
     },
     ref
   ) {
@@ -176,6 +186,9 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       x: number;
       y: number;
     } | null>(null);
+    // Shift+drag marquee selection, in canvas inches. Non-null start means
+    // a marquee is in progress (stage panning is suspended meanwhile).
+    const [marquee, setMarquee] = useState<MarqueeRect | null>(null);
 
     // Refs used during touch gestures so handlers don't need to be
     // re-bound on every render. The pinch handler in particular runs
@@ -449,6 +462,10 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       // Calibration clicks are handled at the Stage level (they must land
       // even when the click hits a bed); don't double-handle them here.
       if (calibrating) return;
+      if (marqueeJustFinishedRef.current) {
+        marqueeJustFinishedRef.current = false;
+        return;
+      }
       if (!drawing) {
         onSelect(null);
         return;
@@ -495,6 +512,18 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
     }
 
     function handleStageMouseMove(event: KonvaEventObject<MouseEvent>) {
+      if (marquee) {
+        const stage = event.target.getStage();
+        const pointer = stage ? relativePointer(stage) : null;
+        if (pointer) {
+          setMarquee({
+            ...marquee,
+            width: pointer.x / PX_PER_INCH - marquee.x,
+            height: pointer.y / PX_PER_INCH - marquee.y,
+          });
+        }
+        return;
+      }
       if (!drawing && !measuring && !calibrating) return;
       const stage = event.target.getStage();
       if (!stage) return;
@@ -510,6 +539,58 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       const inchX = snapValue(Math.round(pointer.x / PX_PER_INCH), snap);
       const inchY = snapValue(Math.round(pointer.y / PX_PER_INCH), snap);
       setHoverPoint({ x: inchX, y: inchY });
+    }
+
+    // Click fires right after the marquee's mouseup; swallow that one so
+    // it doesn't immediately deselect what the marquee just picked.
+    const marqueeJustFinishedRef = useRef(false);
+
+    function handleWorldMouseDown(event: KonvaEventObject<MouseEvent>) {
+      if (drawing || measuring || calibrating) return;
+      if (!event.evt.shiftKey) return;
+      const stage = event.target.getStage();
+      if (!stage) return;
+      const pointer = relativePointer(stage);
+      if (!pointer) return;
+      stage.stopDrag();
+      setMarquee({
+        x: pointer.x / PX_PER_INCH,
+        y: pointer.y / PX_PER_INCH,
+        width: 0,
+        height: 0,
+      });
+    }
+
+    function handleStageMouseUp() {
+      if (!marquee) return;
+      const hits: SelectedRef[] = [];
+      for (const bed of beds) {
+        const x = bed.positionX ?? 12;
+        const y = bed.positionY ?? 12;
+        const bounds = {
+          left: x,
+          top: y,
+          right: x + (bed.lengthInches ?? 96),
+          bottom: y + (bed.widthInches ?? 48),
+        };
+        if (marqueeIntersects(marquee, bounds)) hits.push({ kind: 'bed', id: bed.id });
+      }
+      for (const annotation of annotations) {
+        const x = annotation.positionX ?? 12;
+        const y = annotation.positionY ?? 12;
+        const bounds = {
+          left: x,
+          top: y,
+          right: x + (annotation.lengthInches ?? 48),
+          bottom: y + (annotation.widthInches ?? 48),
+        };
+        if (marqueeIntersects(marquee, bounds)) {
+          hits.push({ kind: 'annotation', id: annotation.id });
+        }
+      }
+      setMarquee(null);
+      marqueeJustFinishedRef.current = true;
+      onMarqueeSelect(hits);
     }
 
     function handleMeasureClick(event: KonvaEventObject<MouseEvent | TouchEvent>) {
@@ -609,34 +690,38 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
       };
     }
 
+    function inGroup(kind: 'bed' | 'annotation', id: string): boolean {
+      return (
+        groupSelection.length > 1 &&
+        groupSelection.some((ref) => ref.kind === kind && ref.id === id)
+      );
+    }
+
     function handleBedMove(bedId: string, x: number, y: number) {
       const alignedToNeighbor = elementSnapActiveRef.current;
       elementSnapActiveRef.current = false;
       setAlignGuides([]);
-      if (alignedToNeighbor) {
-        // The drop position came from edge/center alignment; grid-snapping
-        // it afterwards would break the alignment the user just saw.
-        onMoveBed(bedId, Math.max(0, x), Math.max(0, y));
+      const nextX = alignedToNeighbor ? Math.max(0, x) : Math.max(0, snapValue(x, snap));
+      const nextY = alignedToNeighbor ? Math.max(0, y) : Math.max(0, snapValue(y, snap));
+      if (inGroup('bed', bedId)) {
+        // Dragging a multi-selection member moves the whole group.
+        onMoveGroup({ kind: 'bed', id: bedId }, nextX, nextY);
         return;
       }
-      const snappedX = snapValue(x, snap);
-      const snappedY = snapValue(y, snap);
-      onMoveBed(bedId, Math.max(0, snappedX), Math.max(0, snappedY));
+      onMoveBed(bedId, nextX, nextY);
     }
 
     function handleAnnotationMove(annotationId: string, x: number, y: number) {
       const alignedToNeighbor = elementSnapActiveRef.current;
       elementSnapActiveRef.current = false;
       setAlignGuides([]);
-      if (alignedToNeighbor) {
-        onMoveAnnotation(annotationId, Math.max(0, x), Math.max(0, y));
+      const nextX = alignedToNeighbor ? Math.max(0, x) : Math.max(0, snapValue(x, snap));
+      const nextY = alignedToNeighbor ? Math.max(0, y) : Math.max(0, snapValue(y, snap));
+      if (inGroup('annotation', annotationId)) {
+        onMoveGroup({ kind: 'annotation', id: annotationId }, nextX, nextY);
         return;
       }
-      onMoveAnnotation(
-        annotationId,
-        Math.max(0, snapValue(x, snap)),
-        Math.max(0, snapValue(y, snap))
-      );
+      onMoveAnnotation(annotationId, nextX, nextY);
     }
 
     const draftLinePoints = draftPoints.flatMap((p) => [
@@ -671,7 +756,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
             scaleY={scale}
             x={position.x}
             y={position.y}
-            draggable={!drawing && !calibrating}
+            draggable={!drawing && !calibrating && !marquee}
             onClick={(event) => {
               // While calibrating, every click anywhere on the stage
               // (beds included — they bubble) places a reference point.
@@ -696,6 +781,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
             onDblClick={handleStageDblClick}
             onDblTap={handleStageDblClick}
             onMouseMove={handleStageMouseMove}
+            onMouseUp={handleStageMouseUp}
             onWheel={handleStageWheel}
             onDragEnd={handleStageDragEnd}
           >
@@ -720,6 +806,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                 fill="rgba(0,0,0,0)"
                 onClick={handleEmptyClick}
                 onTap={handleEmptyClick}
+                onMouseDown={handleWorldMouseDown}
               />
             </Layer>
             <Layer>
@@ -732,9 +819,15 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                     isSelected={
                       selected?.kind === 'annotation' && selected.id === item.annotation.id
                     }
+                    isGroupSelected={inGroup('annotation', item.annotation.id)}
                     isEditable={isEditable && !drawing && !calibrating}
-                    onSelect={(id) => {
-                      if (!calibrating) onSelect({ kind: 'annotation', id });
+                    onSelect={(id, shiftKey) => {
+                      if (calibrating) return;
+                      if (shiftKey) {
+                        onToggleSelected({ kind: 'annotation', id });
+                      } else {
+                        onSelect({ kind: 'annotation', id });
+                      }
                     }}
                     onMove={handleAnnotationMove}
                     onResize={onResizeAnnotation}
@@ -751,6 +844,7 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                     bed={item.bed}
                     pxPerInch={PX_PER_INCH}
                     isSelected={selected?.kind === 'bed' && selected.id === item.bed.id}
+                    isGroupSelected={inGroup('bed', item.bed.id)}
                     isEditable={
                       isEditable &&
                       !drawing &&
@@ -758,8 +852,13 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                       item.bed.id !== vertexEditBed?.id
                     }
                     crops={cropsByBedId.get(item.bed.id) ?? []}
-                    onSelect={(id) => {
-                      if (!calibrating) onSelect({ kind: 'bed', id });
+                    onSelect={(id, shiftKey) => {
+                      if (calibrating) return;
+                      if (shiftKey) {
+                        onToggleSelected({ kind: 'bed', id });
+                      } else {
+                        onSelect({ kind: 'bed', id });
+                      }
                     }}
                     onMove={handleBedMove}
                     onResize={onResizeBed}
@@ -809,6 +908,19 @@ export const DesignerCanvas = forwardRef<DesignerCanvasHandle, DesignerCanvasPro
                   y={hoverPoint.y * PX_PER_INCH}
                   radius={4}
                   fill="rgba(58, 126, 90, 0.4)"
+                  listening={false}
+                />
+              )}
+              {marquee && (
+                <Rect
+                  x={marquee.x * PX_PER_INCH}
+                  y={marquee.y * PX_PER_INCH}
+                  width={marquee.width * PX_PER_INCH}
+                  height={marquee.height * PX_PER_INCH}
+                  fill="rgba(58, 126, 90, 0.08)"
+                  stroke="#3a7e5a"
+                  strokeWidth={1}
+                  dash={[6, 4]}
                   listening={false}
                 />
               )}

--- a/apps/grn/src/components/GardenDesigner/alignment.test.ts
+++ b/apps/grn/src/components/GardenDesigner/alignment.test.ts
@@ -79,3 +79,19 @@ describe('snapToNeighbors', () => {
     expect(result).toEqual({ x: 10, y: 10, guides: [] });
   });
 });
+
+import { marqueeIntersects } from './alignment';
+
+describe('marqueeIntersects', () => {
+  const bounds = { left: 100, top: 50, right: 196, bottom: 98 };
+
+  it('hits overlapping rects and respects negative drag direction', () => {
+    expect(marqueeIntersects({ x: 90, y: 40, width: 50, height: 20 }, bounds)).toBe(true);
+    expect(marqueeIntersects({ x: 140, y: 60, width: -50, height: -20 }, bounds)).toBe(true);
+  });
+
+  it('misses disjoint rects and edge-touching rects', () => {
+    expect(marqueeIntersects({ x: 0, y: 0, width: 50, height: 20 }, bounds)).toBe(false);
+    expect(marqueeIntersects({ x: 0, y: 0, width: 100, height: 50 }, bounds)).toBe(false);
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/alignment.ts
+++ b/apps/grn/src/components/GardenDesigner/alignment.ts
@@ -96,3 +96,25 @@ export function snapToNeighbors(args: {
 
   return { x: nextX, y: nextY, guides };
 }
+
+export interface MarqueeRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// Axis-aligned overlap test for marquee selection. Rotated elements use
+// their unrotated bounding box — close enough for grab-everything-here.
+export function marqueeIntersects(rect: MarqueeRect, bounds: ElementBounds): boolean {
+  const left = Math.min(rect.x, rect.x + rect.width);
+  const right = Math.max(rect.x, rect.x + rect.width);
+  const top = Math.min(rect.y, rect.y + rect.height);
+  const bottom = Math.max(rect.y, rect.y + rect.height);
+  return (
+    bounds.left < right &&
+    bounds.right > left &&
+    bounds.top < bottom &&
+    bounds.bottom > top
+  );
+}

--- a/apps/grn/src/hooks/designerHistory.test.ts
+++ b/apps/grn/src/hooks/designerHistory.test.ts
@@ -102,3 +102,35 @@ describe('designerHistory', () => {
     expect(h.entries[1].id).toBe('old');
   });
 });
+
+import { remapEntityId as remapBatch, pushEntry as pushBatch, EMPTY_HISTORY as EMPTY } from './designerHistory';
+
+describe('batch entries', () => {
+  it('remaps ids inside batch entries recursively', () => {
+    let h = pushBatch(EMPTY, {
+      kind: 'batch',
+      at: 0,
+      entries: [
+        {
+          kind: 'bed-update',
+          id: 'old',
+          before: { name: 'Bed', positionX: 0 },
+          after: { name: 'Bed', positionX: 12 },
+          at: 0,
+        },
+        {
+          kind: 'annotation-update',
+          id: 'old',
+          before: { label: 'Tree' },
+          after: { label: 'Oak' },
+          at: 0,
+        },
+      ],
+    });
+    h = remapBatch(h, 'bed', 'old', 'new');
+    const batch = h.entries[0];
+    if (batch.kind !== 'batch') throw new Error('expected batch');
+    expect(batch.entries[0].id).toBe('new');
+    expect(batch.entries[1].id).toBe('old');
+  });
+});

--- a/apps/grn/src/hooks/designerHistory.ts
+++ b/apps/grn/src/hooks/designerHistory.ts
@@ -42,7 +42,9 @@ export type HistoryEntry =
       id: string;
       payload: UpsertGardenAnnotationRequest;
       at: number;
-    };
+    }
+  // Group operations (multi-select move/delete) undo as one step.
+  | { kind: 'batch'; entries: HistoryEntry[]; at: number };
 
 export interface DesignerHistory {
   entries: HistoryEntry[];
@@ -109,6 +111,23 @@ export function steppedForward(history: DesignerHistory): DesignerHistory {
 // Undoing a delete (or redoing a create) recreates the entity server-side
 // under a fresh id. Every other entry referring to the old id must follow,
 // or the rest of the stack would orphan.
+function remapEntry(
+  entry: HistoryEntry,
+  kind: HistoryEntityKind,
+  oldId: string,
+  newId: string
+): HistoryEntry {
+  if (entry.kind === 'batch') {
+    return {
+      ...entry,
+      entries: entry.entries.map((child) => remapEntry(child, kind, oldId, newId)),
+    };
+  }
+  return entry.kind.startsWith(kind) && entry.id === oldId
+    ? { ...entry, id: newId }
+    : entry;
+}
+
 export function remapEntityId(
   history: DesignerHistory,
   kind: HistoryEntityKind,
@@ -117,10 +136,6 @@ export function remapEntityId(
 ): DesignerHistory {
   return {
     ...history,
-    entries: history.entries.map((entry) =>
-      entry.kind.startsWith(kind) && entry.id === oldId
-        ? { ...entry, id: newId }
-        : entry
-    ),
+    entries: history.entries.map((entry) => remapEntry(entry, kind, oldId, newId)),
   };
 }

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -67,6 +67,8 @@ export type SelectedItem =
   | { kind: 'annotation'; id: string }
   | null;
 
+export type SelectedRef = NonNullable<SelectedItem>;
+
 export interface UseGardenDesignerResult {
   canvas: GardenCanvas | undefined;
   beds: GardenBed[];
@@ -77,6 +79,10 @@ export interface UseGardenDesignerResult {
   loadError: Error | null;
   selected: SelectedItem;
   setSelected: (next: SelectedItem) => void;
+  groupSelection: SelectedRef[];
+  toggleSelected: (item: SelectedRef) => void;
+  marqueeSelect: (items: SelectedRef[]) => void;
+  moveSelectedGroup: (anchor: SelectedRef, positionX: number, positionY: number) => void;
   selectedBed: GardenBed | undefined;
   selectedAnnotation: GardenAnnotation | undefined;
   mode: DesignerMode;
@@ -205,6 +211,10 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   // ends the moment focus moves off the bed being reshaped (deselect,
   // another element, a freshly created one). Re-clicking the same bed
   // keeps the handles up.
+  // Marquee / shift-click multi-selection. The primary `selected` keeps
+  // driving the inspector; the group drives group drag, nudge, and delete.
+  const [groupSelection, setGroupSelection] = useState<SelectedRef[]>([]);
+
   const selectItem = useCallback(
     (next: SelectedItem) => {
       setMode((current) => {
@@ -214,9 +224,37 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         return sameBed ? current : 'idle';
       });
       setSelected(next);
+      setGroupSelection(next ? [next] : []);
     },
     [selected]
   );
+
+  // Shift-click membership toggle. Removing the primary promotes the
+  // first remaining member.
+  const toggleSelected = useCallback(
+    (item: SelectedRef) => {
+      setMode((current) => (current === 'editing-vertices' ? 'idle' : current));
+      const exists = groupSelection.some(
+        (ref) => ref.kind === item.kind && ref.id === item.id
+      );
+      const next = exists
+        ? groupSelection.filter((ref) => !(ref.kind === item.kind && ref.id === item.id))
+        : [...groupSelection, item];
+      setGroupSelection(next);
+      if (exists && selected?.kind === item.kind && selected.id === item.id) {
+        setSelected(next[0] ?? null);
+      } else if (!exists && !selected) {
+        setSelected(item);
+      }
+    },
+    [groupSelection, selected]
+  );
+
+  const marqueeSelect = useCallback((items: SelectedRef[]) => {
+    setMode((current) => (current === 'editing-vertices' ? 'idle' : current));
+    setGroupSelection(items);
+    setSelected(items[0] ?? null);
+  }, []);
 
   const canvasQuery = useQuery({
     queryKey: CANVAS_QUERY_KEY,
@@ -848,49 +886,64 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     async (
       entry: HistoryEntry,
       direction: 'undo' | 'redo'
-    ): Promise<{ kind: HistoryEntityKind; oldId: string; newId: string } | null> => {
-      switch (entry.kind) {
+    ): Promise<Array<{ kind: HistoryEntityKind; oldId: string; newId: string }>> => {
+      type Remap = { kind: HistoryEntityKind; oldId: string; newId: string };
+      async function apply(current: HistoryEntry): Promise<Remap[]> {
+      switch (current.kind) {
+        case 'batch': {
+          // Undo replays children newest-first so dependent edits unwind
+          // in order; redo replays them as recorded.
+          const children =
+            direction === 'undo' ? [...current.entries].reverse() : current.entries;
+          const remaps: Remap[] = [];
+          for (const child of children) {
+            remaps.push(...(await apply(child)));
+          }
+          return remaps;
+        }
         case 'bed-update':
           await updateBedMutation.mutateAsync({
-            bedId: entry.id,
-            payload: direction === 'undo' ? entry.before : entry.after,
+            bedId: current.id,
+            payload: direction === 'undo' ? current.before : current.after,
           });
-          return null;
+          return [];
         case 'annotation-update':
           await updateAnnotationMutation.mutateAsync({
-            annotationId: entry.id,
-            payload: direction === 'undo' ? entry.before : entry.after,
+            annotationId: current.id,
+            payload: direction === 'undo' ? current.before : current.after,
           });
-          return null;
+          return [];
         case 'bed-create':
         case 'bed-delete': {
           const recreate =
-            (entry.kind === 'bed-create') === (direction === 'redo');
+            (current.kind === 'bed-create') === (direction === 'redo');
           if (!recreate) {
-            await deleteBedMutation.mutateAsync(entry.id);
-            if (selected?.kind === 'bed' && selected.id === entry.id) {
+            await deleteBedMutation.mutateAsync(current.id);
+            if (selected?.kind === 'bed' && selected.id === current.id) {
               setSelected(null);
             }
-            return null;
+            return [];
           }
-          const created = await createBedMutation.mutateAsync(entry.payload);
-          return { kind: 'bed', oldId: entry.id, newId: created.id };
+          const created = await createBedMutation.mutateAsync(current.payload);
+          return [{ kind: 'bed', oldId: current.id, newId: created.id }];
         }
         case 'annotation-create':
         case 'annotation-delete': {
           const recreate =
-            (entry.kind === 'annotation-create') === (direction === 'redo');
+            (current.kind === 'annotation-create') === (direction === 'redo');
           if (!recreate) {
-            await deleteAnnotationMutation.mutateAsync(entry.id);
-            if (selected?.kind === 'annotation' && selected.id === entry.id) {
+            await deleteAnnotationMutation.mutateAsync(current.id);
+            if (selected?.kind === 'annotation' && selected.id === current.id) {
               setSelected(null);
             }
-            return null;
+            return [];
           }
-          const created = await createAnnotationMutation.mutateAsync(entry.payload);
-          return { kind: 'annotation', oldId: entry.id, newId: created.id };
+          const created = await createAnnotationMutation.mutateAsync(current.payload);
+          return [{ kind: 'annotation', oldId: current.id, newId: created.id }];
         }
       }
+      }
+      return apply(entry);
     },
     [
       createAnnotationMutation,
@@ -911,8 +964,8 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       historyBusyRef.current = true;
       setHistory(direction === 'undo' ? steppedBack : steppedForward);
       try {
-        const remap = await applyEntry(entry, direction);
-        if (remap) {
+        const remaps = await applyEntry(entry, direction);
+        for (const remap of remaps) {
           setHistory((h) => remapEntityId(h, remap.kind, remap.oldId, remap.newId));
           setSelected((prev) =>
             prev && prev.id === remap.oldId ? { ...prev, id: remap.newId } : prev
@@ -985,11 +1038,130 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     selectedBed,
   ]);
 
+  // Dragging any member of a multi-selection moves the whole group by the
+  // same delta and records it as ONE undoable batch. The anchor lands
+  // exactly where it was dropped; everyone else shifts by the delta,
+  // clamped at the canvas origin.
+  const moveSelectedGroup = useCallback(
+    (anchor: SelectedRef, positionX: number, positionY: number) => {
+      if (!isEditable) return;
+      const anchorEntity =
+        anchor.kind === 'bed'
+          ? beds.find((b) => b.id === anchor.id)
+          : annotations.find((a) => a.id === anchor.id);
+      if (!anchorEntity) return;
+      const dx = positionX - (anchorEntity.positionX ?? 12);
+      const dy = positionY - (anchorEntity.positionY ?? 12);
+      if (dx === 0 && dy === 0) return;
+
+      const entries: HistoryEntry[] = [];
+      for (const ref of groupSelection) {
+        if (ref.kind === 'bed') {
+          const bed = beds.find((b) => b.id === ref.id);
+          if (!bed) continue;
+          const before = bedToUpsertPayload(bed);
+          const after = {
+            ...before,
+            positionX: Math.max(0, (bed.positionX ?? 12) + dx),
+            positionY: Math.max(0, (bed.positionY ?? 12) + dy),
+          };
+          entries.push({ kind: 'bed-update', id: bed.id, before, after, at: Date.now() });
+          updateBedMutation.mutate({ bedId: bed.id, payload: after });
+        } else {
+          const annotation = annotations.find((a) => a.id === ref.id);
+          if (!annotation) continue;
+          const before = annotationToUpsertPayload(annotation);
+          const after = {
+            ...before,
+            positionX: Math.max(0, (annotation.positionX ?? 12) + dx),
+            positionY: Math.max(0, (annotation.positionY ?? 12) + dy),
+          };
+          entries.push({
+            kind: 'annotation-update',
+            id: annotation.id,
+            before,
+            after,
+            at: Date.now(),
+          });
+          updateAnnotationMutation.mutate({ annotationId: annotation.id, payload: after });
+        }
+      }
+      if (entries.length > 0) {
+        record({ kind: 'batch', entries, at: Date.now() });
+      }
+    },
+    [
+      annotations,
+      beds,
+      groupSelection,
+      isEditable,
+      record,
+      updateAnnotationMutation,
+      updateBedMutation,
+    ]
+  );
+
+  // Multi-selection delete: snapshots first, then deletes, recorded as a
+  // single undoable batch.
+  const deleteSelectedGroup = useCallback(async () => {
+    if (!isEditable || groupSelection.length === 0) return;
+    const entries: HistoryEntry[] = [];
+    for (const ref of groupSelection) {
+      if (ref.kind === 'bed') {
+        const bed = beds.find((b) => b.id === ref.id);
+        if (!bed) continue;
+        await deleteBedMutation.mutateAsync(bed.id);
+        entries.push({
+          kind: 'bed-delete',
+          id: bed.id,
+          payload: bedToUpsertPayload(bed),
+          at: Date.now(),
+        });
+      } else {
+        const annotation = annotations.find((a) => a.id === ref.id);
+        if (!annotation) continue;
+        await deleteAnnotationMutation.mutateAsync(annotation.id);
+        entries.push({
+          kind: 'annotation-delete',
+          id: annotation.id,
+          payload: annotationToUpsertPayload(annotation),
+          at: Date.now(),
+        });
+      }
+    }
+    if (entries.length > 0) {
+      record({ kind: 'batch', entries, at: Date.now() });
+    }
+    setSelected(null);
+    setGroupSelection([]);
+  }, [
+    annotations,
+    beds,
+    deleteAnnotationMutation,
+    deleteBedMutation,
+    groupSelection,
+    isEditable,
+    record,
+  ]);
+
   // Arrow-key nudging for the selected element. Rapid presses coalesce
   // into a single undo step (see designerHistory).
   const nudgeSelected = useCallback(
     (dx: number, dy: number) => {
       if (!isEditable) return;
+      if (groupSelection.length > 1 && selected) {
+        const anchor =
+          selected.kind === 'bed'
+            ? beds.find((b) => b.id === selected.id)
+            : annotations.find((a) => a.id === selected.id);
+        if (!anchor) return;
+        moveSelectedGroup(
+          selected,
+          Math.max(0, (anchor.positionX ?? 12) + dx),
+          Math.max(0, (anchor.positionY ?? 12) + dy)
+        );
+        return;
+      }
       if (selected?.kind === 'bed' && selectedBed) {
         const payload = bedToUpsertPayload({
           ...selectedBed,
@@ -1007,9 +1179,13 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       }
     },
     [
+      annotations,
+      beds,
       commitAnnotationUpdate,
       commitBedUpdate,
+      groupSelection.length,
       isEditable,
+      moveSelectedGroup,
       selected,
       selectedAnnotation,
       selectedBed,
@@ -1150,6 +1326,17 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         // risk it nuking the whole bed.
         if (mode === 'editing-vertices') return;
         if (!isEditable || !selected) return;
+        if (groupSelection.length > 1) {
+          event.preventDefault();
+          if (
+            window.confirm(
+              `Delete ${groupSelection.length} selected elements? This can't be undone.`
+            )
+          ) {
+            void deleteSelectedGroup();
+          }
+          return;
+        }
         if (selected.kind === 'bed' && selectedBed) {
           event.preventDefault();
           const label = selectedBed.name.trim() || 'this bed';
@@ -1176,6 +1363,8 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     isEditable,
     deleteBed,
     deleteAnnotation,
+    deleteSelectedGroup,
+    groupSelection.length,
     undo,
     redo,
     nudgeSelected,
@@ -1231,6 +1420,10 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       null,
     selected,
     setSelected: selectItem,
+    groupSelection,
+    toggleSelected,
+    marqueeSelect,
+    moveSelectedGroup,
     selectedBed,
     selectedAnnotation,
     mode,

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -233,6 +233,10 @@ export function GardenDesignerPage() {
               }}
               onCancelPolygon={() => designer.setMode('idle')}
               onUpdateBedPoints={designer.updateBedPoints}
+              groupSelection={designer.groupSelection}
+              onToggleSelected={designer.toggleSelected}
+              onMarqueeSelect={designer.marqueeSelect}
+              onMoveGroup={designer.moveSelectedGroup}
               onCalibrationCaptured={setCalibrationDrawnLength}
               onCancelCalibration={cancelCalibration}
             />


### PR DESCRIPTION
The final deferred feature from the designer program: marquee multi-select.

## How it works
- **Shift+drag** on empty canvas sweeps a dashed marquee; every intersecting bed and annotation joins the selection. **Shift-click** toggles individual membership. The primary selection keeps driving the inspector; group members get the accent stroke (Transformer stays on the primary only).
- **Group move**: drag any member and the whole group shifts by the same delta — the anchor lands exactly where you dropped it (with alignment/grid snapping), everyone else follows, clamped at the canvas origin. Recorded as **one undo step**.
- **Group nudge**: arrow keys (Shift = 12") move the whole group, also one undo step.
- **Group delete**: Delete asks once ("Delete N selected elements?") and removes them as a single undoable batch.

## Under the hood
- `designerHistory` gains a `batch` entry kind: undo replays children newest-first, redo as recorded, and entity-id remapping recurses into batches — so undoing a group delete recreates everything and the rest of the stack follows the new ids.
- `marqueeIntersects` is pure and unit-tested (negative drag directions, edge-touching); batch remapping unit-tested.
- Marquee suspends stage panning while active and swallows the click that follows mouseup so it can't insta-deselect its own result.

## Testing
469 tests pass (3 new); lint 0 errors; typecheck clean; build + perf budget pass (1,090,148 / 1,228,800).

Targets main directly — no CI-on-open quirk this time since pushes preceded the PR; if checks don't appear, a re-run from the Actions tab or any push kicks them.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b)_