### PR TITLE
GRN: fix 500 on the public shared-garden endpoint (staging Postman catch)

### DIFF
--- a/services/grn-api/src/api/handlers/garden_share.rs
+++ b/services/grn-api/src/api/handlers/garden_share.rs
@@ -212,7 +212,7 @@ pub async fn get_shared_garden(
 
     let canvas_row = client
         .query_opt(
-            "select width_inches, height_inches, north_offset_deg
+            "select width_inches, height_inches, north_offset_deg::int as north_offset_deg
              from garden_canvases where user_id = $1",
             &[&user_id],
         )
@@ -260,12 +260,12 @@ pub async fn get_shared_garden(
     // name only — no surplus, pricing, or contact data.
     let crop_rows = client
         .query(
-            "select bed_id, crop_name, plant_count
-             from grower_crop_library
-             where user_id = $1
-               and bed_id is not null
-               and deleted_at is null
-               and visibility in ('local', 'public')",
+            "select g.bed_id, g.crop_name, g.plant_count
+             from grower_crop_library g
+             join garden_beds b on b.id = g.bed_id and b.archived_at is null
+             where g.user_id = $1
+               and g.bed_id is not null
+               and g.visibility in ('local', 'public')",
             &[&user_id],
         )
         .await


### PR DESCRIPTION
Fixes the 500 on `GET /shared-gardens/{token}` that the Garden Sharing Postman contract run caught against staging (surfaced on #353's validation, but the bug shipped with the share-links feature — it's a main bug, not a #353 bug).

Two staging-only crashes the local suite couldn't catch (no live DB):
1. The crops query filtered on `grower_crop_library.deleted_at`, which **doesn't exist** — crops are hard-deleted. Now joins active beds instead, matching the crop list handler's convention (also correctly drops crops whose bed was archived).
2. `garden_canvases.north_offset_deg` is `smallint`; tokio_postgres panics decoding it as i32. Cast to `::int` in SQL.

`cargo fmt --check`, `clippy --all-targets --all-features -- -D warnings`, and all tests pass. The existing Postman request will verify the fix on the next staging validation run.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b)_