### PR TITLE
GRN: whimsical ambient critters on the garden masterplan

### DIFF
--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -18,6 +18,20 @@ beforeAll(() => {
     disconnect() {}
   }
   vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  // jsdom lacks matchMedia; IsoCritters queries prefers-reduced-motion.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    }))
+  );
 });
 
 const canvas: GardenCanvas = {
@@ -530,6 +544,26 @@ describe('GardenMasterplan', () => {
       expect(screen.getByTestId('masterplan-detail-panel')).not.toHaveTextContent(
         /mostly in shade/i
       );
+    });
+  });
+
+  describe('ambient critters', () => {
+    it('renders an aria-hidden decorative critter layer for a lively garden', () => {
+      const { container } = renderMasterplan({
+        annotations: [
+          makeAnnotation({ id: 'coop', label: 'Chicken coop', icon: '🐔', shape: 'rect' }),
+        ],
+      });
+      const layer = container.querySelector('.mp-critters');
+      expect(layer).toBeInTheDocument();
+      expect(layer).toHaveAttribute('aria-hidden', 'true');
+      // Coop + planted bed → one flyer and the chicken, never more.
+      expect(layer!.querySelectorAll('.mp-critter')).toHaveLength(2);
+    });
+
+    it('renders no critters for an empty garden', () => {
+      const { container } = renderMasterplan({ beds: [], annotations: [], crops: [] });
+      expect(container.querySelector('.mp-critters')).not.toBeInTheDocument();
     });
   });
 

--- a/apps/grn/src/components/GardenMasterplan/IsoCritters.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoCritters.tsx
@@ -1,0 +1,258 @@
+import { memo, useEffect, useState } from 'react';
+import type { Critter } from './critters';
+import { projectPoint, smoothClosedPath } from './iso';
+import { SCENE, mute, shade, tint } from './palette';
+
+// Two-tone palette per critter, derived from the scene's muted ramps so
+// the residents sit in the same marker-rendering world as the planting.
+const RABBIT_BODY = tint(SCENE.marker, 0.3);
+const RABBIT_EAR = shade(SCENE.marker, 0.28);
+const CHICKEN_BODY = tint(SCENE.sand, 0.22);
+const CHICKEN_COMB = mute('#c2674f', 0.2);
+const BEE_BODY = mute('#d8a83c', 0.2);
+const BEE_DARK = shade('#d8a83c', 0.55);
+const BEE_WING = tint(SCENE.glass, 0.45);
+const WING_FORE = mute('#c2674f', 0.3);
+const WING_HIND = shade(mute('#c2674f', 0.3), 0.28);
+
+// Hand-authored flat silhouettes, drawn around the origin with feet (or
+// body center, for flyers) at 0,0 so animateMotion can carry the group.
+
+function RabbitSprite() {
+  return (
+    <g>
+      <path
+        d="M-2.5 -10.5 C-4.5 -15 -4 -19.5 -2 -20 C-0.5 -20.3 0.4 -15.5 0.2 -11 Z M2.2 -10.8 C2 -15.5 3.4 -19.2 5 -18.6 C6.4 -18 5 -13 3.6 -10 Z"
+        fill={RABBIT_EAR}
+      />
+      <path
+        d="M-8.5 0 C-10 -4.5 -8 -8.5 -4.5 -9.5 C-3.5 -11.5 -0.5 -12 1.5 -11 C4 -11.8 6.5 -10.5 7.5 -8 C9.5 -6.5 10 -3 8.5 0 Z"
+        fill={RABBIT_BODY}
+      />
+      <circle cx={-8.3} cy={-3.2} r={1.7} fill={RABBIT_EAR} />
+    </g>
+  );
+}
+
+function ChickenSprite() {
+  return (
+    <g>
+      <path
+        d="M-1 0 L-1 2.4 M2.2 0 L2.2 2.4"
+        stroke={CHICKEN_COMB}
+        strokeWidth={0.9}
+        strokeLinecap="round"
+      />
+      <path
+        d="M-9 -12.5 C-7.5 -9 -6 -7.5 -4 -7 C-3.5 -10.5 -1 -12.5 2 -12.5 C4.5 -12.5 6.5 -10.8 6.8 -8.5 C8 -8 8.6 -7 8.8 -5.8 L6.5 -5.2 C7 -3 6 -1 3.8 -0.4 C0.5 0.6 -4 0.3 -6.3 -1.8 C-8.6 -3.9 -10.2 -8.7 -9 -12.5 Z"
+        fill={CHICKEN_BODY}
+      />
+      <path
+        d="M1.2 -12.4 C1.6 -14.4 2.5 -15 3.1 -14.2 C3.5 -15.2 4.4 -15.3 4.7 -14.2 C5.2 -14.9 5.9 -14.6 5.9 -13.4 L5.4 -12 C4.1 -12.7 2.6 -12.6 1.2 -12.4 Z"
+        fill={CHICKEN_COMB}
+      />
+      <circle cx={6.4} cy={-6.6} r={0.9} fill={CHICKEN_COMB} />
+    </g>
+  );
+}
+
+function BeeSprite({ animate }: { animate: boolean }) {
+  return (
+    <g>
+      <ellipse cx={0} cy={0} rx={4.6} ry={3.1} fill={BEE_BODY} />
+      <rect x={-2.7} y={-3} width={1.5} height={6} rx={0.7} fill={BEE_DARK} />
+      <rect x={-0.3} y={-3} width={1.5} height={6} rx={0.7} fill={BEE_DARK} />
+      <circle cx={4.4} cy={-0.4} r={2} fill={BEE_DARK} />
+      <ellipse
+        cx={-1}
+        cy={-4.6}
+        rx={2.7}
+        ry={1.7}
+        fill={BEE_WING}
+        transform="rotate(-24 -1 -4.6)"
+      >
+        {animate && (
+          <animate
+            attributeName="opacity"
+            values="1;0.35;1"
+            dur="0.3s"
+            repeatCount="indefinite"
+          />
+        )}
+      </ellipse>
+    </g>
+  );
+}
+
+function ButterflyWings({ animate }: { animate: boolean }) {
+  return (
+    <g>
+      <path
+        d="M0 -2 C-6 -9.5 -11.5 -8.5 -10.5 -3.5 C-9.8 -0.4 -4.5 0.3 0 -1 Z"
+        fill={WING_FORE}
+      />
+      <path
+        d="M0 -0.8 C-5 -0.2 -8.2 3 -6.4 5.4 C-4.7 7.6 -1 4.6 0 0.5 Z"
+        fill={WING_HIND}
+      />
+      {animate && (
+        <animateTransform
+          attributeName="transform"
+          type="scale"
+          values="1 1;0.45 1;1 1"
+          dur="0.9s"
+          repeatCount="indefinite"
+          additive="sum"
+        />
+      )}
+    </g>
+  );
+}
+
+function ButterflySprite({ animate }: { animate: boolean }) {
+  return (
+    <g>
+      <ButterflyWings animate={animate} />
+      <g transform="scale(-1 1)">
+        <ButterflyWings animate={animate} />
+      </g>
+      <ellipse cx={0} cy={1} rx={0.9} ry={3.6} fill={shade(WING_FORE, 0.4)} />
+    </g>
+  );
+}
+
+function CritterBody({ critter, animate }: { critter: Critter; animate: boolean }) {
+  switch (critter.kind) {
+    case 'rabbit':
+      return <RabbitSprite />;
+    case 'chicken':
+      return <ChickenSprite />;
+    case 'bee':
+      return <BeeSprite animate={animate} />;
+    case 'butterfly':
+      return <ButterflySprite animate={animate} />;
+  }
+}
+
+interface CritterFigureProps {
+  critter: Critter;
+  index: number;
+  reducedMotion: boolean;
+}
+
+function CritterFigure({ critter, index, reducedMotion }: CritterFigureProps) {
+  const flyer = critter.heightInches > 0;
+  const shadow = flyer
+    ? { dx: 1.5, dy: 1, rx: 4, ry: 1.5, opacity: 0.55 }
+    : { dx: 0, dy: 0.8, rx: 7, ry: 2.6, opacity: 1 };
+
+  if (reducedMotion) {
+    // Static residents: parked at the first waypoint, no animate elements.
+    const ground = projectPoint(critter.waypoints[0], 0);
+    const body = projectPoint(critter.waypoints[0], critter.heightInches);
+    return (
+      <g className="mp-critter">
+        <ellipse
+          cx={ground.x + shadow.dx}
+          cy={ground.y + shadow.dy}
+          rx={shadow.rx}
+          ry={shadow.ry}
+          fill={SCENE.elementShadowSoft}
+          opacity={shadow.opacity}
+        />
+        <g transform={`translate(${body.x} ${body.y})`}>
+          <CritterBody critter={critter} animate={false} />
+        </g>
+      </g>
+    );
+  }
+
+  // Shadow and body ride separate motion paths projected from the same
+  // waypoints (ground vs travel height), so a flyer's shadow tracks the
+  // lawn directly beneath it. Negative begins stagger the pair of
+  // critters so they never feel choreographed.
+  const groundPath = smoothClosedPath(critter.waypoints.map((p) => projectPoint(p, 0)));
+  const travelPath = flyer
+    ? smoothClosedPath(critter.waypoints.map((p) => projectPoint(p, critter.heightInches)))
+    : groundPath;
+  const dur = `${critter.durationSeconds}s`;
+  const begin = `${-index * 13}s`;
+
+  return (
+    <g className="mp-critter">
+      <g>
+        <ellipse
+          cx={shadow.dx}
+          cy={shadow.dy}
+          rx={shadow.rx}
+          ry={shadow.ry}
+          fill={SCENE.elementShadowSoft}
+          opacity={shadow.opacity}
+        />
+        <animateMotion dur={dur} begin={begin} repeatCount="indefinite" path={groundPath} />
+      </g>
+      <g>
+        {flyer ? (
+          <g>
+            <CritterBody critter={critter} animate />
+            <animateTransform
+              attributeName="transform"
+              type="translate"
+              values="0 0;0 -2.4;0 0"
+              dur={critter.kind === 'bee' ? '1.7s' : '2.9s'}
+              repeatCount="indefinite"
+              additive="sum"
+            />
+          </g>
+        ) : (
+          <CritterBody critter={critter} animate />
+        )}
+        <animateMotion dur={dur} begin={begin} repeatCount="indefinite" path={travelPath} />
+      </g>
+    </g>
+  );
+}
+
+interface IsoCrittersProps {
+  critters: Critter[];
+}
+
+/**
+ * Decorative ambient critters drifting over the masterplan. Renders
+ * above the elements layer (small flyers reading over the garden, like
+ * birds), never intercepts pointer events, and is hidden from assistive
+ * tech. Honors prefers-reduced-motion by parking each critter at its
+ * first waypoint with no SMIL at all.
+ */
+export const IsoCritters = memo(function IsoCritters({ critters }: IsoCrittersProps) {
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  if (critters.length === 0) return null;
+
+  return (
+    <g className="mp-critters" aria-hidden="true" pointerEvents="none">
+      {critters.map((critter, index) => (
+        <CritterFigure
+          key={critter.kind}
+          critter={critter}
+          index={index}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+    </g>
+  );
+});

--- a/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
@@ -23,8 +23,10 @@ import {
   smoothClosedPath,
   type WorldPoint,
 } from './iso';
+import { chooseCritters } from './critters';
 import { IsoAnnotation } from './IsoAnnotation';
 import { IsoBed } from './IsoBed';
+import { IsoCritters } from './IsoCritters';
 import { KIND_LABELS, SCENE, annotationKind } from './palette';
 import type { SeasonMonth } from './season';
 import { collectShadowCasters, shadowPolygonsFor, type SunTime } from './shadows';
@@ -221,6 +223,21 @@ export const IsoScene = memo(function IsoScene({
     return list;
   }, [annotations, beds, cropsByBedId, onSelect, seasonMonth, selected, shouldIgnoreClick]);
 
+  // Ambient critters: deterministic per garden (seeded by the canvas id),
+  // purely decorative, free for every IsoScene consumer including the
+  // shared public garden page.
+  const critters = useMemo(
+    () =>
+      chooseCritters({
+        canvas: { widthInches: w, heightInches: h },
+        beds,
+        annotations,
+        cropsByBedId,
+        seed: canvas.id,
+      }),
+    [annotations, beds, canvas.id, cropsByBedId, h, w]
+  );
+
   // Compass + scale bar live in screen space at the plate corners.
   const plate = boundsOf(
     projectFootprint([
@@ -280,6 +297,7 @@ export const IsoScene = memo(function IsoScene({
         </g>
       )}
       <g className="mp-elements">{items.map((item) => item.node)}</g>
+      <IsoCritters critters={critters} />
       <g
         className="mp-compass"
         aria-hidden="true"

--- a/apps/grn/src/components/GardenMasterplan/critters.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/critters.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GrowerCropItem,
+} from '../../types/listing';
+import { annotationFootprint, bedFootprint } from './footprints';
+import { worldCentroid } from './iso';
+import { chooseCritters, type Critter } from './critters';
+
+const canvas = { widthInches: 360, heightInches: 240 };
+
+function makeBed(overrides: Partial<GardenBed>): GardenBed {
+  return {
+    id: 'bed-1',
+    userId: 'u1',
+    name: 'Herb spiral',
+    description: null,
+    sunExposure: 'full_sun',
+    soilType: 'loam',
+    lengthInches: 96,
+    widthInches: 48,
+    locationNotes: null,
+    sortOrder: 0,
+    bedType: 'raised',
+    shape: 'rect',
+    positionX: 120,
+    positionY: 96,
+    rotationDeg: 0,
+    points: null,
+    color: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeAnnotation(overrides: Partial<GardenAnnotation>): GardenAnnotation {
+  return {
+    id: 'ann-1',
+    userId: 'u1',
+    label: 'Old oak',
+    icon: '🌳',
+    shape: 'circle',
+    positionX: 200,
+    positionY: 60,
+    lengthInches: 60,
+    widthInches: 60,
+    rotationDeg: 0,
+    points: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeCrop(bedId: string, id = `crop-${bedId}`): GrowerCropItem {
+  return {
+    id,
+    userId: 'u1',
+    canonicalId: null,
+    cropName: 'Tomato',
+    varietyId: null,
+    status: 'active',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId,
+    bedName: 'Herb spiral',
+    plantingDate: null,
+    expectedHarvestDate: null,
+    plantCount: 4,
+    spacingInches: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function cropsFor(...bedIds: string[]): Map<string, GrowerCropItem[]> {
+  return new Map(bedIds.map((id) => [id, [makeCrop(id)]]));
+}
+
+const coop = makeAnnotation({ id: 'coop-1', label: 'Chicken coop', icon: '🐔', shape: 'rect' });
+
+function kinds(critters: Critter[]): string[] {
+  return critters.map((c) => c.kind);
+}
+
+describe('chooseCritters', () => {
+  it('returns no critters for an empty garden', () => {
+    expect(
+      chooseCritters({ canvas, beds: [], annotations: [], cropsByBedId: new Map(), seed: 's' })
+    ).toEqual([]);
+  });
+
+  it('never exceeds two critters and never repeats a kind', () => {
+    for (const seed of ['a', 'b', 'c', 'garden-42']) {
+      const critters = chooseCritters({
+        canvas,
+        beds: [makeBed({}), makeBed({ id: 'bed-2', positionX: 240 })],
+        annotations: [coop],
+        cropsByBedId: cropsFor('bed-1', 'bed-2'),
+        seed,
+      });
+      expect(critters.length).toBeLessThanOrEqual(2);
+      expect(new Set(kinds(critters)).size).toBe(critters.length);
+    }
+  });
+
+  it('is deterministic for the same garden and seed', () => {
+    const args = {
+      canvas,
+      beds: [makeBed({})],
+      annotations: [coop],
+      cropsByBedId: cropsFor('bed-1'),
+      seed: 'stable',
+    };
+    expect(chooseCritters(args)).toEqual(chooseCritters(args));
+  });
+
+  it('pairs one flyer with one ground critter when both are possible', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [coop],
+      cropsByBedId: cropsFor('bed-1'),
+      seed: 's',
+    });
+    expect(critters).toHaveLength(2);
+    expect(kinds(critters).filter((k) => k === 'bee' || k === 'butterfly')).toHaveLength(1);
+    expect(kinds(critters)).toContain('chicken');
+  });
+
+  it('only fields a chicken when the garden has a coop', () => {
+    const without = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [makeAnnotation({})],
+      cropsByBedId: cropsFor('bed-1'),
+      seed: 's',
+    });
+    expect(kinds(without)).not.toContain('chicken');
+    expect(kinds(without)).toContain('rabbit');
+  });
+
+  it('pecks its chicken loop in front of (south of) the coop', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [],
+      annotations: [coop],
+      cropsByBedId: new Map(),
+      seed: 's',
+    });
+    const chicken = critters.find((c) => c.kind === 'chicken');
+    expect(chicken).toBeDefined();
+    expect(chicken!.heightInches).toBe(0);
+    const footprint = annotationFootprint(coop);
+    const front = Math.max(...footprint.map((p) => p.y));
+    const center = worldCentroid(footprint);
+    for (const p of chicken!.waypoints) {
+      expect(p.y).toBeGreaterThan(front);
+      expect(Math.abs(p.x - center.x)).toBeLessThan(80);
+    }
+  });
+
+  it('only fields pollinators when at least one bed is planted', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [],
+      cropsByBedId: new Map(),
+      seed: 's',
+    });
+    expect(kinds(critters)).toEqual(['rabbit']);
+  });
+
+  it('routes the flyer through planted bed centroids above the bed surface', () => {
+    const beds = [
+      makeBed({ id: 'bed-1', positionX: 24, positionY: 24 }),
+      makeBed({ id: 'bed-2', positionX: 220, positionY: 60 }),
+      makeBed({ id: 'bed-3', positionX: 120, positionY: 160 }),
+    ];
+    const critters = chooseCritters({
+      canvas,
+      beds,
+      annotations: [],
+      cropsByBedId: cropsFor('bed-1', 'bed-2', 'bed-3'),
+      seed: 's',
+    });
+    const flyer = critters.find((c) => c.kind === 'bee' || c.kind === 'butterfly');
+    expect(flyer).toBeDefined();
+    // Raised beds are 11" tall; cruise altitude is surface +6–10".
+    expect(flyer!.heightInches).toBeGreaterThanOrEqual(17);
+    expect(flyer!.heightInches).toBeLessThanOrEqual(21);
+    const centroids = beds.map((bed) => worldCentroid(bedFootprint(bed)));
+    const stopCount = flyer!.waypoints.filter((p) =>
+      centroids.some((c) => Math.abs(c.x - p.x) < 0.01 && Math.abs(c.y - p.y) < 0.01)
+    ).length;
+    expect(stopCount).toBeGreaterThanOrEqual(2);
+    expect(stopCount).toBeLessThanOrEqual(4);
+  });
+
+  it('keeps the rabbit on the lawn margins, clear of bed footprints', () => {
+    const bed = makeBed({ positionX: 140, positionY: 90 });
+    const critters = chooseCritters({
+      canvas,
+      beds: [bed],
+      annotations: [],
+      cropsByBedId: new Map(),
+      seed: 's',
+    });
+    const rabbit = critters.find((c) => c.kind === 'rabbit');
+    expect(rabbit).toBeDefined();
+    expect(rabbit!.heightInches).toBe(0);
+    expect(rabbit!.waypoints.length).toBeGreaterThanOrEqual(4);
+    const footprint = bedFootprint(bed);
+    const minX = Math.min(...footprint.map((p) => p.x)) - 12;
+    const maxX = Math.max(...footprint.map((p) => p.x)) + 12;
+    const minY = Math.min(...footprint.map((p) => p.y)) - 12;
+    const maxY = Math.max(...footprint.map((p) => p.y)) + 12;
+    for (const p of rabbit!.waypoints) {
+      const insideBed = p.x >= minX && p.x <= maxX && p.y >= minY && p.y <= maxY;
+      expect(insideBed).toBe(false);
+      expect(p.x).toBeGreaterThan(0);
+      expect(p.x).toBeLessThan(canvas.widthInches);
+      expect(p.y).toBeGreaterThan(0);
+      expect(p.y).toBeLessThan(canvas.heightInches);
+    }
+  });
+
+  it('keeps every duration in the ambient 25–60s band', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [coop],
+      cropsByBedId: cropsFor('bed-1'),
+      seed: 's',
+    });
+    for (const critter of critters) {
+      expect(critter.durationSeconds).toBeGreaterThanOrEqual(25);
+      expect(critter.durationSeconds).toBeLessThanOrEqual(60);
+    }
+  });
+});

--- a/apps/grn/src/components/GardenMasterplan/critters.ts
+++ b/apps/grn/src/components/GardenMasterplan/critters.ts
@@ -1,0 +1,252 @@
+// Ambient critter selection + routing for the masterplan.
+//
+// Purely decorative: the scene shows at most two critters, chosen
+// deterministically from what the garden actually contains (a chicken
+// needs a coop, pollinators need planted beds, a rabbit just needs a
+// garden to lope around). Routes are world-space waypoint loops; the
+// renderer projects and smooths them. Everything here is seeded through
+// hashSeed so a given garden always hosts the same residents — this
+// module stays component-free and unit-testable.
+
+import type {
+  GardenAnnotation,
+  GardenBed,
+  GardenCanvas,
+  GrowerCropItem,
+} from '../../types/listing';
+import { annotationFootprint, bedFootprint } from './footprints';
+import { hashSeed, worldCentroid, type WorldPoint } from './iso';
+import { annotationKind } from './palette';
+import { IN_GROUND_BED_HEIGHT, MOUND_HEIGHT, RAISED_BED_HEIGHT } from './shadows';
+
+export type CritterKind = 'rabbit' | 'bee' | 'butterfly' | 'chicken';
+
+export interface Critter {
+  kind: CritterKind;
+  /** Looping route in world inches; the renderer closes the loop. */
+  waypoints: WorldPoint[];
+  /** Travel height above the ground plane (0 for ground critters). */
+  heightInches: number;
+  durationSeconds: number;
+}
+
+export interface ChooseCrittersArgs {
+  canvas: Pick<GardenCanvas, 'widthInches' | 'heightInches'>;
+  beds: GardenBed[];
+  annotations: GardenAnnotation[];
+  cropsByBedId: Map<string, GrowerCropItem[]>;
+  seed: string;
+}
+
+interface WorldBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function worldBoundsOf(points: WorldPoint[]): WorldBounds {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function seededDuration(seed: string, min: number, max: number): number {
+  return Math.round((min + hashSeed(seed) * (max - min)) * 10) / 10;
+}
+
+// Small pecking loop just south of the coop — "in front" in this
+// isometric view means toward the camera (south-east).
+function chickenRoute(coop: GardenAnnotation, seed: string): WorldPoint[] {
+  const footprint = annotationFootprint(coop);
+  const c = worldCentroid(footprint);
+  const b = worldBoundsOf(footprint);
+  const cx = c.x + (hashSeed(`${seed}:cx`) - 0.5) * 14;
+  const cy = b.maxY + 14 + hashSeed(`${seed}:cy`) * 10;
+  const rx = 16 + hashSeed(`${seed}:rx`) * 8;
+  const ry = 9 + hashSeed(`${seed}:ry`) * 5;
+  const points: WorldPoint[] = [];
+  const n = 6;
+  for (let i = 0; i < n; i += 1) {
+    const angle = (i / n) * Math.PI * 2;
+    const wobble = 1 + (hashSeed(`${seed}:w${i}`) - 0.5) * 0.4;
+    points.push({
+      x: cx + Math.cos(angle) * rx * wobble,
+      y: cy + Math.sin(angle) * ry * wobble,
+    });
+  }
+  return points;
+}
+
+function bedSurfaceHeight(bed: GardenBed): number {
+  switch (bed.bedType) {
+    case 'raised':
+      return RAISED_BED_HEIGHT;
+    case 'mound':
+      return MOUND_HEIGHT;
+    default:
+      return IN_GROUND_BED_HEIGHT;
+  }
+}
+
+// Pollinator circuit: 2–4 planted bed centroids with a meandering
+// midpoint between each pair so the flight reads as a wander, not a bus
+// route. Cruise altitude sits a hand above the tallest visited surface.
+function flyerRoute(
+  planted: GardenBed[],
+  seed: string
+): { waypoints: WorldPoint[]; heightInches: number } {
+  const count = Math.max(
+    1,
+    Math.min(planted.length, 2 + Math.floor(hashSeed(`${seed}:n`) * 3))
+  );
+  const start = Math.floor(hashSeed(`${seed}:s`) * planted.length) % planted.length;
+  const visited: GardenBed[] = [];
+  for (let i = 0; i < count; i += 1) {
+    visited.push(planted[(start + i) % planted.length]);
+  }
+  const stops = visited.map((bed) => worldCentroid(bedFootprint(bed)));
+  const heightInches =
+    Math.max(...visited.map(bedSurfaceHeight)) + 6 + hashSeed(`${seed}:h`) * 4;
+
+  if (stops.length === 1) {
+    // Lone planted bed: hover a lazy hexagon around its centroid.
+    const c = stops[0];
+    const r = 18 + hashSeed(`${seed}:r`) * 10;
+    const ring: WorldPoint[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      const angle = (i / 6) * Math.PI * 2;
+      ring.push({ x: c.x + Math.cos(angle) * r, y: c.y + Math.sin(angle) * r * 0.7 });
+    }
+    return { waypoints: ring, heightInches };
+  }
+
+  const waypoints: WorldPoint[] = [];
+  for (let i = 0; i < stops.length; i += 1) {
+    const a = stops[i];
+    const b = stops[(i + 1) % stops.length];
+    waypoints.push(a);
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const offset = (hashSeed(`${seed}:m${i}`) - 0.5) * Math.min(60, len * 0.6);
+    waypoints.push({
+      x: (a.x + b.x) / 2 + (-dy / len) * offset,
+      y: (a.y + b.y) / 2 + (dx / len) * offset,
+    });
+  }
+  return { waypoints, heightInches };
+}
+
+// How far rabbit hop points keep away from bed edges (inches).
+const RABBIT_CLEARANCE = 24;
+
+// Hop circuit around the open lawn margin, skipping stretches that run
+// through (or hug) a bed footprint.
+function rabbitRoute(
+  canvas: Pick<GardenCanvas, 'widthInches' | 'heightInches'>,
+  beds: GardenBed[],
+  seed: string
+): WorldPoint[] {
+  const w = canvas.widthInches;
+  const h = canvas.heightInches;
+  const inset = Math.max(10, Math.min(w, h) * 0.08);
+  const step = Math.max(30, Math.min(w, h) / 6);
+  const jitter = (i: number) => (hashSeed(`${seed}:j${i}`) - 0.5) * inset * 0.8;
+
+  const ring: WorldPoint[] = [];
+  for (let x = inset; x < w - inset; x += step) {
+    ring.push({ x, y: inset + jitter(ring.length) });
+  }
+  for (let y = inset; y < h - inset; y += step) {
+    ring.push({ x: w - inset + jitter(ring.length), y });
+  }
+  for (let x = w - inset; x > inset; x -= step) {
+    ring.push({ x, y: h - inset + jitter(ring.length) });
+  }
+  for (let y = h - inset; y > inset; y -= step) {
+    ring.push({ x: inset + jitter(ring.length), y });
+  }
+
+  const keepOut = beds.map((bed) => {
+    const b = worldBoundsOf(bedFootprint(bed));
+    return {
+      minX: b.minX - RABBIT_CLEARANCE,
+      minY: b.minY - RABBIT_CLEARANCE,
+      maxX: b.maxX + RABBIT_CLEARANCE,
+      maxY: b.maxY + RABBIT_CLEARANCE,
+    };
+  });
+  const clear = ring.filter(
+    (p) =>
+      !keepOut.some(
+        (b) => p.x >= b.minX && p.x <= b.maxX && p.y >= b.minY && p.y <= b.maxY
+      )
+  );
+  // A wall-to-wall garden can swallow the whole margin; better an
+  // occasional overlap than a rabbit with nowhere to go.
+  const route = clear.length >= 4 ? clear : ring;
+  const start = Math.floor(hashSeed(`${seed}:start`) * route.length) % route.length;
+  return route.map((_, i) => route[(start + i) % route.length]);
+}
+
+/**
+ * Pick at most two ambient critters for a garden: one flyer (bee or
+ * butterfly, seed's choice) when any bed is planted, plus one ground
+ * critter — a chicken if there's a coop to belong to, otherwise a
+ * rabbit. An empty garden hosts no one.
+ */
+export function chooseCritters({
+  canvas,
+  beds,
+  annotations,
+  cropsByBedId,
+  seed,
+}: ChooseCrittersArgs): Critter[] {
+  if (beds.length === 0 && annotations.length === 0) return [];
+
+  const coop = annotations.find((a) => annotationKind(a) === 'coop');
+  const planted = beds.filter((bed) => (cropsByBedId.get(bed.id) ?? []).length > 0);
+
+  const critters: Critter[] = [];
+  if (planted.length > 0) {
+    const kind: CritterKind = hashSeed(`${seed}:flyer`) < 0.5 ? 'bee' : 'butterfly';
+    const route = flyerRoute(planted, `${seed}:${kind}`);
+    critters.push({
+      kind,
+      waypoints: route.waypoints,
+      heightInches: route.heightInches,
+      durationSeconds: seededDuration(`${seed}:${kind}:dur`, 25, 45),
+    });
+  }
+
+  const ground: Critter[] = [];
+  if (coop) {
+    ground.push({
+      kind: 'chicken',
+      waypoints: chickenRoute(coop, `${seed}:chicken`),
+      heightInches: 0,
+      durationSeconds: seededDuration(`${seed}:chicken:dur`, 28, 45),
+    });
+  }
+  ground.push({
+    kind: 'rabbit',
+    waypoints: rabbitRoute(canvas, beds, `${seed}:rabbit`),
+    heightInches: 0,
+    durationSeconds: seededDuration(`${seed}:rabbit:dur`, 40, 60),
+  });
+
+  for (const critter of ground) {
+    if (critters.length >= 2) break;
+    critters.push(critter);
+  }
+  return critters;
+}

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -4120,6 +4120,11 @@ body {
   filter: drop-shadow(0 0 4px rgba(224, 168, 88, 0.85));
 }
 
+/* Ambient critters are scenery: never a click target, never an outline. */
+.mp-critters {
+  pointer-events: none;
+}
+
 /* --- Motion preferences ---------------------------------------------------------- */
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Whimsy for the masterplan: up to **two ambient critters** that live in the illustrated garden, drawn in the same flat-shaded style as everything else.

## Who shows up (deterministic per garden, never more than two, always distinct)
- **Bee or butterfly** (seed picks) whenever any bed has crops — it tours 2–4 planted bed centroids at just above bed-surface height, meandering between them. Its soft shadow tracks the lawn directly beneath it via a second motion path at ground level.
- **Chicken** when a coop exists — a small pecking loop in front of the coop.
- **Rabbit** otherwise — hops a route along the lawn margins, avoiding bed footprints.
- Empty garden → no critters. The same garden always shows the same critters (seeded by canvas id).

## How it behaves
- Hand-authored two-tone silhouettes (~20–26px) in muted palette tones — rabbit body+ears, bee body+wing, butterfly fore/hind wings, chicken body+comb. No emoji, no gradients.
- SMIL `animateMotion` along smoothed projected world paths, 25–60s ambient loops, staggered starts, subtle wing-flutter/bob for flyers. Pure compositor work, no JS animation loop.
- **`prefers-reduced-motion`**: critters render static at their first waypoint with zero animate elements.
- Fully decorative: `aria-hidden`, `pointer-events: none`, painted after the elements group so they never intercept a click or shift depth sorting.
- The shared public garden page reuses IsoScene, so visitors get the critters too.

## Testing
- 500 tests pass (12 new: eligibility rules, determinism, max-two/variety, empty garden, plus masterplan render assertions); lint 0 errors; typecheck clean; build + perf budget pass (1,101,767 / 1,228,800).

## Known limitations
- Rabbit avoidance uses bed bounding boxes (ponds aren't avoided); critters ignore the season scrubber (a pollinator stays out in a scrubbed-empty month); exports rasterize critters at their loop start; sprites stay upright rather than banking along the path.

https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016xJHbRqN8dmyC1MqWBLN7b)_