### PR TITLE
GRN: fix prod 404s by stripping the grn base path when routing custom-domain requests

### DIFF
--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -32,14 +32,23 @@ fn add_cors_headers(mut response: Response<Body>) -> Response<Body> {
     response
 }
 
+// lambda_http builds the request URI from the proxy event's `path` and
+// prefixes the stage name, so direct execute-api calls arrive as `/api/me`.
+// Requests through the shared custom domain (api.<domain>/grn/...) also
+// carry the `grn` base path because API Gateway does not strip base path
+// mappings from REST proxy events, yielding `/api/grn/me`. Strip both so
+// routes match regardless of how the request reached us.
 fn normalize_route_path(path: &str) -> &str {
-    match path {
-        "/api" => "/",
-        _ => path
-            .strip_prefix("/api")
-            .filter(|normalized| normalized.starts_with('/'))
-            .unwrap_or(path),
+    strip_path_prefix(strip_path_prefix(path, "/api"), "/grn")
+}
+
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
+    if path == prefix {
+        return "/";
     }
+    path.strip_prefix(prefix)
+        .filter(|stripped| stripped.starts_with('/'))
+        .unwrap_or(path)
 }
 
 pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_http::Error> {
@@ -515,6 +524,28 @@ mod tests {
         assert_eq!(normalize_route_path("/crops"), "/crops");
         assert_eq!(normalize_route_path("/catalog/crops"), "/catalog/crops");
         assert_eq!(normalize_route_path("/api"), "/");
+    }
+
+    /// Regression guard: requests through the shared custom domain
+    /// (api.<domain>/grn/...) keep the `grn` base path in the event path, so
+    /// the router used to fall through to the catch-all 404 for every route.
+    #[test]
+    fn normalize_route_path_strips_custom_domain_base_path() {
+        assert_eq!(normalize_route_path("/api/grn/me"), "/me");
+        assert_eq!(
+            normalize_route_path("/api/grn/catalog/crops"),
+            "/catalog/crops"
+        );
+        assert_eq!(normalize_route_path("/grn/me"), "/me");
+        assert_eq!(normalize_route_path("/grn"), "/");
+        assert_eq!(normalize_route_path("/api/grn"), "/");
+    }
+
+    #[test]
+    fn normalize_route_path_leaves_grn_like_segments_unchanged() {
+        assert_eq!(normalize_route_path("/grnxyz/me"), "/grnxyz/me");
+        assert_eq!(normalize_route_path("/api/grnxyz"), "/grnxyz");
+        assert_eq!(normalize_route_path("/growers"), "/growers");
     }
 
     #[test]

--- a/services/grn-api/src/auth/authorizer.rs
+++ b/services/grn-api/src/auth/authorizer.rs
@@ -191,25 +191,32 @@ fn is_public_route(event: &ApiGatewayCustomAuthorizerRequestTypeRequest) -> bool
     let method = event.http_method.as_ref().map(reqwest::Method::as_str);
     let path = event.path.as_deref().unwrap_or_default();
 
-    match method {
-        Some("GET") if path == "/api/catalog/crops" || path == "/catalog/crops" => true,
-        Some("GET")
-            if path.ends_with("/varieties")
-                && (path.starts_with("/api/catalog/crops/")
-                    || path.starts_with("/catalog/crops/")) =>
-        {
-            true
-        }
+    method == Some("GET") && is_public_get_path(path)
+}
+
+fn is_public_get_path(path: &str) -> bool {
+    // The authorizer sees the raw request path: direct execute-api calls may
+    // carry the `/api` stage, and requests through the shared custom domain
+    // (api.<domain>/grn/...) carry the `grn` base path, which API Gateway
+    // does not strip for REST proxy events. Remove both before matching the
+    // allow-list.
+    let path = strip_path_prefix(strip_path_prefix(path, "/api"), "/grn");
+
+    path == "/catalog/crops"
+        || (path.starts_with("/catalog/crops/") && path.ends_with("/varieties"))
         // Read-only shared-garden views are addressed by an unguessable
         // token; the handler returns a privacy-trimmed payload and a
         // constant 404 for unknown or revoked tokens.
-        Some("GET")
-            if path.starts_with("/api/shared-gardens/") || path.starts_with("/shared-gardens/") =>
-        {
-            true
-        }
-        _ => false,
+        || path.starts_with("/shared-gardens/")
+}
+
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> &'a str {
+    if path == prefix {
+        return "/";
     }
+    path.strip_prefix(prefix)
+        .filter(|stripped| stripped.starts_with('/'))
+        .unwrap_or(path)
 }
 
 async fn get_user_attributes(
@@ -559,5 +566,35 @@ mod tests {
     fn normalize_user_type_rejects_unsupported_values() {
         assert_eq!(normalize_user_type(""), None);
         assert_eq!(normalize_user_type("free"), None);
+    }
+
+    /// Regression guard: requests through the shared custom domain
+    /// (api.<domain>/grn/...) keep the `grn` base path in the authorizer
+    /// event path, so public routes used to fall through to a Deny.
+    #[test]
+    fn public_get_paths_match_through_stage_and_base_path_prefixes() {
+        for path in [
+            "/catalog/crops",
+            "/api/catalog/crops",
+            "/grn/catalog/crops",
+            "/api/grn/catalog/crops",
+        ] {
+            assert!(is_public_get_path(path), "{path} should be public");
+        }
+
+        assert!(is_public_get_path("/api/grn/catalog/crops/123/varieties"));
+        assert!(is_public_get_path("/catalog/crops/123/varieties"));
+        assert!(is_public_get_path("/grn/shared-gardens/some-token"));
+        assert!(is_public_get_path("/api/shared-gardens/some-token"));
+    }
+
+    #[test]
+    fn non_public_paths_stay_guarded() {
+        assert!(!is_public_get_path("/me"));
+        assert!(!is_public_get_path("/api/grn/me"));
+        assert!(!is_public_get_path("/grn/beds"));
+        assert!(!is_public_get_path("/grnxyz/catalog/crops"));
+        assert!(!is_public_get_path("/catalog/crops/123"));
+        assert!(!is_public_get_path("/shared-gardens"));
     }
 }


### PR DESCRIPTION
## What

Every GRN endpoint returned the router catch-all 404 (`{"error":"Not Found"}`) when called through the shared custom domain (`https://api.oliviasgarden.org/grn/...`). Users first hit this as 404s on GET /me and PUT /me right after sign-in, leaving them stuck in onboarding on prod.

Two changes in `services/grn-api`:

- **`src/api/router.rs`** — `normalize_route_path` now strips an optional `/api` stage prefix and then an optional `/grn` base path, so `/api/grn/me` (custom domain) and `/api/me` (direct execute-api) both resolve to `/me`. Bare prefixes normalize to `/`; lookalike segments (`/grnxyz`) are untouched.
- **`src/auth/authorizer.rs`** — the public-route allow-list applies the same normalization. Previously it only matched `/api/...` and bare paths, so the anonymous catalog and shared-garden endpoints were denied 403 at the gateway when called through the custom domain.

## Why

API Gateway does **not** strip BasePathMapping prefixes from REST proxy events: requests via the custom domain arrive with `event.path = /grn/me`, and `lambda_http` then prepends the stage name, handing the router `/api/grn/me`. The router only stripped `/api`, so nothing matched and every route fell through to the catch-all 404. The profile handlers were never the problem — PUT /me has always upserted, and GET /me lazy-creates the profile (#311, #340); requests just never reached them.

web-api already handles this for its own `/web` base path (`services/web-api/src/services/http.mjs`); this brings grn-api in line. Note that store-api and admin-api still only strip `/api` and have the same latent bug — tracked separately.

## Why CI didn't catch it

The staging Postman suites (including Profile Smoke) run against the execute-api `ApiUrl`, which never carries a base path. Custom-domain routing is only exercised on prod. After deploy, a quick manual check of `https://api.oliviasgarden.org/grn/catalog/crops` (public, no auth) confirms the fix end-to-end.

## Testing

- New regression tests: `normalize_route_path` with `/api/grn/...`, `/grn/...`, bare-prefix, and lookalike-segment inputs; authorizer public/guarded path matching through both prefixes.
- All 246 unit tests pass across both binaries; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
