### PR TITLE
GRN: edit on the illustrated plan + livelier ambient critters

### DIFF
--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type {
@@ -8,7 +8,8 @@ import type {
   GrowerCropItem,
 } from '../../types/listing';
 import { GARDEN_TEMPLATES } from '../GardenDesigner/gardenTemplates';
-import { GardenMasterplan } from './GardenMasterplan';
+import { GardenMasterplan, type MasterplanEditing } from './GardenMasterplan';
+import { screenDeltaToWorld } from './iso';
 
 beforeAll(() => {
   // jsdom has no ResizeObserver; the viewport hook only needs construct/observe.
@@ -128,6 +129,7 @@ function renderMasterplan(args?: {
   onPatchAnnotation?: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
   onOpenLayoutEditor?: () => void;
   onApplyTemplate?: (templateId: string) => Promise<void>;
+  editing?: Partial<MasterplanEditing>;
 }) {
   const beds = args?.beds ?? [makeBed({})];
   const annotations = args?.annotations ?? [makeAnnotation({})];
@@ -138,6 +140,25 @@ function renderMasterplan(args?: {
     cropsByBedId.set(crop.bedId, [...(cropsByBedId.get(crop.bedId) ?? []), crop]);
   }
   const selected = args?.selected ?? null;
+  const editing: MasterplanEditing | undefined = args?.editing
+    ? {
+        snap: 'off',
+        onSnapChange: () => {},
+        onMoveBed: () => {},
+        onMoveAnnotation: () => {},
+        onAddBed: () => {},
+        onAddAnnotation: () => {},
+        onDeleteBed: () => {},
+        onDeleteAnnotation: () => {},
+        onDuplicate: () => {},
+        canUndo: false,
+        canRedo: false,
+        onUndo: () => {},
+        onRedo: () => {},
+        isSaving: false,
+        ...args.editing,
+      }
+    : undefined;
   return render(
     <GardenMasterplan
       canvas={canvas}
@@ -158,6 +179,7 @@ function renderMasterplan(args?: {
       onPatchAnnotation={args?.onPatchAnnotation ?? (() => {})}
       onOpenLayoutEditor={args?.onOpenLayoutEditor ?? (() => {})}
       onApplyTemplate={args?.onApplyTemplate ?? (async () => {})}
+      editing={editing}
     />
   );
 }
@@ -580,5 +602,52 @@ describe('GardenMasterplan', () => {
     expect(
       screen.getByRole('button', { name: /back fence \(fence\)/i })
     ).toBeInTheDocument();
+  });
+
+  describe('editable plan', () => {
+    it('shows the design bar only when editing is enabled', () => {
+      const { rerender } = renderMasterplan();
+      expect(
+        screen.queryByRole('toolbar', { name: /design tools/i })
+      ).not.toBeInTheDocument();
+      rerender(<></>);
+      renderMasterplan({ editing: {} });
+      expect(
+        screen.getByRole('toolbar', { name: /design tools/i })
+      ).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /add a landmark/i })).toBeInTheDocument();
+    });
+
+    it('marks elements draggable and commits a dragged bed to onMoveBed', () => {
+      const onMoveBed = vi.fn();
+      renderMasterplan({ editing: { onMoveBed } });
+      const bed = screen.getByRole('button', { name: /herb spiral/i });
+      expect(bed).toHaveClass('mp-el--draggable');
+
+      // jsdom has no layout/CTM, so client deltas map 1:1 to scene units.
+      fireEvent.pointerDown(bed, { pointerId: 1, button: 0, clientX: 100, clientY: 100 });
+      fireEvent.pointerMove(bed, { pointerId: 1, clientX: 150, clientY: 130 });
+      fireEvent.pointerUp(bed, { pointerId: 1, clientX: 150, clientY: 130 });
+
+      const world = screenDeltaToWorld(50, 30);
+      // Base bed position is (24, 24); the move adds the unprojected delta.
+      expect(onMoveBed).toHaveBeenCalledTimes(1);
+      expect(onMoveBed).toHaveBeenCalledWith(
+        'bed-1',
+        Math.round(24 + world.x),
+        Math.round(24 + world.y)
+      );
+    });
+
+    it('treats a press without movement as a selection, not a move', () => {
+      const onMoveBed = vi.fn();
+      const onSelect = vi.fn();
+      renderMasterplan({ editing: { onMoveBed }, onSelect });
+      const bed = screen.getByRole('button', { name: /herb spiral/i });
+      fireEvent.pointerDown(bed, { pointerId: 1, button: 0, clientX: 100, clientY: 100 });
+      fireEvent.pointerUp(bed, { pointerId: 1, clientX: 101, clientY: 100 });
+      expect(onMoveBed).not.toHaveBeenCalled();
+      expect(onSelect).toHaveBeenCalledWith({ kind: 'bed', id: 'bed-1' });
+    });
   });
 });

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import type {
+  BedShape,
   GardenAnnotation,
   GardenBed,
   GardenCanvas,
@@ -7,11 +8,13 @@ import type {
 } from '../../types/listing';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
 import { GARDEN_TEMPLATES } from '../GardenDesigner/gardenTemplates';
+import type { GridSnap } from '../GardenDesigner/Toolbar';
 import { downloadScenePng, downloadSceneSvg } from './exportScene';
 import { SharePopover } from './SharePopover';
 import { sceneMetrics } from './footprints';
 import { GardenReviewPanel } from './GardenReviewPanel';
 import { IsoScene } from './IsoScene';
+import { MasterplanDesignBar } from './MasterplanDesignBar';
 import { MasterplanDetailPanel } from './MasterplanDetailPanel';
 import {
   MONTH_LABELS_FULL,
@@ -30,6 +33,30 @@ const SUN_OPTIONS: Array<{ value: SunTime | null; label: string; title: string }
   { value: 'evening', label: 'PM', title: 'Evening sun (low in the west)' },
 ];
 
+/**
+ * Direct-manipulation editing on the illustrated plan. When supplied, the
+ * masterplan becomes the primary design surface: elements drag to
+ * reposition on the ground plane, and the floating design bar adds beds /
+ * landmarks and drives undo-redo. Omit it for read-only contexts (the
+ * public shared garden) and the plan stays explore-only.
+ */
+export interface MasterplanEditing {
+  snap: GridSnap;
+  onSnapChange: (snap: GridSnap) => void;
+  onMoveBed: (bedId: string, positionX: number, positionY: number) => void;
+  onMoveAnnotation: (annotationId: string, positionX: number, positionY: number) => void;
+  onAddBed: (shape: BedShape) => void;
+  onAddAnnotation: (presetId: string) => void;
+  onDeleteBed: (bedId: string) => void;
+  onDeleteAnnotation: (annotationId: string) => void;
+  onDuplicate: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  isSaving: boolean;
+}
+
 interface GardenMasterplanProps {
   canvas: GardenCanvas;
   beds: GardenBed[];
@@ -43,7 +70,11 @@ interface GardenMasterplanProps {
   onPatchAnnotation: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
   onOpenLayoutEditor: () => void;
   onApplyTemplate: (templateId: string) => Promise<void>;
+  /** Present when the plan is an editable design surface. */
+  editing?: MasterplanEditing;
 }
+
+const SNAP_INCHES: Record<GridSnap, number> = { off: 0, '6': 6, '12': 12 };
 
 /**
  * The masterplan explorer: an isometric illustrated map of the whole
@@ -65,6 +96,7 @@ export function GardenMasterplan({
   onPatchAnnotation,
   onOpenLayoutEditor,
   onApplyTemplate,
+  editing,
 }: GardenMasterplanProps) {
   const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
 
@@ -175,8 +207,26 @@ export function GardenMasterplan({
             shouldIgnoreClick={shouldIgnoreClick}
             seasonMonth={seasonMonth}
             sunTime={sunTime}
+            editable={Boolean(editing)}
+            snapInches={editing ? SNAP_INCHES[editing.snap] : 0}
+            onMoveBed={editing?.onMoveBed}
+            onMoveAnnotation={editing?.onMoveAnnotation}
           />
         </div>
+
+        {editing && !isEmpty && (
+          <MasterplanDesignBar
+            snap={editing.snap}
+            onSnapChange={editing.onSnapChange}
+            onAddBed={editing.onAddBed}
+            onAddAnnotation={editing.onAddAnnotation}
+            canUndo={editing.canUndo}
+            canRedo={editing.canRedo}
+            onUndo={editing.onUndo}
+            onRedo={editing.onRedo}
+            isSaving={editing.isSaving}
+          />
+        )}
 
         <div className="mp-explorer__zoom" role="group" aria-label="Map zoom controls">
           <button
@@ -249,7 +299,9 @@ export function GardenMasterplan({
 
         {!isEmpty && (
           <p className="mp-explorer__hint" aria-hidden="true">
-            Drag to explore · scroll to zoom · click anything for details
+            {editing
+              ? 'Drag an element to move it · scroll to zoom · drag the lawn to pan'
+              : 'Drag to explore · scroll to zoom · click anything for details'}
           </p>
         )}
 
@@ -385,6 +437,18 @@ export function GardenMasterplan({
           }}
           onClose={() => onSelect(null)}
           onOpenLayoutEditor={onOpenLayoutEditor}
+          editing={
+            editing
+              ? {
+                  onDuplicate: editing.onDuplicate,
+                  onDelete: () => {
+                    if (selectedBed) editing.onDeleteBed(selectedBed.id);
+                    else if (selectedAnnotation)
+                      editing.onDeleteAnnotation(selectedAnnotation.id);
+                  },
+                }
+              : undefined
+          }
         />
       )}
     </div>

--- a/apps/grn/src/components/GardenMasterplan/IsoCritters.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoCritters.tsx
@@ -18,13 +18,27 @@ const WING_HIND = shade(mute('#c2674f', 0.3), 0.28);
 // Hand-authored flat silhouettes, drawn around the origin with feet (or
 // body center, for flyers) at 0,0 so animateMotion can carry the group.
 
-function RabbitSprite() {
+function RabbitSprite({ animate }: { animate: boolean }) {
   return (
     <g>
-      <path
-        d="M-2.5 -10.5 C-4.5 -15 -4 -19.5 -2 -20 C-0.5 -20.3 0.4 -15.5 0.2 -11 Z M2.2 -10.8 C2 -15.5 3.4 -19.2 5 -18.6 C6.4 -18 5 -13 3.6 -10 Z"
-        fill={RABBIT_EAR}
-      />
+      {/* Ears twitch on their own slow cycle, pivoting at their base
+          (~0,-10), so a paused rabbit still reads as alert and alive. */}
+      <g>
+        <path
+          d="M-2.5 -10.5 C-4.5 -15 -4 -19.5 -2 -20 C-0.5 -20.3 0.4 -15.5 0.2 -11 Z M2.2 -10.8 C2 -15.5 3.4 -19.2 5 -18.6 C6.4 -18 5 -13 3.6 -10 Z"
+          fill={RABBIT_EAR}
+        />
+        {animate && (
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            values="0 0 -10;0 0 -10;-13 0 -10;5 0 -10;0 0 -10"
+            keyTimes="0;0.8;0.87;0.93;1"
+            dur="4.5s"
+            repeatCount="indefinite"
+          />
+        )}
+      </g>
       <path
         d="M-8.5 0 C-10 -4.5 -8 -8.5 -4.5 -9.5 C-3.5 -11.5 -0.5 -12 1.5 -11 C4 -11.8 6.5 -10.5 7.5 -8 C9.5 -6.5 10 -3 8.5 0 Z"
         fill={RABBIT_BODY}
@@ -124,7 +138,7 @@ function ButterflySprite({ animate }: { animate: boolean }) {
 function CritterBody({ critter, animate }: { critter: Critter; animate: boolean }) {
   switch (critter.kind) {
     case 'rabbit':
-      return <RabbitSprite />;
+      return <RabbitSprite animate={animate} />;
     case 'chicken':
       return <ChickenSprite />;
     case 'bee':
@@ -178,6 +192,21 @@ function CritterFigure({ critter, index, reducedMotion }: CritterFigureProps) {
   const dur = `${critter.durationSeconds}s`;
   const begin = `${-index * 13}s`;
 
+  // Ground critters carry a stop-and-go timeline; both the body and its
+  // shadow share it so they stay locked together as the critter pauses.
+  const motionAttrs = critter.motion
+    ? {
+        keyPoints: critter.motion.keyPoints,
+        keyTimes: critter.motion.keyTimes,
+        calcMode: 'linear' as const,
+      }
+    : {};
+
+  // A small vertical lilt: a brisk hop for the rabbit, a slower bob for
+  // the chicken, layered on top of the path motion via an inner group.
+  const groundLilt = critter.kind === 'rabbit' ? '0 0;0 -1.8;0 0' : '0 0;0 -0.9;0 0';
+  const liltDur = critter.kind === 'rabbit' ? '1.05s' : '1.9s';
+
   return (
     <g className="mp-critter">
       <g>
@@ -189,7 +218,13 @@ function CritterFigure({ critter, index, reducedMotion }: CritterFigureProps) {
           fill={SCENE.elementShadowSoft}
           opacity={shadow.opacity}
         />
-        <animateMotion dur={dur} begin={begin} repeatCount="indefinite" path={groundPath} />
+        <animateMotion
+          dur={dur}
+          begin={begin}
+          repeatCount="indefinite"
+          path={groundPath}
+          {...motionAttrs}
+        />
       </g>
       <g>
         {flyer ? (
@@ -205,9 +240,25 @@ function CritterFigure({ critter, index, reducedMotion }: CritterFigureProps) {
             />
           </g>
         ) : (
-          <CritterBody critter={critter} animate />
+          <g>
+            <CritterBody critter={critter} animate />
+            <animateTransform
+              attributeName="transform"
+              type="translate"
+              values={groundLilt}
+              dur={liltDur}
+              repeatCount="indefinite"
+              additive="sum"
+            />
+          </g>
         )}
-        <animateMotion dur={dur} begin={begin} repeatCount="indefinite" path={travelPath} />
+        <animateMotion
+          dur={dur}
+          begin={begin}
+          repeatCount="indefinite"
+          path={travelPath}
+          {...motionAttrs}
+        />
       </g>
     </g>
   );

--- a/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
+++ b/apps/grn/src/components/GardenMasterplan/IsoScene.tsx
@@ -1,4 +1,13 @@
-import { memo, useMemo, type KeyboardEvent, type MouseEvent, type ReactNode } from 'react';
+import {
+  memo,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
 import type {
   GardenAnnotation,
   GardenBed,
@@ -18,9 +27,12 @@ import {
   PX_PER_INCH,
   boundsOf,
   depthOf,
+  project,
   projectFootprint,
   scaleFootprint,
+  screenDeltaToWorld,
   smoothClosedPath,
+  type ScreenPoint,
   type WorldPoint,
 } from './iso';
 import { chooseCritters } from './critters';
@@ -53,37 +65,187 @@ function groundRing(w: number, h: number, margin: number): WorldPoint[] {
   return points;
 }
 
+// Past this much pointer travel (in scene units) a press becomes a drag
+// rather than a click — mirrors the viewport's own click/pan threshold so
+// the two feel consistent.
+const DRAG_THRESHOLD = 4;
+
+interface DragState {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  // Inverse of the scene <svg>'s screen CTM captured at grab time, so we
+  // can convert client pixels into scene units regardless of pan/zoom.
+  toScene: DOMMatrix | null;
+  moved: boolean;
+  worldX: number;
+  worldY: number;
+}
+
 interface IsoElementProps {
   label: string;
   isSelected: boolean;
   onSelect: () => void;
   shouldIgnoreClick: () => boolean;
   children: ReactNode;
+  // Editing (all optional; the read-only masterplan and shared view leave
+  // these unset). When draggable is true and onMove + basePosition are
+  // provided, pressing and dragging slides the element across the ground
+  // plane and commits the new world position on release.
+  draggable?: boolean;
+  basePosition?: WorldPoint;
+  snapInches?: number;
+  onMove?: (x: number, y: number) => void;
+}
+
+function clientToScene(
+  svg: SVGSVGElement,
+  clientX: number,
+  clientY: number,
+  inverse: DOMMatrix
+): ScreenPoint {
+  const point = svg.createSVGPoint();
+  point.x = clientX;
+  point.y = clientY;
+  const mapped = point.matrixTransform(inverse);
+  return { x: mapped.x, y: mapped.y };
 }
 
 // Shared interaction shell: focusable, labelled, and class-driven so
 // hover/dim/selection styling stays in CSS where it can be GPU-animated.
-function IsoElement({ label, isSelected, onSelect, shouldIgnoreClick, children }: IsoElementProps) {
+// When editable, it also owns pointer-drag repositioning; a live screen
+// translate gives instant feedback and the committed position only lands
+// on release.
+function IsoElement({
+  label,
+  isSelected,
+  onSelect,
+  shouldIgnoreClick,
+  children,
+  draggable = false,
+  basePosition,
+  snapInches = 0,
+  onMove,
+}: IsoElementProps) {
+  const [dragTranslate, setDragTranslate] = useState<ScreenPoint | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const canDrag = draggable && !!onMove && !!basePosition;
+
   function handleClick(event: MouseEvent) {
     event.stopPropagation();
     if (shouldIgnoreClick()) return;
-    onSelect();
+    // For draggable elements selection already happened on pointerdown;
+    // re-selecting here is harmless but skipped to keep intent clear.
+    if (!canDrag) onSelect();
   }
+
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onSelect();
     }
   }
+
+  function handlePointerDown(event: ReactPointerEvent<SVGGElement>) {
+    if (!canDrag || event.button > 0) return;
+    event.stopPropagation();
+    const svg = event.currentTarget.ownerSVGElement;
+    let ctm: DOMMatrix | null = null;
+    try {
+      ctm = svg?.getScreenCTM() ?? null;
+    } catch {
+      // Not all environments implement getScreenCTM (e.g. jsdom); fall
+      // back to raw client deltas, which are 1:1 with scene units at the
+      // default zoom.
+    }
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      toScene: ctm ? ctm.inverse() : null,
+      moved: false,
+      worldX: basePosition!.x,
+      worldY: basePosition!.y,
+    };
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture is best-effort; some environments reject it.
+    }
+    // Grab-to-select: dragging an unselected element selects it first.
+    onSelect();
+  }
+
+  function handlePointerMove(event: ReactPointerEvent<SVGGElement>) {
+    const state = dragRef.current;
+    if (!state || event.pointerId !== state.pointerId) return;
+    event.stopPropagation();
+    const svg = event.currentTarget.ownerSVGElement;
+    let sceneDx: number;
+    let sceneDy: number;
+    if (state.toScene && svg) {
+      const from = clientToScene(svg, state.startClientX, state.startClientY, state.toScene);
+      const to = clientToScene(svg, event.clientX, event.clientY, state.toScene);
+      sceneDx = to.x - from.x;
+      sceneDy = to.y - from.y;
+    } else {
+      sceneDx = event.clientX - state.startClientX;
+      sceneDy = event.clientY - state.startClientY;
+    }
+    if (!state.moved && Math.hypot(sceneDx, sceneDy) < DRAG_THRESHOLD) return;
+    state.moved = true;
+    const delta = screenDeltaToWorld(sceneDx, sceneDy);
+    let nextX = Math.max(0, basePosition!.x + delta.x);
+    let nextY = Math.max(0, basePosition!.y + delta.y);
+    if (snapInches > 0) {
+      nextX = Math.round(nextX / snapInches) * snapInches;
+      nextY = Math.round(nextY / snapInches) * snapInches;
+    }
+    state.worldX = nextX;
+    state.worldY = nextY;
+    // Live feedback: project the committed ground delta back to screen so
+    // the whole illustration (walls, crops, shadow) slides as one piece.
+    setDragTranslate(project(nextX - basePosition!.x, nextY - basePosition!.y, 0));
+  }
+
+  function endDrag(event: ReactPointerEvent<SVGGElement>) {
+    const state = dragRef.current;
+    if (!state || event.pointerId !== state.pointerId) return;
+    event.stopPropagation();
+    try {
+      event.currentTarget.releasePointerCapture(state.pointerId);
+    } catch {
+      // Capture may already be gone (e.g. pointercancel); ignore.
+    }
+    dragRef.current = null;
+    if (state.moved && onMove) {
+      onMove(Math.round(state.worldX), Math.round(state.worldY));
+    }
+    setDragTranslate(null);
+  }
+
+  const dragProps = canDrag
+    ? {
+        onPointerDown: handlePointerDown,
+        onPointerMove: handlePointerMove,
+        onPointerUp: endDrag,
+        onPointerCancel: endDrag,
+      }
+    : {};
+
   return (
     <g
-      className={`mp-el${isSelected ? ' mp-el--selected' : ''}`}
+      className={`mp-el${isSelected ? ' mp-el--selected' : ''}${
+        canDrag ? ' mp-el--draggable' : ''
+      }${dragTranslate ? ' mp-el--dragging' : ''}`}
       role="button"
       tabIndex={0}
       aria-label={label}
       aria-pressed={isSelected}
+      transform={dragTranslate ? `translate(${dragTranslate.x} ${dragTranslate.y})` : undefined}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      {...dragProps}
     >
       {children}
     </g>
@@ -102,6 +264,12 @@ interface IsoSceneProps {
   seasonMonth?: SeasonMonth;
   /** Time of day for cast sun shadows, or null to hide the layer. */
   sunTime?: SunTime | null;
+  /** When true, elements can be dragged to reposition them on the ground plane. */
+  editable?: boolean;
+  /** Grid snap for drag repositioning, in inches (0 = free placement). */
+  snapInches?: number;
+  onMoveBed?: (bedId: string, positionX: number, positionY: number) => void;
+  onMoveAnnotation?: (annotationId: string, positionX: number, positionY: number) => void;
 }
 
 interface RenderItem {
@@ -129,6 +297,10 @@ export const IsoScene = memo(function IsoScene({
   shouldIgnoreClick,
   seasonMonth = null,
   sunTime = null,
+  editable = false,
+  snapInches = 0,
+  onMoveBed,
+  onMoveAnnotation,
 }: IsoSceneProps) {
   const metrics = sceneMetrics(canvas);
   const w = canvas.widthInches;
@@ -177,6 +349,14 @@ export const IsoScene = memo(function IsoScene({
             isSelected={selected?.kind === 'annotation' && selected.id === annotation.id}
             onSelect={() => onSelect({ kind: 'annotation', id: annotation.id })}
             shouldIgnoreClick={shouldIgnoreClick}
+            draggable={editable}
+            basePosition={{ x: annotation.positionX ?? 12, y: annotation.positionY ?? 12 }}
+            snapInches={snapInches}
+            onMove={
+              onMoveAnnotation
+                ? (x, y) => onMoveAnnotation(annotation.id, x, y)
+                : undefined
+            }
           >
             <IsoAnnotation
               annotation={annotation}
@@ -200,6 +380,10 @@ export const IsoScene = memo(function IsoScene({
             isSelected={selected?.kind === 'bed' && selected.id === bed.id}
             onSelect={() => onSelect({ kind: 'bed', id: bed.id })}
             shouldIgnoreClick={shouldIgnoreClick}
+            draggable={editable}
+            basePosition={{ x: bed.positionX ?? 12, y: bed.positionY ?? 12 }}
+            snapInches={snapInches}
+            onMove={onMoveBed ? (x, y) => onMoveBed(bed.id, x, y) : undefined}
           >
             <IsoBed
               bed={bed}
@@ -221,7 +405,19 @@ export const IsoScene = memo(function IsoScene({
         a.layer - b.layer || Number(b.flat) - Number(a.flat) || a.depth - b.depth
     );
     return list;
-  }, [annotations, beds, cropsByBedId, onSelect, seasonMonth, selected, shouldIgnoreClick]);
+  }, [
+    annotations,
+    beds,
+    cropsByBedId,
+    onSelect,
+    seasonMonth,
+    selected,
+    shouldIgnoreClick,
+    editable,
+    snapInches,
+    onMoveBed,
+    onMoveAnnotation,
+  ]);
 
   // Ambient critters: deterministic per garden (seeded by the canvas id),
   // purely decorative, free for every IsoScene consumer including the

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
@@ -1,0 +1,122 @@
+import type { BedShape } from '../../types/listing';
+import { ANNOTATION_PRESETS } from '../GardenDesigner/annotationPresets';
+import { BED_SHAPES } from '../GardenDesigner/bedDefaults';
+import type { GridSnap } from '../GardenDesigner/Toolbar';
+
+interface MasterplanDesignBarProps {
+  snap: GridSnap;
+  onSnapChange: (snap: GridSnap) => void;
+  onAddBed: (shape: BedShape) => void;
+  onAddAnnotation: (presetId: string) => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  isSaving: boolean;
+}
+
+/**
+ * Floating editing dock for the masterplan. Keeps the "design while looking
+ * at the illustrated plan" tools — add a bed or landmark, undo/redo, grid
+ * snap — on the same view as the artwork, so dragging elements around isn't
+ * the only thing you can do without leaving for the precision editor.
+ */
+export function MasterplanDesignBar({
+  snap,
+  onSnapChange,
+  onAddBed,
+  onAddAnnotation,
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  isSaving,
+}: MasterplanDesignBarProps) {
+  return (
+    <div className="mp-design" role="toolbar" aria-label="Design tools">
+      <div className="mp-design__group" role="group" aria-label="Edit history">
+        <button
+          type="button"
+          className="mp-design__btn"
+          onClick={onUndo}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+          aria-label="Undo"
+        >
+          ↶
+        </button>
+        <button
+          type="button"
+          className="mp-design__btn"
+          onClick={onRedo}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Shift+Z)"
+          aria-label="Redo"
+        >
+          ↷
+        </button>
+      </div>
+
+      <span className="mp-design__divider" aria-hidden="true" />
+
+      <div className="mp-design__group" role="group" aria-label="Add a bed">
+        {BED_SHAPES.map((shape) => (
+          <button
+            key={shape.value}
+            type="button"
+            className="mp-design__btn"
+            onClick={() => onAddBed(shape.value)}
+            title={shape.hint}
+            aria-label={shape.hint}
+          >
+            <span aria-hidden="true">{shape.emoji}</span>
+            <span className="mp-design__btn-label">{shape.label}</span>
+          </button>
+        ))}
+      </div>
+
+      <span className="mp-design__divider" aria-hidden="true" />
+
+      <label className="mp-design__field">
+        <span className="mp-design__field-label">Add landmark</span>
+        <select
+          aria-label="Add a landmark"
+          // Value resets to placeholder after each pick so the same
+          // landmark can be added twice in a row.
+          value=""
+          onChange={(event) => {
+            if (event.target.value) onAddAnnotation(event.target.value);
+          }}
+        >
+          <option value="">＋ Landmark…</option>
+          {ANNOTATION_PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.icon} {preset.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <span className="mp-design__divider" aria-hidden="true" />
+
+      <label className="mp-design__field">
+        <span className="mp-design__field-label">Snap</span>
+        <select
+          value={snap}
+          aria-label="Grid snap"
+          onChange={(event) => onSnapChange(event.target.value as GridSnap)}
+        >
+          <option value="off">Off</option>
+          <option value="6">6 in</option>
+          <option value="12">1 ft</option>
+        </select>
+      </label>
+
+      {isSaving && (
+        <span className="mp-design__saving" role="status">
+          Saving…
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
@@ -44,6 +44,11 @@ interface MasterplanDetailPanelProps {
   onArrange: (direction: 'forward' | 'backward') => void;
   onClose: () => void;
   onOpenLayoutEditor: () => void;
+  /** Quick edit actions, present only when the plan is an editable surface. */
+  editing?: {
+    onDuplicate: () => void;
+    onDelete: () => void;
+  };
 }
 
 /**
@@ -62,6 +67,7 @@ export function MasterplanDetailPanel({
   onArrange,
   onClose,
   onOpenLayoutEditor,
+  editing,
 }: MasterplanDetailPanelProps) {
   if (!bed && !annotation) return null;
 
@@ -232,8 +238,28 @@ export function MasterplanDetailPanel({
             ↑ Bring forward
           </button>
         </div>
+        {editing && (
+          <div className="mp-panel__quick" role="group" aria-label="Quick actions">
+            <button
+              type="button"
+              className="mp-panel__quick-btn"
+              onClick={editing.onDuplicate}
+              title="Duplicate this element (Ctrl+D)"
+            >
+              ⧉ Duplicate
+            </button>
+            <button
+              type="button"
+              className="mp-panel__quick-btn mp-panel__quick-btn--danger"
+              onClick={editing.onDelete}
+              title="Delete this element"
+            >
+              🗑 Delete
+            </button>
+          </div>
+        )}
         <button type="button" className="mp-panel__action" onClick={onOpenLayoutEditor}>
-          Edit in layout editor
+          {editing ? 'Resize & fine-tune →' : 'Edit in layout editor'}
         </button>
       </footer>
     </aside>

--- a/apps/grn/src/components/GardenMasterplan/critters.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/critters.test.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../types/listing';
 import { annotationFootprint, bedFootprint } from './footprints';
 import { worldCentroid } from './iso';
-import { chooseCritters, type Critter } from './critters';
+import { chooseCritters, dwellTimeline, type Critter } from './critters';
 
 const canvas = { widthInches: 360, heightInches: 240 };
 
@@ -232,7 +232,36 @@ describe('chooseCritters', () => {
     }
   });
 
-  it('keeps every duration in the ambient 25–60s band', () => {
+  it('gives ground critters a stop-and-go motion timeline but leaves flyers cruising', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [coop],
+      cropsByBedId: cropsFor('bed-1'),
+      seed: 's',
+    });
+    const chicken = critters.find((c) => c.kind === 'chicken');
+    const flyer = critters.find((c) => c.kind === 'bee' || c.kind === 'butterfly');
+    expect(chicken?.motion).toBeDefined();
+    expect(flyer?.motion).toBeUndefined();
+  });
+
+  it('runs the rabbit on a longer, more relaxed loop than the flyers', () => {
+    const critters = chooseCritters({
+      canvas,
+      beds: [makeBed({})],
+      annotations: [],
+      cropsByBedId: new Map(),
+      seed: 'paced',
+    });
+    const rabbit = critters.find((c) => c.kind === 'rabbit');
+    expect(rabbit?.motion).toBeDefined();
+    // The relaxed loop runs well past the old 40–60s ceiling.
+    expect(rabbit!.durationSeconds).toBeGreaterThanOrEqual(64);
+    expect(rabbit!.durationSeconds).toBeLessThanOrEqual(92);
+  });
+
+  it('keeps every flyer and chicken duration in the ambient 25–60s band', () => {
     const critters = chooseCritters({
       canvas,
       beds: [makeBed({})],
@@ -244,5 +273,43 @@ describe('chooseCritters', () => {
       expect(critter.durationSeconds).toBeGreaterThanOrEqual(25);
       expect(critter.durationSeconds).toBeLessThanOrEqual(60);
     }
+  });
+});
+
+describe('dwellTimeline', () => {
+  it('returns null when there are too few stops to form a loop', () => {
+    expect(dwellTimeline(1, 's')).toBeNull();
+    expect(dwellTimeline(0, 's')).toBeNull();
+  });
+
+  it('produces matched keyPoints/keyTimes that span the whole loop', () => {
+    const timeline = dwellTimeline(6, 'loop');
+    expect(timeline).not.toBeNull();
+    const points = timeline!.keyPoints.split(';').map(Number);
+    const times = timeline!.keyTimes.split(';').map(Number);
+    expect(points.length).toBe(times.length);
+    expect(points[0]).toBe(0);
+    expect(points[points.length - 1]).toBe(1);
+    expect(times[0]).toBe(0);
+    expect(times[times.length - 1]).toBe(1);
+  });
+
+  it('keeps keyTimes monotonically non-decreasing', () => {
+    const timeline = dwellTimeline(8, 'mono')!;
+    const times = timeline.keyTimes.split(';').map(Number);
+    for (let i = 1; i < times.length; i += 1) {
+      expect(times[i]).toBeGreaterThanOrEqual(times[i - 1]);
+    }
+  });
+
+  it('holds a keyPoint across two keyTimes so the critter actually pauses', () => {
+    const timeline = dwellTimeline(7, 'pause')!;
+    const points = timeline.keyPoints.split(';');
+    const held = points.some((p, i) => i > 0 && p === points[i - 1]);
+    expect(held).toBe(true);
+  });
+
+  it('is deterministic for the same stop count and seed', () => {
+    expect(dwellTimeline(5, 'same')).toEqual(dwellTimeline(5, 'same'));
   });
 });

--- a/apps/grn/src/components/GardenMasterplan/critters.ts
+++ b/apps/grn/src/components/GardenMasterplan/critters.ts
@@ -21,6 +21,18 @@ import { IN_GROUND_BED_HEIGHT, MOUND_HEIGHT, RAISED_BED_HEIGHT } from './shadows
 
 export type CritterKind = 'rabbit' | 'bee' | 'butterfly' | 'chicken';
 
+/**
+ * keyPoints/keyTimes for a SMIL <animateMotion calcMode="linear">. Holding
+ * the same keyPoint across two keyTimes parks the critter in place, which
+ * is how a ground critter reads as "lope, then stop and nose around" rather
+ * than gliding a constant loop. Both strings carry the same number of
+ * semicolon-separated entries.
+ */
+export interface MotionTimeline {
+  keyPoints: string;
+  keyTimes: string;
+}
+
 export interface Critter {
   kind: CritterKind;
   /** Looping route in world inches; the renderer closes the loop. */
@@ -28,6 +40,67 @@ export interface Critter {
   /** Travel height above the ground plane (0 for ground critters). */
   heightInches: number;
   durationSeconds: number;
+  /**
+   * Optional stop-and-go timeline for the loop. Present on ground critters
+   * (rabbit, chicken) so they pause at waypoints; absent on flyers, which
+   * cruise at a steady speed.
+   */
+  motion?: MotionTimeline;
+}
+
+// How a ground critter spends its loop: it covers the gap between two
+// waypoints (travel), then often lingers (dwell). Dwell is deliberately
+// lumpy — some stops are a brief hesitation, others a long graze — so the
+// wandering never feels metronomic. Returned weights are unitless; the
+// renderer's dur spreads them across real time.
+function travelWeight(seed: string, i: number): number {
+  // 0.7–1.3: travel pace wobbles a little leg to leg.
+  return 0.7 + hashSeed(`${seed}:t${i}`) * 0.6;
+}
+
+function dwellWeight(seed: string, i: number): number {
+  const roll = hashSeed(`${seed}:d${i}`);
+  // ~45% of stops are a near-instant hesitation; the rest are a real
+  // pause to nose around, scaled by the roll so no two match.
+  if (roll < 0.45) return 0.12;
+  return 0.9 + roll * 1.8;
+}
+
+/**
+ * Build a move-pause-move timeline that visits each waypoint of a closed
+ * loop in order, dwelling at most of them. `stops` is the waypoint count;
+ * fewer than two can't form a loop, so it returns null (the renderer then
+ * falls back to steady motion). Seeded, so a critter always wanders the
+ * same way.
+ */
+export function dwellTimeline(stops: number, seed: string): MotionTimeline | null {
+  if (stops < 2) return null;
+  const travel: number[] = [];
+  const dwell: number[] = [];
+  let total = 0;
+  for (let i = 0; i < stops; i += 1) {
+    const t = travelWeight(seed, i);
+    const d = dwellWeight(seed, i);
+    travel.push(t);
+    dwell.push(d);
+    total += t + d;
+  }
+  const points = ['0'];
+  const times = ['0'];
+  let acc = 0;
+  for (let i = 0; i < stops; i += 1) {
+    const fraction = (i + 1) / stops;
+    acc += travel[i] / total;
+    points.push(fraction.toFixed(4));
+    times.push(acc.toFixed(4));
+    acc += dwell[i] / total;
+    points.push(fraction.toFixed(4));
+    times.push(acc.toFixed(4));
+  }
+  // Pin the final keyTime to exactly 1 so the loop closes cleanly despite
+  // accumulated rounding.
+  times[times.length - 1] = '1';
+  return { keyPoints: points.join(';'), keyTimes: times.join(';') };
 }
 
 export interface ChooseCrittersArgs {
@@ -230,18 +303,27 @@ export function chooseCritters({
 
   const ground: Critter[] = [];
   if (coop) {
+    const chickenWaypoints = chickenRoute(coop, `${seed}:chicken`);
     ground.push({
       kind: 'chicken',
-      waypoints: chickenRoute(coop, `${seed}:chicken`),
+      waypoints: chickenWaypoints,
       heightInches: 0,
-      durationSeconds: seededDuration(`${seed}:chicken:dur`, 28, 45),
+      // Pecking is mostly standing still, so the loop runs long and the
+      // dwells do the talking.
+      durationSeconds: seededDuration(`${seed}:chicken:dur`, 34, 52),
+      motion: dwellTimeline(chickenWaypoints.length, `${seed}:chicken:dwell`) ?? undefined,
     });
   }
+  const rabbitWaypoints = rabbitRoute(canvas, beds, `${seed}:rabbit`);
   ground.push({
     kind: 'rabbit',
-    waypoints: rabbitRoute(canvas, beds, `${seed}:rabbit`),
+    waypoints: rabbitWaypoints,
     heightInches: 0,
-    durationSeconds: seededDuration(`${seed}:rabbit:dur`, 40, 60),
+    // Slower than before, and most of the loop is now spent paused: the
+    // rabbit covers a leg in a few quick hops, then settles to nose around
+    // before moving on. The longer span keeps the hops from looking frantic.
+    durationSeconds: seededDuration(`${seed}:rabbit:dur`, 64, 92),
+    motion: dwellTimeline(rabbitWaypoints.length, `${seed}:rabbit:dwell`) ?? undefined,
   });
 
   for (const critter of ground) {

--- a/apps/grn/src/components/GardenMasterplan/iso.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/iso.test.ts
@@ -14,10 +14,52 @@ import {
   project,
   rectFootprint,
   scaleFootprint,
+  screenDeltaToWorld,
   smoothClosedPath,
   toPath,
+  unprojectGround,
   worldCentroid,
 } from './iso';
+
+describe('unprojectGround', () => {
+  it('round-trips any ground-plane point through project()', () => {
+    for (const [x, y] of [
+      [0, 0],
+      [96, 48],
+      [12, 240],
+      [333, 7],
+    ]) {
+      const back = unprojectGround(project(x, y, 0));
+      expect(back.x).toBeCloseTo(x);
+      expect(back.y).toBeCloseTo(y);
+    }
+  });
+
+  it('inverts the screen origin to the world origin', () => {
+    const back = unprojectGround({ x: 0, y: 0 });
+    expect(back.x).toBeCloseTo(0);
+    expect(back.y).toBeCloseTo(0);
+  });
+});
+
+describe('screenDeltaToWorld', () => {
+  it('maps a screen-space delta to the world delta project() would undo', () => {
+    const world = screenDeltaToWorld(...(() => {
+      const p = project(30, -18, 0);
+      return [p.x, p.y] as const;
+    })());
+    expect(world.x).toBeCloseTo(30);
+    expect(world.y).toBeCloseTo(-18);
+  });
+
+  it('is origin-independent (a delta is a delta)', () => {
+    const a = project(50, 50, 0);
+    const b = project(70, 35, 0);
+    const world = screenDeltaToWorld(b.x - a.x, b.y - a.y);
+    expect(world.x).toBeCloseTo(20);
+    expect(world.y).toBeCloseTo(-15);
+  });
+});
 
 describe('project', () => {
   it('maps the world origin to the screen origin', () => {

--- a/apps/grn/src/components/GardenMasterplan/iso.ts
+++ b/apps/grn/src/components/GardenMasterplan/iso.ts
@@ -43,6 +43,24 @@ export function projectPoint(p: WorldPoint, z = 0): ScreenPoint {
   return project(p.x, p.y, z);
 }
 
+// Inverse of project() on the ground plane (z = 0): turns a scene-space SVG
+// point back into world inches. Used by the isometric editor to translate
+// pointer movement into bed/annotation repositioning. Off the ground plane
+// the mapping is ambiguous (a screen point is a whole ray), so this is
+// ground-only by design.
+export function unprojectGround(screen: ScreenPoint): WorldPoint {
+  const u = screen.x / (ISO_COS * PX_PER_INCH); // = x - y
+  const v = screen.y / (ISO_SIN * PX_PER_INCH); // = x + y
+  return { x: (v + u) / 2, y: (v - u) / 2 };
+}
+
+// A scene-space delta (SVG px) translated into a ground-plane world delta
+// (inches). project() is linear in (x, y) at z = 0, so a delta maps the
+// same way a point does — independent of where the drag started.
+export function screenDeltaToWorld(dx: number, dy: number): WorldPoint {
+  return unprojectGround({ x: dx, y: dy });
+}
+
 export function projectFootprint(points: WorldPoint[], z = 0): ScreenPoint[] {
   return points.map((p) => project(p.x, p.y, z));
 }

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -114,8 +114,8 @@ export function GardenDesignerPage() {
           <h1 className="grn-designer-page__title">Garden</h1>
           <p className="grn-designer-page__subtitle">
             {view === 'masterplan'
-              ? 'An illustrated masterplan of your growing space — click anything to explore.'
-              : 'Lay out your beds, drop in crops, and watch it come together.'}
+              ? 'Design right on the illustrated plan — drag elements to arrange, add beds and landmarks, and click anything to edit.'
+              : 'Precision tools: resize, rotate, draw custom shapes, measure, and trace a site photo.'}
           </p>
         </div>
         <div className="grn-view-toggle" role="group" aria-label="Garden view">
@@ -135,7 +135,7 @@ export function GardenDesignerPage() {
             aria-pressed={view === 'layout'}
             onClick={() => switchView('layout')}
           >
-            Layout editor
+            Precision editor
           </button>
         </div>
       </header>
@@ -154,6 +154,36 @@ export function GardenDesignerPage() {
           onPatchAnnotation={designer.patchAnnotation}
           onOpenLayoutEditor={() => switchView('layout')}
           onApplyTemplate={designer.applyTemplate}
+          editing={
+            designer.isEditable
+              ? {
+                  snap: designer.snap,
+                  onSnapChange: designer.setSnap,
+                  onMoveBed: designer.moveBed,
+                  onMoveAnnotation: designer.moveAnnotation,
+                  onAddBed: (shape) => {
+                    void designer.addBed(shape);
+                  },
+                  onAddAnnotation: (presetId) => {
+                    void designer.addAnnotation(presetId);
+                  },
+                  onDeleteBed: (bedId) => {
+                    void designer.deleteBed(bedId);
+                  },
+                  onDeleteAnnotation: (annotationId) => {
+                    void designer.deleteAnnotation(annotationId);
+                  },
+                  onDuplicate: () => {
+                    void designer.duplicateSelected();
+                  },
+                  canUndo: designer.canUndo,
+                  canRedo: designer.canRedo,
+                  onUndo: designer.undo,
+                  onRedo: designer.redo,
+                  isSaving: designer.isSaving,
+                }
+              : undefined
+          }
         />
       ) : (
         <>

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -3450,6 +3450,148 @@ body {
   cursor: progress;
 }
 
+/* --- Masterplan design bar (editable plan) ------------------------------- */
+
+.mp-design {
+  position: absolute;
+  top: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  max-width: calc(100% - 6.5rem);
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 0.3rem 0.45rem;
+  border-radius: var(--og-radius-pill);
+  border: 1px solid rgba(91, 58, 28, 0.15);
+  background: rgba(253, 250, 241, 0.94);
+  box-shadow: 0 6px 16px rgba(91, 58, 28, 0.14);
+  z-index: 6;
+}
+
+.mp-design__group {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.mp-design__divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 0.15rem 0.1rem;
+  background: rgba(91, 58, 28, 0.16);
+}
+
+.mp-design__btn {
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--og-color-soil);
+  background: transparent;
+  border: none;
+  border-radius: var(--og-radius-pill);
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+  transition: background 120ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mp-design__btn:hover:not(:disabled),
+.mp-design__btn:focus-visible {
+  background: rgba(91, 140, 74, 0.12);
+  outline: none;
+}
+
+.mp-design__btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.mp-design__field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: rgba(79, 56, 37, 0.7);
+}
+
+.mp-design__field select {
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--og-color-soil);
+  background: #fff;
+  border: 1px solid rgba(91, 58, 28, 0.2);
+  border-radius: var(--og-radius-pill);
+  padding: 0.25rem 0.45rem;
+  cursor: pointer;
+}
+
+.mp-design__saving {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: rgba(79, 56, 37, 0.6);
+  padding-right: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .mp-design__btn-label,
+  .mp-design__field-label {
+    display: none;
+  }
+}
+
+/* Draggable elements on the editable plan get a grab affordance. */
+.mp-el--draggable {
+  cursor: grab;
+}
+
+.mp-el--dragging {
+  cursor: grabbing;
+}
+
+/* --- Masterplan detail panel quick actions ------------------------------- */
+
+.mp-panel__quick {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mp-panel__quick-btn {
+  flex: 1;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--og-color-soil);
+  background: transparent;
+  border: 1px solid rgba(91, 58, 28, 0.2);
+  border-radius: var(--og-radius-pill);
+  padding: 0.4rem 0.5rem;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.mp-panel__quick-btn:hover,
+.mp-panel__quick-btn:focus-visible {
+  background: rgba(91, 58, 28, 0.06);
+  outline: none;
+}
+
+.mp-panel__quick-btn--danger {
+  color: #8b1f1a;
+  border-color: rgba(139, 31, 26, 0.3);
+}
+
+.mp-panel__quick-btn--danger:hover,
+.mp-panel__quick-btn--danger:focus-visible {
+  background: rgba(139, 31, 26, 0.08);
+}
+
 /* --- AI garden review panel ---------------------------------------------- */
 
 .mp-review__list {


### PR DESCRIPTION
Brings the garden builder in line with the masterplan the user liked.

Isometric editing: the masterplan is now a direct-manipulation design
surface. Beds and landmarks drag to reposition on the ground plane
(inverse-projected pointer movement, grid-snapped, with a live screen
translate for feedback), a floating design bar adds beds/landmarks and
drives undo-redo + snap, and the detail card gains duplicate/delete.
The top-down Konva canvas stays as the "Precision editor" for resize,
rotate, custom shapes, measuring, and photo tracing. Page copy and the
view toggle reflect the new split.

Ambient critters: the rabbit now lopes, pauses, and noses around instead
of looping at constant speed. Ground critters carry a seeded stop-and-go
keyPoints/keyTimes timeline, the rabbit runs a longer/calmer loop, and a
small hop bob plus an ear twitch add life during pauses.

Adds unprojectGround/screenDeltaToWorld helpers and dwellTimeline with
unit tests, plus drag-to-move coverage on the masterplan.