### PR TITLE
Make store variation editing easier with presets, bulk paste, and color swatches

### DIFF
--- a/apps/admin/src/pages/StorePage.tsx
+++ b/apps/admin/src/pages/StorePage.tsx
@@ -4,6 +4,8 @@ import {
   Card,
   FormFeedback,
   Input,
+  isColorVariation,
+  resolveColorSwatch,
   SectionHeading,
   Select,
   Textarea,
@@ -65,6 +67,27 @@ const fulfillmentOptions = [
 
 const MAX_PRODUCT_IMAGES = 8;
 const MAX_PRODUCT_IMAGE_BYTES = 5 * 1024 * 1024;
+
+// Standard apparel sizes are consistent enough to pre-fill; colors vary per
+// product, so the Color preset starts empty and offers suggestion chips.
+const SIZE_PRESET_VALUES = ['XS', 'S', 'M', 'L', 'XL', '2XL'];
+const COMMON_COLOR_VALUES = [
+  'Black',
+  'White',
+  'Navy',
+  'Heather Gray',
+  'Royal Blue',
+  'Red',
+  'Forest Green',
+  'Maroon',
+];
+const COMMON_SIZE_VALUES = ['XS', 'S', 'M', 'L', 'XL', '2XL', '3XL'];
+
+function suggestedValuesFor(name: string): string[] {
+  if (isColorVariation(name)) return COMMON_COLOR_VALUES;
+  if (/\bsizes?\b/i.test(name)) return COMMON_SIZE_VALUES;
+  return [];
+}
 
 type ProductImageFormItem = Pick<
   StoreProductImage,
@@ -239,8 +262,11 @@ export function StorePage({ session }: StorePageProps) {
     setProductForm((current) => ({ ...current, variations: next }));
   };
 
-  const addVariation = () => {
-    updateVariations([...variations, { name: '', values: [] }]);
+  const addVariation = (preset?: ProductVariation) => {
+    updateVariations([
+      ...variations,
+      preset ? { name: preset.name, values: [...preset.values] } : { name: '', values: [] },
+    ]);
   };
 
   const removeVariation = (index: number) => {
@@ -251,15 +277,29 @@ export function StorePage({ session }: StorePageProps) {
     updateVariations(variations.map((variation, i) => (i === index ? { ...variation, name } : variation)));
   };
 
+  // Accepts one or many values: anything separated by commas or newlines is
+  // added in a single step, so admins can paste "Red, Blue, Green" at once.
+  // Dedupe is case-insensitive to match the API's uniqueness check.
   const addVariationValue = (index: number, value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
+    const additions = value
+      .split(/[,\n]/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (additions.length === 0) return;
     updateVariations(
-      variations.map((variation, i) =>
-        i === index && !variation.values.includes(trimmed)
-          ? { ...variation, values: [...variation.values, trimmed] }
-          : variation
-      )
+      variations.map((variation, i) => {
+        if (i !== index) return variation;
+        const seen = new Set(variation.values.map((existing) => existing.toLowerCase()));
+        const values = [...variation.values];
+        for (const addition of additions) {
+          const key = addition.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            values.push(addition);
+          }
+        }
+        return { ...variation, values };
+      })
     );
   };
 
@@ -617,7 +657,7 @@ export function StorePage({ session }: StorePageProps) {
 
 interface VariationsEditorProps {
   variations: ProductVariation[];
-  onAdd: () => void;
+  onAdd: (preset?: ProductVariation) => void;
   onRemove: (index: number) => void;
   onNameChange: (index: number, name: string) => void;
   onAddValue: (index: number, value: string) => void;
@@ -642,7 +682,9 @@ function VariationsEditor({
   };
 
   const handleValueKey = (event: KeyboardEvent<HTMLInputElement>, index: number) => {
-    if (event.key === 'Enter' || event.key === ',') {
+    // Comma is handled inside onAddValue (it splits on commas), so only Enter
+    // needs to flush the draft here.
+    if (event.key === 'Enter') {
       event.preventDefault();
       submitValue(index);
     }
@@ -654,65 +696,126 @@ function VariationsEditor({
         <div>
           <p className="og-section-label">Variations (optional)</p>
           <h4>Customer-selectable options</h4>
-          <small>e.g. Color: Red, Blue · Ink: Black, White. Each option requires a name and at least one value.</small>
+          <small>
+            Add a Color or Size to start, then click suggestions or paste a comma-separated
+            list (e.g. “Red, Blue, Green”) to add values fast. Each option needs a name and at
+            least one value.
+          </small>
         </div>
-        <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
-          Add variation
-        </Button>
+        <div className="admin-store-variations__presets">
+          <Button type="button" variant="secondary" size="sm" onClick={() => onAdd({ name: 'Color', values: [] })}>
+            + Color
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => onAdd({ name: 'Size', values: SIZE_PRESET_VALUES })}
+          >
+            + Size
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={() => onAdd()}>
+            + Custom
+          </Button>
+        </div>
       </div>
       {variations.length === 0 ? (
         <p className="admin-store-variations__empty">No variations. Customers buy a single SKU.</p>
       ) : (
         <ul className="admin-store-variations__list">
-          {variations.map((variation, index) => (
-            <li key={index} className="admin-store-variations__item">
-              <div className="admin-store-variations__row">
-                <Input
-                  label="Option name"
-                  placeholder="Color"
-                  value={variation.name}
-                  onChange={(event) => onNameChange(index, event.target.value)}
-                />
-                <Button type="button" variant="secondary" size="sm" onClick={() => onRemove(index)}>
-                  Remove
-                </Button>
-              </div>
-              <div className="admin-store-variations__values">
-                {variation.values.map((value, valueIndex) => (
-                  <span key={valueIndex} className="admin-store-variations__chip">
-                    {value}
-                    <button
-                      type="button"
-                      aria-label={`Remove ${value}`}
-                      onClick={() => onRemoveValue(index, valueIndex)}
-                    >
-                      ×
-                    </button>
-                  </span>
-                ))}
-              </div>
-              <div className="admin-store-variations__row">
-                <Input
-                  label="Add value"
-                  placeholder="Red"
-                  value={drafts[index] ?? ''}
-                  onChange={(event) =>
-                    setDrafts((current) => ({ ...current, [index]: event.target.value }))
-                  }
-                  onKeyDown={(event) => handleValueKey(event, index)}
-                />
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => submitValue(index)}
-                  disabled={!drafts[index]?.trim()}
-                >
-                  Add value
-                </Button>
-              </div>
-            </li>
-          ))}
+          {variations.map((variation, index) => {
+            const showSwatches = isColorVariation(variation.name);
+            const existing = new Set(variation.values.map((value) => value.toLowerCase()));
+            const suggestions = suggestedValuesFor(variation.name).filter(
+              (value) => !existing.has(value.toLowerCase())
+            );
+            return (
+              <li key={index} className="admin-store-variations__item">
+                <div className="admin-store-variations__row">
+                  <Input
+                    label="Option name"
+                    placeholder="Color"
+                    value={variation.name}
+                    onChange={(event) => onNameChange(index, event.target.value)}
+                  />
+                  <Button type="button" variant="secondary" size="sm" onClick={() => onRemove(index)}>
+                    Remove
+                  </Button>
+                </div>
+                {variation.values.length > 0 ? (
+                  <div className="admin-store-variations__values">
+                    {variation.values.map((value, valueIndex) => {
+                      const swatch = showSwatches ? resolveColorSwatch(value) : null;
+                      return (
+                        <span key={valueIndex} className="admin-store-variations__chip">
+                          {swatch ? (
+                            <span
+                              className="admin-store-variations__swatch"
+                              style={{ background: swatch }}
+                              aria-hidden="true"
+                            />
+                          ) : null}
+                          {value}
+                          <button
+                            type="button"
+                            aria-label={`Remove ${value}`}
+                            onClick={() => onRemoveValue(index, valueIndex)}
+                          >
+                            ×
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                {suggestions.length > 0 ? (
+                  <div className="admin-store-variations__suggestions">
+                    <span className="admin-store-variations__suggestions-label">Quick add:</span>
+                    {suggestions.map((value) => {
+                      const swatch = showSwatches ? resolveColorSwatch(value) : null;
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          className="admin-store-variations__suggestion"
+                          onClick={() => onAddValue(index, value)}
+                        >
+                          {swatch ? (
+                            <span
+                              className="admin-store-variations__swatch"
+                              style={{ background: swatch }}
+                              aria-hidden="true"
+                            />
+                          ) : null}
+                          {value}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : null}
+                <div className="admin-store-variations__row">
+                  <Input
+                    label="Add value(s)"
+                    placeholder="Red, Blue, Green"
+                    value={drafts[index] ?? ''}
+                    onChange={(event) =>
+                      setDrafts((current) => ({ ...current, [index]: event.target.value }))
+                    }
+                    onKeyDown={(event) => handleValueKey(event, index)}
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => submitValue(index)}
+                    disabled={!drafts[index]?.trim()}
+                  >
+                    Add value
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/apps/admin/src/store-swatch.test.ts
+++ b/apps/admin/src/store-swatch.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { isColorVariation, resolveColorSwatch } from '@olivias/ui';
+
+describe('isColorVariation', () => {
+  it('matches color/colour option names regardless of case', () => {
+    expect(isColorVariation('Color')).toBe(true);
+    expect(isColorVariation('colour')).toBe(true);
+    expect(isColorVariation('Shirt Color')).toBe(true);
+  });
+
+  it('does not match non-color options', () => {
+    expect(isColorVariation('Size')).toBe(false);
+    expect(isColorVariation('Ink')).toBe(false);
+  });
+});
+
+describe('resolveColorSwatch', () => {
+  it('accepts hex codes', () => {
+    expect(resolveColorSwatch('#fff')).toBe('#fff');
+    expect(resolveColorSwatch('#1f2a44')).toBe('#1f2a44');
+  });
+
+  it('maps apparel color names that the browser cannot resolve', () => {
+    expect(resolveColorSwatch('Navy')).toBe('#1f2a44');
+    expect(resolveColorSwatch('heather gray')).toBe('#b7b7b7');
+    expect(resolveColorSwatch('Royal Blue')).toBe('#2b4c9b');
+  });
+
+  it('resolves standard CSS color names', () => {
+    expect(resolveColorSwatch('red')).toBe('red');
+  });
+
+  it('returns null for values that are not colors', () => {
+    expect(resolveColorSwatch('Large')).toBeNull();
+    expect(resolveColorSwatch('   ')).toBeNull();
+  });
+});

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -1173,6 +1173,53 @@ body {
   padding: 0;
 }
 
+.admin-store-variations__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.admin-store-variations__swatch {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.admin-store-variations__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.admin-store-variations__suggestions-label {
+  font-size: 0.8rem;
+  color: rgba(79, 56, 37, 0.62);
+}
+
+.admin-store-variations__suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(79, 56, 37, 0.35);
+  background: #fff;
+  color: var(--og-color-soil);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.admin-store-variations__suggestion:hover {
+  border-style: solid;
+  border-color: var(--og-color-moss, #6b8b5b);
+  background: rgba(107, 139, 91, 0.08);
+}
+
 .admin-checkbox {
   display: inline-flex;
   align-items: center;

--- a/apps/store/src/pages/ProductPage.tsx
+++ b/apps/store/src/pages/ProductPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Button, Card, FormFeedback, SectionHeading } from '@olivias/ui';
+import {
+  Button,
+  Card,
+  FormFeedback,
+  isColorVariation,
+  resolveColorSwatch,
+  SectionHeading,
+} from '@olivias/ui';
 import { getProductBySlug, type StoreProduct } from '../api';
 import { formatMoney, useCart } from '../cart/CartContext';
 
@@ -160,34 +167,47 @@ export function ProductPage() {
 
           {product.variations.length > 0 ? (
             <div className="store-variations">
-              {product.variations.map((variation) => (
-                <div key={variation.name} className="store-variations__group">
-                  <span className="store-variations__label">{variation.name}</span>
-                  <div className="store-variations__options" role="radiogroup" aria-label={variation.name}>
-                    {variation.values.map((value) => {
-                      const isSelected = selectedVariations[variation.name] === value;
-                      return (
-                        <button
-                          key={value}
-                          type="button"
-                          role="radio"
-                          aria-checked={isSelected}
-                          className={`store-variations__option${isSelected ? ' is-selected' : ''}`}
-                          onClick={() => {
-                            setSelectedVariations((current) => ({
-                              ...current,
-                              [variation.name]: value,
-                            }));
-                            setVariationError(null);
-                          }}
-                        >
-                          {value}
-                        </button>
-                      );
-                    })}
+              {product.variations.map((variation) => {
+                const showSwatches = isColorVariation(variation.name);
+                return (
+                  <div key={variation.name} className="store-variations__group">
+                    <span className="store-variations__label">{variation.name}</span>
+                    <div className="store-variations__options" role="radiogroup" aria-label={variation.name}>
+                      {variation.values.map((value) => {
+                        const isSelected = selectedVariations[variation.name] === value;
+                        const swatch = showSwatches ? resolveColorSwatch(value) : null;
+                        return (
+                          <button
+                            key={value}
+                            type="button"
+                            role="radio"
+                            aria-checked={isSelected}
+                            className={`store-variations__option${isSelected ? ' is-selected' : ''}${
+                              swatch ? ' has-swatch' : ''
+                            }`}
+                            onClick={() => {
+                              setSelectedVariations((current) => ({
+                                ...current,
+                                [variation.name]: value,
+                              }));
+                              setVariationError(null);
+                            }}
+                          >
+                            {swatch ? (
+                              <span
+                                className="store-variations__swatch"
+                                style={{ background: swatch }}
+                                aria-hidden="true"
+                              />
+                            ) : null}
+                            {value}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
               {variationError ? (
                 <FormFeedback tone="error">{variationError}</FormFeedback>
               ) : null}

--- a/apps/store/src/styles.css
+++ b/apps/store/src/styles.css
@@ -483,6 +483,21 @@ body {
   color: #fff;
 }
 
+.store-variations__option.has-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.store-variations__swatch {
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
 .store-cart__line-variations {
   margin: 0.15rem 0 0;
   font-size: 0.85rem;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,6 +27,7 @@ export {
   theme,
   typography,
 } from './theme.ts';
+export { resolveColorSwatch, isColorVariation } from './swatch.ts';
 export type { FormFeedbackProps, FormFeedbackTone } from './components/FormFeedback.tsx';
 export type { FormFieldProps } from './components/FormField.tsx';
 export type { InputProps } from './components/Input.tsx';

--- a/packages/ui/src/swatch.ts
+++ b/packages/ui/src/swatch.ts
@@ -1,0 +1,71 @@
+// Helpers for rendering color swatches next to product variation values
+// (e.g. t-shirt colors). These are purely presentational: variation values
+// are still stored as plain strings, and the swatch color is derived from
+// the value text at render time.
+
+const HEX_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+// Apparel-specific names that the browser can't resolve on its own (multi-word
+// names, or shades that differ from the CSS named color). Keys are lowercased.
+const APPAREL_COLORS: Record<string, string> = {
+  navy: '#1f2a44',
+  'navy blue': '#1f2a44',
+  royal: '#2b4c9b',
+  'royal blue': '#2b4c9b',
+  'carolina blue': '#4b9cd3',
+  'baby blue': '#a3c1e0',
+  'sky blue': '#87ceeb',
+  heather: '#b7b7b7',
+  'heather gray': '#b7b7b7',
+  'heather grey': '#b7b7b7',
+  'sport gray': '#9e9e9e',
+  'sport grey': '#9e9e9e',
+  charcoal: '#36454f',
+  ash: '#d6d6cf',
+  'kelly green': '#4cbb17',
+  forest: '#228b22',
+  'forest green': '#228b22',
+  'military green': '#4b5320',
+  cardinal: '#8c1515',
+  burgundy: '#800020',
+  maroon: '#800000',
+  rust: '#b7410e',
+  sand: '#c2b280',
+  natural: '#f5f0e1',
+  cream: '#fffdd0',
+  mustard: '#e1ad01',
+  'dusty rose': '#c9a9a6',
+  blush: '#de9b9b',
+};
+
+let probe: HTMLElement | null = null;
+
+function resolveViaBrowser(value: string): string | null {
+  if (typeof document === 'undefined') return null;
+  if (!probe) {
+    probe = document.createElement('span');
+  }
+  probe.style.color = '';
+  probe.style.color = value;
+  // Invalid values are rejected by the browser and leave the property empty.
+  return probe.style.color ? value : null;
+}
+
+/**
+ * Returns a CSS color string to use for a swatch, or null when the value
+ * doesn't look like a color we can render. Handles hex codes, common apparel
+ * color names, and any CSS named color the browser recognizes.
+ */
+export function resolveColorSwatch(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (HEX_PATTERN.test(trimmed)) return trimmed;
+  const mapped = APPAREL_COLORS[trimmed.toLowerCase()];
+  if (mapped) return mapped;
+  return resolveViaBrowser(trimmed);
+}
+
+/** True when a variation's name suggests its values are colors. */
+export function isColorVariation(name: string): boolean {
+  return /colou?r/i.test(name);
+}


### PR DESCRIPTION
Admin StorePage:
- Add quick "+ Color" / "+ Size" / "+ Custom" preset buttons; Size pre-fills
  standard apparel sizes.
- Add value(s) field now accepts comma/newline-separated lists so admins can
  paste "Red, Blue, Green" in one step (case-insensitive dedupe matching the API).
- Show "Quick add" suggestion chips for Color/Size options.
- Render color swatches beside values on color variations.

Public store ProductPage:
- Render matching color swatches on color option buttons.

Shared @olivias/ui:
- New resolveColorSwatch / isColorVariation helpers (hex, apparel color names,
  CSS named colors) so admin and store stay in sync. Purely presentational —
  variation values remain plain strings, no schema change.