### PR TITLE
Add per-crop harvest tracking to GRN API

### DIFF
--- a/postman/collections/Good Roots Network API/Crop Library/List Harvests.request.yaml
+++ b/postman/collections/Good Roots Network API/Crop Library/List Harvests.request.yaml
@@ -1,9 +1,9 @@
 $kind: http-request
-name: Get Crop
-description: Retrieve a specific crop from the user's crop library.
+name: List Harvests
+description: Retrieve the harvest log for the user's crop, including the running total and entries.
 method: GET
-url: '{{baseUrl}}/crops/:cropLibraryId'
-order: 3000
+url: '{{baseUrl}}/crops/:cropLibraryId/harvests'
+order: 4300
 headers:
   - key: Authorization
     value: 'Bearer {{authToken}}'
@@ -32,15 +32,14 @@ scripts:
           pm.response.to.have.status(200);
       });
 
-      pm.test("Response matches requested crop", function () {
-          const crop = pm.response.json();
-          pm.expect(crop).to.have.property("id", pm.collectionVariables.get("cropLibraryId"));
-          pm.expect(crop).to.have.property("crop_name");
-          pm.expect(crop).to.have.property("status");
-      });
-
-      pm.test("Detail read includes harvest aggregates", function () {
-          const crop = pm.response.json();
-          pm.expect(crop).to.have.property("total_harvested");
-          pm.expect(crop).to.have.property("harvest_count");
+      pm.test("Harvest log matches the crop and contract", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("growerCropId", pm.collectionVariables.get("cropLibraryId"));
+          pm.expect(body).to.have.property("totalHarvested");
+          pm.expect(body).to.have.property("harvestCount");
+          pm.expect(body.harvestCount).to.be.at.least(1);
+          pm.expect(body).to.have.property("harvests").that.is.an("array");
+          pm.expect(body.harvests.length).to.be.at.least(1);
+          pm.expect(body.harvests[0]).to.have.property("amount");
+          pm.expect(body.harvests[0]).to.have.property("harvestedOn");
       });

--- a/postman/collections/Good Roots Network API/Crop Library/Record Harvest.request.yaml
+++ b/postman/collections/Good Roots Network API/Crop Library/Record Harvest.request.yaml
@@ -1,0 +1,57 @@
+$kind: http-request
+name: Record Harvest
+description: Log a harvest against the user's crop and verify the running total is returned.
+method: POST
+url: '{{baseUrl}}/crops/:cropLibraryId/harvests'
+order: 4200
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+pathVariables:
+  - key: cropLibraryId
+    value: '{{cropLibraryId}}'
+    description: UUID of the grower crop
+body:
+  type: json
+  content: |-
+    {
+      "amount": 3.5,
+      "unit": "lb",
+      "harvestedOn": "2026-06-22",
+      "notes": "First picking of the season"
+    }
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const cropLibraryId = pm.collectionVariables.get("cropLibraryId");
+      const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      pm.test("cropLibraryId is set and valid UUID", function () {
+          pm.expect(cropLibraryId, "cropLibraryId is required").to.be.a("string").and.not.empty;
+          pm.expect(cropLibraryId).to.match(uuidRe);
+      });
+
+      if (!cropLibraryId || !uuidRe.test(cropLibraryId)) {
+          postman.setNextRequest(null);
+      }
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+
+      pm.test("Response returns the harvest and updated total", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("harvest");
+          pm.expect(body.harvest).to.have.property("id");
+          pm.expect(body.harvest).to.have.property("growerCropId", pm.collectionVariables.get("cropLibraryId"));
+          pm.expect(body.harvest).to.have.property("amount", "3.5");
+          pm.expect(body.harvest).to.have.property("unit", "lb");
+          pm.expect(body.harvest).to.have.property("harvestedOn", "2026-06-22");
+          pm.expect(body).to.have.property("totalHarvested");
+          pm.expect(body).to.have.property("harvestCount");
+          pm.expect(body.harvestCount).to.be.at.least(1);
+      });

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -551,6 +551,27 @@ create index if not exists idx_grower_crop_library_canonical on grower_crop_libr
 create index if not exists idx_grower_crop_library_bed on grower_crop_library(bed_id) where bed_id is not null;
 
 -- ============================
+-- CROP HARVESTS (private bookkeeping)
+-- ============================
+-- Personal harvest log per grower crop. Separate from surplus_listings:
+-- this records how much a grower has brought in, not what they are sharing.
+create table if not exists crop_harvests (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  grower_crop_id uuid not null references grower_crop_library(id) on delete cascade,
+  amount double precision not null,
+  unit text,                                   -- falls back to the crop's default_unit when omitted
+  harvested_on date not null default current_date,
+  notes text,
+  created_at timestamptz not null default now(),
+
+  constraint crop_harvests_amount_positive check (amount > 0)
+);
+
+create index if not exists idx_crop_harvests_grower_crop on crop_harvests(grower_crop_id, harvested_on desc);
+create index if not exists idx_crop_harvests_user on crop_harvests(user_id);
+
+-- ============================
 -- SURPLUS LISTINGS
 -- ============================
 create table if not exists surplus_listings (

--- a/services/grn-api/db/migrations/0037_crop_harvests.sql
+++ b/services/grn-api/db/migrations/0037_crop_harvests.sql
@@ -1,0 +1,26 @@
+-- Migration: Track harvests per grower crop
+-- Adds a crop_harvests table so growers can log how much they have brought
+-- in for each crop in their personal library. This is private bookkeeping
+-- and is intentionally separate from surplus_listings (the public sharing
+-- feature). The running total per crop is derived by summing amounts.
+
+create table if not exists crop_harvests (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id) on delete cascade,
+  grower_crop_id uuid not null references grower_crop_library(id) on delete cascade,
+  amount double precision not null,
+  unit text,                                   -- falls back to the crop's default_unit when omitted
+  harvested_on date not null default current_date,
+  notes text,
+  created_at timestamptz not null default now(),
+
+  constraint crop_harvests_amount_positive check (amount > 0)
+);
+
+-- Read path: aggregate and list harvests for one crop, newest first.
+create index if not exists idx_crop_harvests_grower_crop
+  on crop_harvests(grower_crop_id, harvested_on desc);
+
+-- Owner-scoped lookups.
+create index if not exists idx_crop_harvests_user
+  on crop_harvests(user_id);

--- a/services/grn-api/openapi.yaml
+++ b/services/grn-api/openapi.yaml
@@ -62,6 +62,8 @@ paths:
     $ref: 'openapi/paths/crop-library.yaml#/~1crops'
   /crops/{cropLibraryId}:
     $ref: 'openapi/paths/crop-library.yaml#/~1crops~1{cropLibraryId}'
+  /crops/{cropLibraryId}/harvests:
+    $ref: 'openapi/paths/crop-library.yaml#/~1crops~1{cropLibraryId}~1harvests'
   /beds:
     $ref: 'openapi/paths/garden.yaml#/~1beds'
   /beds/{bedId}:

--- a/services/grn-api/openapi/paths/crop-library.yaml
+++ b/services/grn-api/openapi/paths/crop-library.yaml
@@ -97,3 +97,63 @@
         $ref: '../schemas/_responses.yaml#/ErrorResponse'
       '500':
         $ref: '../schemas/_responses.yaml#/ErrorResponse'
+
+/crops/{cropLibraryId}/harvests:
+  parameters:
+    - in: path
+      name: cropLibraryId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [Crop Library, Idempotent]
+    summary: List harvests logged for one crop
+    description: |
+      Returns the private harvest log for a single crop: the running total
+      brought in, the number of entries, and every logged harvest newest-first.
+      This is personal bookkeeping and is separate from surplus listings.
+    operationId: listCropHarvests
+    responses:
+      '200':
+        description: Harvest log for the crop
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/crop-library.yaml#/HarvestLogResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+  post:
+    tags: [Crop Library]
+    summary: Log a harvest for one crop
+    description: |
+      Records how much was brought in for this crop and returns the new entry
+      plus the updated running total. When `unit` is omitted it falls back to
+      the crop's `default_unit`; when `harvestedOn` is omitted it defaults to
+      today.
+    operationId: recordCropHarvest
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/crop-library.yaml#/RecordHarvestRequest'
+    responses:
+      '201':
+        description: Harvest recorded
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/crop-library.yaml#/RecordHarvestResponse'
+      '400':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '401':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '404':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'
+      '500':
+        $ref: '../schemas/_responses.yaml#/ErrorResponse'

--- a/services/grn-api/openapi/schemas/crop-library.yaml
+++ b/services/grn-api/openapi/schemas/crop-library.yaml
@@ -49,12 +49,103 @@ GrowerCropItem:
     notes:
       type: string
       nullable: true
+    total_harvested:
+      type: string
+      description: |
+        Running total of everything harvested for this crop, summed across all
+        logged harvests. Serialized as a string to preserve precision. Only
+        present on the crop detail read (GET /crops/{cropLibraryId}); omitted
+        from the list response.
+    harvest_count:
+      type: integer
+      format: int64
+      description: |
+        Number of harvest entries logged for this crop. Only present on the
+        crop detail read.
     created_at:
       type: string
       format: date-time
     updated_at:
       type: string
       format: date-time
+
+RecordHarvestRequest:
+  type: object
+  description: Log a harvest against a crop in the user's library.
+  required: [amount]
+  properties:
+    amount:
+      type: number
+      format: double
+      description: How much was brought in. Must be greater than 0.
+    unit:
+      type: string
+      nullable: true
+      description: "Unit for the amount (e.g. \"lb\", \"bunch\"). Falls back to the crop's default_unit when omitted."
+    harvestedOn:
+      type: string
+      format: date
+      description: Date the harvest was brought in (YYYY-MM-DD). Defaults to today when omitted.
+    notes:
+      type: string
+      nullable: true
+
+HarvestItem:
+  type: object
+  required: [id, growerCropId, amount, harvestedOn, createdAt]
+  properties:
+    id:
+      type: string
+      format: uuid
+    growerCropId:
+      type: string
+      format: uuid
+    amount:
+      type: string
+      description: Amount brought in, serialized as a string to preserve precision.
+    unit:
+      type: string
+      nullable: true
+    harvestedOn:
+      type: string
+      format: date
+    notes:
+      type: string
+      nullable: true
+    createdAt:
+      type: string
+      format: date-time
+
+HarvestLogResponse:
+  type: object
+  required: [growerCropId, totalHarvested, harvestCount, harvests]
+  properties:
+    growerCropId:
+      type: string
+      format: uuid
+    totalHarvested:
+      type: string
+      description: Running total across all logged harvests, serialized as a string.
+    harvestCount:
+      type: integer
+      format: int64
+    harvests:
+      type: array
+      items:
+        $ref: '#/HarvestItem'
+
+RecordHarvestResponse:
+  type: object
+  required: [harvest, totalHarvested, harvestCount]
+  properties:
+    harvest:
+      $ref: '#/HarvestItem'
+    totalHarvested:
+      type: string
+      description: Updated running total after this harvest, serialized as a string.
+    harvestCount:
+      type: integer
+      format: int64
 
 UpsertGrowerCropRequest:
   type: object

--- a/services/grn-api/src/api/handlers/crop.rs
+++ b/services/grn-api/src/api/handlers/crop.rs
@@ -1,6 +1,9 @@
 use crate::auth::{extract_auth_context_with_fallback, require_grower};
 use crate::db;
-use crate::models::crop::{ErrorResponse, GrowerCropItem, UpsertGrowerCropRequest};
+use crate::models::crop::{
+    ErrorResponse, GrowerCropItem, HarvestItem, HarvestLogResponse, RecordHarvestRequest,
+    RecordHarvestResponse, UpsertGrowerCropRequest,
+};
 use chrono::NaiveDate;
 use lambda_http::{Body, Request, Response};
 use serde::Serialize;
@@ -71,7 +74,11 @@ pub async fn get_my_crop(
         .map_err(|error| db_error(&error))?;
 
     if let Some(row) = maybe_row {
-        return json_response(200, &row_to_item(&row));
+        let mut item = row_to_item(&row);
+        let (total, count) = harvest_totals(&client, id).await?;
+        item.total_harvested = Some(total);
+        item.harvest_count = Some(count);
+        return json_response(200, &item);
     }
 
     json_response(
@@ -80,6 +87,185 @@ pub async fn get_my_crop(
             error: "Grower crop record not found".to_string(),
         },
     )
+}
+
+/// Sum and count of every harvest logged against a grower crop. Returns the
+/// total as a string (matching how amounts are serialized elsewhere) and the
+/// number of entries. A crop with no harvests yields ("0", 0).
+async fn harvest_totals(
+    client: &Client,
+    grower_crop_id: Uuid,
+) -> Result<(String, i64), lambda_http::Error> {
+    let row = client
+        .query_one(
+            "select coalesce(sum(amount), 0)::text as total, count(*) as cnt
+             from crop_harvests where grower_crop_id = $1",
+            &[&grower_crop_id],
+        )
+        .await
+        .map_err(|error| db_error(&error))?;
+    Ok((row.get("total"), row.get("cnt")))
+}
+
+/// Verify the crop library entry belongs to the user and return its
+/// `default_unit` (used as the fallback unit for harvests). Returns Ok(None)
+/// when the crop does not exist or is not owned by the user.
+async fn crop_default_unit(
+    client: &Client,
+    grower_crop_id: Uuid,
+    user_id: Uuid,
+) -> Result<Option<Option<String>>, lambda_http::Error> {
+    let maybe_row = client
+        .query_opt(
+            "select default_unit from grower_crop_library where id = $1 and user_id = $2",
+            &[&grower_crop_id, &user_id],
+        )
+        .await
+        .map_err(|error| db_error(&error))?;
+    Ok(maybe_row.map(|row| row.get::<_, Option<String>>("default_unit")))
+}
+
+pub async fn record_harvest(
+    request: &Request,
+    correlation_id: &str,
+    crop_library_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    // Require grower user type - gatherers will receive 403 Forbidden
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = Uuid::parse_str(&auth_context.user_id)
+        .map_err(|_| lambda_http::Error::from("Invalid user ID format"))?;
+    let id = parse_uuid(crop_library_id, "crop library id")?;
+    let payload: RecordHarvestRequest = parse_json_body(request)?;
+
+    validate_harvest_amount(payload.amount)?;
+    let harvested_on = parse_optional_date(payload.harvested_on.as_deref(), "harvestedOn")?;
+
+    let client = db::connect().await?;
+
+    // Ownership check; also gives us the crop's default unit as a fallback.
+    let Some(default_unit) = crop_default_unit(&client, id, user_id).await? else {
+        return json_response(
+            404,
+            &ErrorResponse {
+                error: "Grower crop record not found".to_string(),
+            },
+        );
+    };
+
+    let unit = payload
+        .unit
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or(default_unit);
+    let notes = payload
+        .notes
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let row = client
+        .query_one(
+            "insert into crop_harvests
+                (user_id, grower_crop_id, amount, unit, harvested_on, notes)
+             values
+                ($1, $2, $3, $4, coalesce($5, current_date), $6)
+             returning id, grower_crop_id, amount::text as amount, unit,
+                       harvested_on, notes, created_at",
+            &[&user_id, &id, &payload.amount, &unit, &harvested_on, &notes],
+        )
+        .await
+        .map_err(|error| db_error(&error))?;
+
+    let harvest = row_to_harvest(&row);
+    let (total, count) = harvest_totals(&client, id).await?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        crop_library_id = %id,
+        harvest_id = %harvest.id,
+        "Recorded crop harvest"
+    );
+
+    json_response(
+        201,
+        &RecordHarvestResponse {
+            harvest,
+            total_harvested: total,
+            harvest_count: count,
+        },
+    )
+}
+
+pub async fn list_harvests(
+    request: &Request,
+    _correlation_id: &str,
+    crop_library_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    // Require grower user type - gatherers will receive 403 Forbidden
+    let auth_context = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth_context)?;
+
+    let user_id = Uuid::parse_str(&auth_context.user_id)
+        .map_err(|_| lambda_http::Error::from("Invalid user ID format"))?;
+    let id = parse_uuid(crop_library_id, "crop library id")?;
+    let client = db::connect().await?;
+
+    if crop_default_unit(&client, id, user_id).await?.is_none() {
+        return json_response(
+            404,
+            &ErrorResponse {
+                error: "Grower crop record not found".to_string(),
+            },
+        );
+    }
+
+    let rows = client
+        .query(
+            "select id, grower_crop_id, amount::text as amount, unit,
+                    harvested_on, notes, created_at
+             from crop_harvests
+             where grower_crop_id = $1
+             order by harvested_on desc, created_at desc",
+            &[&id],
+        )
+        .await
+        .map_err(|error| db_error(&error))?;
+
+    let harvests = rows.iter().map(row_to_harvest).collect::<Vec<_>>();
+    let (total, count) = harvest_totals(&client, id).await?;
+
+    json_response(
+        200,
+        &HarvestLogResponse {
+            grower_crop_id: id.to_string(),
+            total_harvested: total,
+            harvest_count: count,
+            harvests,
+        },
+    )
+}
+
+fn row_to_harvest(row: &Row) -> HarvestItem {
+    HarvestItem {
+        id: row.get::<_, Uuid>("id").to_string(),
+        grower_crop_id: row.get::<_, Uuid>("grower_crop_id").to_string(),
+        amount: row.get("amount"),
+        unit: row.get("unit"),
+        harvested_on: row
+            .get::<_, NaiveDate>("harvested_on")
+            .format("%Y-%m-%d")
+            .to_string(),
+        notes: row.get("notes"),
+        created_at: row
+            .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
+            .to_rfc3339(),
+    }
 }
 
 pub async fn create_my_crop(
@@ -309,6 +495,16 @@ pub async fn delete_my_crop(
         .status(204)
         .body(Body::Empty)
         .map_err(|e| lambda_http::Error::from(e.to_string()))
+}
+
+fn validate_harvest_amount(amount: f64) -> Result<(), lambda_http::Error> {
+    if amount.is_finite() && amount > 0.0 {
+        Ok(())
+    } else {
+        Err(lambda_http::Error::from(
+            "amount must be greater than 0".to_string(),
+        ))
+    }
 }
 
 fn validate_upsert_payload(payload: &UpsertGrowerCropRequest) -> Result<(), lambda_http::Error> {
@@ -546,6 +742,10 @@ fn row_to_item(row: &Row) -> GrowerCropItem {
         plant_count: row.get("plant_count"),
         spacing_inches: row.get("spacing_inches"),
         pyramid_tier: row.get("pyramid_tier"),
+        // Harvest aggregates are attached separately on the detail read; the
+        // shared list query does not compute them.
+        total_harvested: None,
+        harvest_count: None,
         created_at: row
             .get::<_, chrono::DateTime<chrono::Utc>>("created_at")
             .to_rfc3339(),
@@ -584,7 +784,7 @@ pub fn error_response(status: u16, message: &str) -> Result<Response<Body>, lamb
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_upsert_payload, UpsertGrowerCropRequest};
+    use super::{validate_harvest_amount, validate_upsert_payload, UpsertGrowerCropRequest};
 
     fn valid_payload() -> UpsertGrowerCropRequest {
         UpsertGrowerCropRequest {
@@ -654,6 +854,27 @@ mod tests {
         payload.planting_date = Some("2026-05-01".to_string());
         payload.expected_harvest_date = Some("2026-08-01".to_string());
         assert!(validate_upsert_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn harvest_amount_accepts_positive_value() {
+        assert!(validate_harvest_amount(3.5).is_ok());
+    }
+
+    #[test]
+    fn harvest_amount_rejects_zero() {
+        assert!(validate_harvest_amount(0.0).is_err());
+    }
+
+    #[test]
+    fn harvest_amount_rejects_negative() {
+        assert!(validate_harvest_amount(-1.0).is_err());
+    }
+
+    #[test]
+    fn harvest_amount_rejects_non_finite() {
+        assert!(validate_harvest_amount(f64::NAN).is_err());
+        assert!(validate_harvest_amount(f64::INFINITY).is_err());
     }
 
     #[test]

--- a/services/grn-api/src/api/models/crop.rs
+++ b/services/grn-api/src/api/models/crop.rs
@@ -25,6 +25,16 @@ pub struct GrowerCropItem {
     /// the food pyramid (e.g. ornamentals).
     #[serde(default)]
     pub pyramid_tier: Option<i16>,
+    /// Running total of everything harvested for this crop, summed across all
+    /// logged harvests. Returned as a string to avoid float precision issues,
+    /// mirroring how listing quantities are serialized. Only populated on the
+    /// crop detail read; omitted from the list response to keep it cheap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_harvested: Option<String>,
+    /// Number of harvest entries logged for this crop. Only populated on the
+    /// crop detail read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harvest_count: Option<i64>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -60,4 +70,58 @@ pub struct UpsertGrowerCropRequest {
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {
     pub error: String,
+}
+
+/// Request body for logging a harvest against a grower crop.
+#[derive(Debug, Deserialize)]
+pub struct RecordHarvestRequest {
+    pub amount: f64,
+    /// Unit for the amount (e.g. "lb", "bunch"). Falls back to the crop's
+    /// `default_unit` when omitted.
+    #[serde(default)]
+    pub unit: Option<String>,
+    /// Date the harvest was brought in (YYYY-MM-DD). Defaults to today.
+    #[serde(default, alias = "harvestedOn")]
+    pub harvested_on: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// A single logged harvest entry.
+#[derive(Debug, Serialize)]
+pub struct HarvestItem {
+    pub id: String,
+    #[serde(rename = "growerCropId")]
+    pub grower_crop_id: String,
+    /// Serialized as a string to avoid float precision issues.
+    pub amount: String,
+    pub unit: Option<String>,
+    #[serde(rename = "harvestedOn")]
+    pub harvested_on: String,
+    pub notes: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+/// Harvest log for one crop: the running total plus every logged entry.
+#[derive(Debug, Serialize)]
+pub struct HarvestLogResponse {
+    #[serde(rename = "growerCropId")]
+    pub grower_crop_id: String,
+    #[serde(rename = "totalHarvested")]
+    pub total_harvested: String,
+    #[serde(rename = "harvestCount")]
+    pub harvest_count: i64,
+    pub harvests: Vec<HarvestItem>,
+}
+
+/// Response returned after logging a single harvest: the new entry plus the
+/// updated running total for the crop.
+#[derive(Debug, Serialize)]
+pub struct RecordHarvestResponse {
+    pub harvest: HarvestItem,
+    #[serde(rename = "totalHarvested")]
+    pub total_harvested: String,
+    #[serde(rename = "harvestCount")]
+    pub harvest_count: i64,
 }

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -172,11 +172,20 @@ async fn route_dynamic_routes(
     correlation_id: &str,
     request_path: &str,
 ) -> Result<Response<Body>, lambda_http::Error> {
-    if let Some(crop_library_id) = request_path.strip_prefix("/crops/") {
+    if let Some(rest) = request_path.strip_prefix("/crops/") {
+        if let Some(crop_library_id) = rest.strip_suffix("/harvests") {
+            let result = match event.method().as_str() {
+                "GET" => crop::list_harvests(event, correlation_id, crop_library_id).await,
+                "POST" => crop::record_harvest(event, correlation_id, crop_library_id).await,
+                _ => method_not_allowed(),
+            };
+            return handle(result);
+        }
+
         let result = match event.method().as_str() {
-            "GET" => crop::get_my_crop(event, correlation_id, crop_library_id).await,
-            "PUT" => crop::update_my_crop(event, correlation_id, crop_library_id).await,
-            "DELETE" => crop::delete_my_crop(event, correlation_id, crop_library_id).await,
+            "GET" => crop::get_my_crop(event, correlation_id, rest).await,
+            "PUT" => crop::update_my_crop(event, correlation_id, rest).await,
+            "DELETE" => crop::delete_my_crop(event, correlation_id, rest).await,
             _ => method_not_allowed(),
         };
         return handle(result);
@@ -410,6 +419,8 @@ fn map_api_error_to_response(
         || is_garden_designer_validation_message(&message)
         || message.contains("plantingDate must be")
         || message.contains("expectedHarvestDate must be")
+        || message.contains("harvestedOn must be")
+        || message.contains("amount must be greater than 0")
         || message.contains("plantCount must be")
         || message.contains("spacingInches must be")
         || message.contains("does not reference an existing catalog crop")


### PR DESCRIPTION
Growers can now log harvests against crops in their personal library and
see a running total of how much they have brought in per crop. This is
private bookkeeping, kept separate from the public surplus-listings flow.

- New crop_harvests table (migration 0037 + ddl.sql) keyed to
  grower_crop_library, with a positive-amount constraint and read indexes.
- POST /crops/{id}/harvests logs a harvest (amount required; unit falls
  back to the crop's default_unit, harvestedOn defaults to today) and
  returns the entry plus the updated running total.
- GET /crops/{id}/harvests returns the full harvest log with total and count.
- GET /crops/{id} (crop detail read) now includes total_harvested and
  harvest_count; the list endpoint already returns crop name + id and is
  unchanged.
- OpenAPI paths/schemas and Postman Crop Library tests updated; new unit
  tests cover harvest amount validation.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AjDTy7bjxE4u81crLw7ayo