### PR TITLE
Refine Good Roots garden planner UX

### DIFF
--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -127,6 +127,17 @@ describe('PlannerPage', () => {
     );
   });
 
+  it('guides the grower to their next unfilled layer', async () => {
+    mockListMyCrops.mockResolvedValue([crop('c1', 'Potato'), crop('c2', 'Tomato')]);
+    const user = userEvent.setup();
+    renderPage();
+
+    const nextStep = await screen.findByRole('button', { name: /start with fresh/i });
+    await user.click(nextStep);
+
+    expect(await screen.findByRole('heading', { name: 'Fresh' })).toBeInTheDocument();
+  });
+
   it('shows the selected layer detail and switches when another band is clicked', async () => {
     mockListMyCrops.mockResolvedValue([crop('c1', 'Basil')]);
     const user = userEvent.setup();
@@ -143,6 +154,36 @@ describe('PlannerPage', () => {
     // (Scoped to span chips — the pyramid silhouette also carries an svg
     // <title>Basil</title> tooltip.)
     expect(screen.getByText('Basil', { selector: 'span' })).toBeInTheDocument();
+  });
+
+  it('keeps the selected layer in a loading state until the garden is available', async () => {
+    let resolveCrops!: (crops: GrowerCropItem[]) => void;
+    mockListMyCrops.mockImplementation(
+      () => new Promise<GrowerCropItem[]>((resolve) => {
+        resolveCrops = resolve;
+      })
+    );
+
+    renderPage();
+
+    expect(await screen.findByText(/checking this layer/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add a crop to foundation/i })).not.toBeInTheDocument();
+
+    resolveCrops([]);
+
+    expect(await screen.findByRole('button', { name: /add a crop to foundation/i })).toBeInTheDocument();
+  });
+
+  it('offers a retry when the garden cannot be loaded', async () => {
+    mockListMyCrops.mockRejectedValue(new Error('Network unavailable'));
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't load your garden/i);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    await waitFor(() => expect(mockListMyCrops).toHaveBeenCalledTimes(2));
   });
 
   it('surfaces crops it cannot place in a "Not yet placed" section', async () => {

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -30,7 +30,12 @@ export function PlannerPage() {
     retry: 2,
   });
 
-  const { data: myCrops } = useQuery({
+  const {
+    data: myCrops,
+    isLoading: isLoadingCrops,
+    isError: isCropsError,
+    refetch: refetchCrops,
+  } = useQuery({
     queryKey: ['myCrops'],
     queryFn: listMyCrops,
     enabled: profile?.userType === 'grower',
@@ -66,6 +71,7 @@ export function PlannerPage() {
   );
 
   const evaluation = useMemo(() => evaluatePlan(counts), [counts]);
+  const nextTier = ALL_TIERS.find((level) => counts[level] === 0) ?? 1;
 
   if (isLoadingProfile) {
     return (
@@ -88,11 +94,11 @@ export function PlannerPage() {
   return (
     <section className="grn-section grn-planner">
       <SectionHeading
-        title="Garden pyramid"
-        body="Your grower planner, organized in five layers — biggest to smallest. Build from the Foundation up: staples first, then everyday workhorses, fresh greens, flavor, and finally the joy crops."
+        title="Garden planner"
+        body="Choose a layer, see what is growing there, and keep your plan moving one simple step at a time."
       />
 
-      <Card padding="6">
+      <Card padding="6" className="grn-planner__workspace">
         <div className="grn-planner__health">
           <PlanScore evaluation={evaluation} />
           <div className="grn-planner__health-body">
@@ -111,24 +117,43 @@ export function PlannerPage() {
             </div>
             <p className="grn-planner__guidance">{planGuidance(evaluation)}</p>
           </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setActiveTier(nextTier)}
+          >
+            {counts[nextTier] > 0
+              ? `Review ${tierMeta(nextTier).name}`
+              : `Start with ${tierMeta(nextTier).name}`}
+          </Button>
         </div>
-      </Card>
 
-      <Card padding="6">
-        <h3 className="grn-planner__pyramid-title">Your garden pyramid</h3>
-        <GardenPyramid
-          cropsByTier={cropsByTier}
-          activeTier={activeTier}
-          onSelectTier={setActiveTier}
-        />
-      </Card>
+        <div className="grn-planner__workspace-grid">
+          <section className="grn-planner__pyramid-panel" aria-labelledby="planner-layers-title">
+            <div className="grn-planner__panel-heading">
+              <h2 id="planner-layers-title" className="grn-planner__pyramid-title">
+                Choose a layer
+              </h2>
+              <p>Start at the base or jump to the part of your garden you want to tend.</p>
+            </div>
+            <GardenPyramid
+              cropsByTier={cropsByTier}
+              activeTier={activeTier}
+              onSelectTier={setActiveTier}
+            />
+          </section>
 
-      <Card padding="6">
-        <TierDetail
-          tier={activeTier}
-          crops={activeCrops}
-          onAddCrop={() => navigate('/crops/new')}
-        />
+          <section className="grn-planner__detail-panel" aria-label={`${tierMeta(activeTier).name} layer`}>
+            <TierDetail
+              tier={activeTier}
+              crops={activeCrops}
+              isLoading={isLoadingCrops}
+              hasError={isCropsError}
+              onRetry={() => void refetchCrops()}
+              onAddCrop={() => navigate('/crops/new')}
+            />
+          </section>
+        </div>
       </Card>
 
       {unsorted.length > 0 ? (
@@ -164,10 +189,13 @@ function toCropVisual(crop: GrowerCropItem): PyramidCropVisual {
 interface TierDetailProps {
   tier: PyramidTier;
   crops: GrowerCropItem[];
+  isLoading: boolean;
+  hasError: boolean;
+  onRetry: () => void;
   onAddCrop: () => void;
 }
 
-function TierDetail({ tier, crops, onAddCrop }: TierDetailProps) {
+function TierDetail({ tier, crops, isLoading, hasError, onRetry, onAddCrop }: TierDetailProps) {
   const meta = tierMeta(tier);
   const plantedNames = useMemo(
     () => new Set(crops.map((c) => c.cropName.trim().toLowerCase())),
@@ -198,20 +226,36 @@ function TierDetail({ tier, crops, onAddCrop }: TierDetailProps) {
         <h4 className="grn-planner__detail-subhead">
           In your garden ({crops.length})
         </h4>
-        {crops.length > 0 ? (
+        {isLoading ? (
+          <p className="grn-planner__detail-state" role="status">
+            Checking this layer…
+          </p>
+        ) : hasError ? (
+          <div className="grn-planner__detail-state grn-planner__detail-state--error" role="alert">
+            <p>We couldn&apos;t load your garden just now.</p>
+            <Button variant="secondary" size="sm" onClick={onRetry}>
+              Try again
+            </Button>
+          </div>
+        ) : crops.length > 0 ? (
           <ul className="grn-planner__crop-list">
             {crops.map((crop) => (
               <CropChip key={crop.id} crop={crop} />
             ))}
           </ul>
         ) : (
-          <p className="grn-planner__detail-empty">
-            Nothing in this layer yet.
-          </p>
+          <div className="grn-planner__empty-state">
+            <p className="grn-planner__detail-empty">
+              This layer is ready for its first crop.
+            </p>
+            <Button variant="primary" size="sm" onClick={onAddCrop}>
+              Add a crop to {meta.name}
+            </Button>
+          </div>
         )}
       </div>
 
-      {openSuggestions.length > 0 ? (
+      {!isLoading && !hasError && openSuggestions.length > 0 ? (
         <div className="grn-planner__detail-section">
           <h4 className="grn-planner__detail-subhead">Ideas to fill this layer</h4>
           <ul className="grn-planner__suggestions">
@@ -227,11 +271,13 @@ function TierDetail({ tier, crops, onAddCrop }: TierDetailProps) {
         </div>
       ) : null}
 
-      <div className="grn-planner__detail-actions">
-        <Button variant="primary" size="sm" onClick={onAddCrop}>
-          + Add a crop
-        </Button>
-      </div>
+      {!isLoading && !hasError && crops.length > 0 ? (
+        <div className="grn-planner__detail-actions">
+          <Button variant="secondary" size="sm" onClick={onAddCrop}>
+            Add another crop
+          </Button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1622,6 +1622,55 @@ body {
   flex-wrap: wrap;
 }
 
+.grn-planner__workspace {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grn-planner__health {
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(79, 56, 37, 0.12);
+}
+
+.grn-planner__health > .og-button {
+  margin-left: auto;
+}
+
+.grn-planner__workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(18rem, 0.85fr);
+  gap: clamp(1rem, 3vw, 2.5rem);
+  align-items: start;
+}
+
+.grn-planner__pyramid-panel,
+.grn-planner__detail-panel {
+  min-width: 0;
+}
+
+.grn-planner__panel-heading {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.grn-planner__panel-heading p {
+  margin: 0;
+  max-width: 34rem;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.9rem;
+}
+
+.grn-planner__detail-panel {
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  border: 1px solid rgba(79, 56, 37, 0.12);
+  border-radius: var(--og-radius-lg);
+  background:
+    linear-gradient(145deg, rgba(255, 253, 248, 0.9), rgba(237, 243, 222, 0.52)),
+    var(--og-color-paper);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.75);
+}
+
 .grn-planner__health-body {
   display: grid;
   gap: 0.6rem;
@@ -1666,11 +1715,10 @@ body {
 }
 
 .grn-planner__pyramid-title {
-  margin: 0 0 1rem;
+  margin: 0;
   font-family: var(--og-font-display);
   font-size: 1.2rem;
   color: var(--og-color-soil);
-  text-align: center;
 }
 
 .grn-planner__progress-stat {
@@ -1855,6 +1903,28 @@ body {
   font-style: italic;
 }
 
+.grn-planner__empty-state,
+.grn-planner__detail-state {
+  display: grid;
+  justify-items: start;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0.85rem;
+  border: 1px dashed rgba(79, 56, 37, 0.2);
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.grn-planner__detail-state p {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.78);
+}
+
+.grn-planner__detail-state--error {
+  border-color: rgba(176, 106, 60, 0.42);
+  background: rgba(176, 106, 60, 0.08);
+}
+
 .grn-planner__crop-list,
 .grn-planner__suggestions {
   list-style: none;
@@ -1890,6 +1960,33 @@ body {
 
 .grn-planner__detail-actions {
   margin-top: 0.25rem;
+}
+
+@media (max-width: 800px) {
+  .grn-planner__workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .grn-planner__health > .og-button {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .grn-planner__health {
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .grn-planner__health-body {
+    min-width: 0;
+    flex-basis: 12rem;
+  }
+
+  .grn-plan-score__dial {
+    width: 6.75rem;
+    height: 6.75rem;
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

- unite the planner score, illustrated pyramid, and selected-layer details in one responsive workspace
- guide growers to the next unfilled layer and make empty layers immediately actionable
- distinguish loading and retryable error states from a genuinely empty garden

## Verification

- `npm test -- PlannerPage.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run lint && npm test` in `services/grn-api`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bins --all-features`

`cargo fmt --all -- --check` reports pre-existing Windows newline-style warnings in untouched GRN API files; no backend formatting was modified.
