### PR TITLE
Streamline the Good Roots garden designer

### DIFF
--- a/apps/grn/src/components/GardenDesigner/DesignerWorkflowGuide.test.tsx
+++ b/apps/grn/src/components/GardenDesigner/DesignerWorkflowGuide.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { GardenBed } from '../../types/listing';
+import { DesignerWorkflowGuide } from './DesignerWorkflowGuide';
+
+const selectedBed: GardenBed = {
+  id: 'bed-1',
+  userId: 'grower-1',
+  name: 'Kitchen greens',
+  description: null,
+  sunExposure: 'full_sun',
+  soilType: null,
+  lengthInches: 96,
+  widthInches: 48,
+  locationNotes: null,
+  sortOrder: 0,
+  bedType: 'raised',
+  shape: 'rect',
+  positionX: 24,
+  positionY: 24,
+  rotationDeg: 0,
+  points: null,
+  color: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('DesignerWorkflowGuide', () => {
+  it('offers a clear first action when nothing is selected', async () => {
+    const user = userEvent.setup();
+    const onAddBed = vi.fn();
+
+    render(
+      <DesignerWorkflowGuide
+        mode="idle"
+        onAddBed={onAddBed}
+        onCancelMode={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Start arranging')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Add a raised bed' }));
+    expect(onAddBed).toHaveBeenCalledOnce();
+  });
+
+  it('explains and exits an active drawing mode', async () => {
+    const user = userEvent.setup();
+    const onCancelMode = vi.fn();
+
+    render(
+      <DesignerWorkflowGuide
+        mode="drawing-polygon"
+        onAddBed={vi.fn()}
+        onCancelMode={onCancelMode}
+      />
+    );
+
+    expect(screen.getByText(/double-tap the last point/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel drawing' }));
+    expect(onCancelMode).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the selected bed and its next step in view', () => {
+    render(
+      <DesignerWorkflowGuide
+        mode="idle"
+        selectedBed={selectedBed}
+        onAddBed={vi.fn()}
+        onCancelMode={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Kitchen greens')).toBeInTheDocument();
+    expect(screen.getByText(/use the details panel/i)).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/DesignerWorkflowGuide.tsx
+++ b/apps/grn/src/components/GardenDesigner/DesignerWorkflowGuide.tsx
@@ -1,0 +1,115 @@
+import type { GardenAnnotation, GardenBed } from '../../types/listing';
+import type { DesignerMode } from './Toolbar';
+
+interface DesignerWorkflowGuideProps {
+  mode: DesignerMode;
+  selectedBed?: GardenBed;
+  selectedAnnotation?: GardenAnnotation;
+  onAddBed: () => void;
+  onCancelMode: () => void;
+}
+
+/**
+ * A small piece of in-context guidance for the precision editor. The canvas
+ * is intentionally powerful, so this keeps the next action visible without
+ * turning the editor into a multi-step wizard or obscuring the plan itself.
+ */
+export function DesignerWorkflowGuide({
+  mode,
+  selectedBed,
+  selectedAnnotation,
+  onAddBed,
+  onCancelMode,
+}: DesignerWorkflowGuideProps) {
+  if (mode === 'drawing-polygon') {
+    return (
+      <section className="grn-designer-workflow is-mode" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Drawing a custom bed</p>
+        <p className="grn-designer-workflow__copy">
+          Tap to place each corner. Double-tap the last point to finish the shape.
+        </p>
+        <button type="button" className="grn-designer-workflow__action" onClick={onCancelMode}>
+          Cancel drawing
+        </button>
+      </section>
+    );
+  }
+
+  if (mode === 'measuring') {
+    return (
+      <section className="grn-designer-workflow is-mode" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Measuring distance</p>
+        <p className="grn-designer-workflow__copy">
+          Click two points on the plan to measure the space between them.
+        </p>
+        <button type="button" className="grn-designer-workflow__action" onClick={onCancelMode}>
+          Stop measuring
+        </button>
+      </section>
+    );
+  }
+
+  if (mode === 'calibrating-scale') {
+    return (
+      <section className="grn-designer-workflow is-mode" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Calibrating your plan</p>
+        <p className="grn-designer-workflow__copy">
+          Draw a line across something with a known length, then tell us how long it is.
+        </p>
+        <button type="button" className="grn-designer-workflow__action" onClick={onCancelMode}>
+          Cancel calibration
+        </button>
+      </section>
+    );
+  }
+
+  if (mode === 'editing-vertices') {
+    return (
+      <section className="grn-designer-workflow is-mode" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Editing a custom shape</p>
+        <p className="grn-designer-workflow__copy">
+          Drag a point to reshape it. When it looks right, finish editing to continue.
+        </p>
+        <button type="button" className="grn-designer-workflow__action" onClick={onCancelMode}>
+          Finish editing
+        </button>
+      </section>
+    );
+  }
+
+  if (selectedBed) {
+    return (
+      <section className="grn-designer-workflow" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Bed selected</p>
+        <p className="grn-designer-workflow__title">{selectedBed.name}</p>
+        <p className="grn-designer-workflow__copy">
+          Drag to reposition it, or use the details panel to plant, resize, and refine it.
+        </p>
+      </section>
+    );
+  }
+
+  if (selectedAnnotation) {
+    return (
+      <section className="grn-designer-workflow" aria-label="Current design step">
+        <p className="grn-designer-workflow__eyebrow">Landmark selected</p>
+        <p className="grn-designer-workflow__title">{selectedAnnotation.label}</p>
+        <p className="grn-designer-workflow__copy">
+          Drag to reposition it, or use the details panel to refine its place in your plan.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="grn-designer-workflow" aria-label="Current design step">
+      <p className="grn-designer-workflow__eyebrow">Start arranging</p>
+      <p className="grn-designer-workflow__copy">
+        Add a bed, then drag it into place. Select anything on the plan whenever you want to refine it.
+      </p>
+      <button type="button" className="grn-designer-workflow__action" onClick={onAddBed}>
+        Add a raised bed
+      </button>
+    </section>
+  );
+}

--- a/apps/grn/src/components/GardenDesigner/Toolbar.test.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Toolbar } from './Toolbar';
+
+function renderToolbar(overrides: Partial<ComponentProps<typeof Toolbar>> = {}) {
+  const props: ComponentProps<typeof Toolbar> = {
+    isMobile: false,
+    mode: 'idle',
+    onAddBed: vi.fn(),
+    onAddAnnotation: vi.fn(),
+    onStartDrawingPolygon: vi.fn(),
+    onCancelDrawingPolygon: vi.fn(),
+    gridSnap: 'off',
+    onGridSnapChange: vi.fn(),
+    onFitToScreen: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onToggleMeasure: vi.fn(),
+    ...overrides,
+  };
+  render(<Toolbar {...props} />);
+  return props;
+}
+
+describe('Toolbar', () => {
+  it('keeps the default raised bed as a prominent direct action', async () => {
+    const user = userEvent.setup();
+    const onAddBed = vi.fn();
+    renderToolbar({ onAddBed });
+
+    const button = screen.getByRole('button', { name: /add a rectangular bed/i });
+    expect(button).toHaveClass('grn-designer-toolbar__btn--primary');
+    await user.click(button);
+    expect(onAddBed).toHaveBeenCalledWith('rect');
+  });
+
+  it('offers landmarks from one focused desktop control', async () => {
+    const user = userEvent.setup();
+    const onAddAnnotation = vi.fn();
+    renderToolbar({ onAddAnnotation });
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Add a landmark' }), 'compost');
+    expect(onAddAnnotation).toHaveBeenCalledWith('compost');
+    expect(screen.getByRole('group', { name: 'Add a landmark' })).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/GardenDesigner/Toolbar.tsx
+++ b/apps/grn/src/components/GardenDesigner/Toolbar.tsx
@@ -89,7 +89,9 @@ export function Toolbar({
     <button
       key={shape.value}
       type="button"
-      className="grn-designer-toolbar__btn"
+      className={`grn-designer-toolbar__btn ${
+        shape.value === 'rect' ? 'grn-designer-toolbar__btn--primary' : ''
+      }`}
       onClick={() => {
         onAddBed(shape.value);
         setMoreOpen(false);
@@ -208,6 +210,27 @@ export function Toolbar({
     </label>
   );
 
+  const landmarkField = (
+    <label className="grn-designer-toolbar__field grn-designer-toolbar__field--landmark">
+      <span>Add landmark</span>
+      <select
+        value=""
+        onChange={(event) => {
+          if (event.target.value) onAddAnnotation(event.target.value);
+        }}
+        disabled={drawing || calibrating}
+        aria-label="Add a landmark"
+      >
+        <option value="">Chooseâ€¦</option>
+        {ANNOTATION_PRESETS.map((preset) => (
+          <option key={preset.id} value={preset.id}>
+            {preset.icon} {preset.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
   if (isMobile) {
     return (
       <div
@@ -295,9 +318,9 @@ export function Toolbar({
       <div
         className="grn-designer-toolbar__group"
         role="group"
-        aria-label="Add an annotation"
+        aria-label="Add a landmark"
       >
-        {annotationButtons}
+        {landmarkField}
       </div>
 
       <div className="grn-designer-toolbar__divider" aria-hidden="true" />

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -278,6 +278,29 @@ describe('GardenMasterplan', () => {
     expect(onSelect).toHaveBeenCalledWith(null);
   });
 
+  it('gives an unselected editable garden a clear next step', async () => {
+    const onAddBed = vi.fn();
+    renderMasterplan({ editing: { onAddBed } });
+
+    expect(screen.getByText(/your garden at a glance/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 bed.*1 landmark.*1 bed planted/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /add a raised bed/i }));
+
+    expect(onAddBed).toHaveBeenCalledWith('rect');
+  });
+
+  it('keeps alternate bed shapes available without crowding the design dock', () => {
+    const onAddBed = vi.fn();
+    renderMasterplan({ editing: { onAddBed } });
+
+    fireEvent.change(screen.getByLabelText(/add a different bed shape/i), {
+      target: { value: 'circle' },
+    });
+
+    expect(onAddBed).toHaveBeenCalledWith('circle');
+  });
+
   it('shows an inviting empty state when the garden has no elements', () => {
     const onOpenLayoutEditor = vi.fn();
     renderMasterplan({ beds: [], annotations: [], crops: [], onOpenLayoutEditor });

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -163,6 +163,10 @@ export function GardenMasterplan({
     shouldIgnoreClick,
   } = useMapViewport(metrics.width, metrics.height);
   const isEmpty = beds.length === 0 && annotations.length === 0;
+  const plantedBedCount = useMemo(
+    () => beds.filter((bed) => (cropsByBedId.get(bed.id)?.length ?? 0) > 0).length,
+    [beds, cropsByBedId]
+  );
 
   // Plain DOM ref to find the scene <svg> for export; pan/zoom state
   // never touches it.
@@ -229,6 +233,27 @@ export function GardenMasterplan({
             onRedo={editing.onRedo}
             isSaving={editing.isSaving}
           />
+        )}
+
+        {editing && !isEmpty && !selected && (
+          <aside className="mp-explorer__coach" aria-label="Garden design next step">
+            <p className="mp-explorer__coach-kicker">Your garden at a glance</p>
+            <p className="mp-explorer__coach-summary">
+              {beds.length} {beds.length === 1 ? 'bed' : 'beds'} · {annotations.length}{' '}
+              {annotations.length === 1 ? 'landmark' : 'landmarks'} · {plantedBedCount}{' '}
+              {plantedBedCount === 1 ? 'bed planted' : 'beds planted'}
+            </p>
+            <p className="mp-explorer__coach-copy">
+              Select anything on the map to tend it, or keep shaping your garden one bed at a time.
+            </p>
+            <button
+              type="button"
+              className="mp-explorer__coach-action"
+              onClick={() => editing.onAddBed('rect')}
+            >
+              Add a raised bed
+            </button>
+          </aside>
         )}
 
         <div className="mp-explorer__zoom" role="group" aria-label="Map zoom controls">

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
@@ -60,19 +60,32 @@ export function MasterplanDesignBar({
       <span className="mp-design__divider" aria-hidden="true" />
 
       <div className="mp-design__group" role="group" aria-label="Add a bed">
-        {BED_SHAPES.map((shape) => (
-          <button
-            key={shape.value}
-            type="button"
-            className="mp-design__btn"
-            onClick={() => onAddBed(shape.value)}
-            title={shape.hint}
-            aria-label={shape.hint}
+        <button
+          type="button"
+          className="mp-design__btn mp-design__btn--primary"
+          onClick={() => onAddBed('rect')}
+          title="Add a rectangular raised bed"
+        >
+          <span aria-hidden="true">＋</span>
+          <span>Add bed</span>
+        </button>
+        <label className="mp-design__field mp-design__field--shape">
+          <span className="mp-design__field-label">Bed shape</span>
+          <select
+            aria-label="Add a different bed shape"
+            value=""
+            onChange={(event) => {
+              if (event.target.value) onAddBed(event.target.value as BedShape);
+            }}
           >
-            <span aria-hidden="true">{shape.emoji}</span>
-            <span className="mp-design__btn-label">{shape.label}</span>
-          </button>
-        ))}
+            <option value="">More shapes</option>
+            {BED_SHAPES.filter((shape) => shape.value !== 'rect').map((shape) => (
+              <option key={shape.value} value={shape.value}>
+                {shape.emoji} {shape.label}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
       <span className="mp-design__divider" aria-hidden="true" />

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -8,6 +8,7 @@ import {
   type DesignerCanvasHandle,
 } from '../components/GardenDesigner/Canvas';
 import { GardenPropertiesBar } from '../components/GardenDesigner/GardenPropertiesBar';
+import { DesignerWorkflowGuide } from '../components/GardenDesigner/DesignerWorkflowGuide';
 import { Toolbar } from '../components/GardenDesigner/Toolbar';
 import { GardenMasterplan } from '../components/GardenMasterplan/GardenMasterplan';
 import { useGardenDesigner } from '../hooks/useGardenDesigner';
@@ -114,8 +115,8 @@ export function GardenDesignerPage() {
           <h1 className="grn-designer-page__title">Garden</h1>
           <p className="grn-designer-page__subtitle">
             {view === 'masterplan'
-              ? 'Design right on the illustrated plan — drag elements to arrange, add beds and landmarks, and click anything to edit.'
-              : 'Precision tools: resize, rotate, draw custom shapes, measure, and trace a site photo.'}
+              ? 'See the whole garden, place beds and landmarks, then select anything to tend it.'
+              : 'Shape the details when you need precision — resize, draw custom beds, measure, and trace a site photo.'}
           </p>
         </div>
         <div className="grn-view-toggle" role="group" aria-label="Garden view">
@@ -127,7 +128,7 @@ export function GardenDesignerPage() {
             aria-pressed={view === 'masterplan'}
             onClick={() => switchView('masterplan')}
           >
-            Masterplan
+            Garden map
           </button>
           <button
             type="button"
@@ -135,7 +136,7 @@ export function GardenDesignerPage() {
             aria-pressed={view === 'layout'}
             onClick={() => switchView('layout')}
           >
-            Precision editor
+            Fine tune
           </button>
         </div>
       </header>
@@ -247,7 +248,8 @@ export function GardenDesignerPage() {
               }
             />
 
-            <DesignerCanvas
+            <div className="grn-designer-page__canvas-stage">
+              <DesignerCanvas
               ref={canvasRef}
               canvas={designer.canvas}
               beds={designer.beds}
@@ -273,8 +275,24 @@ export function GardenDesignerPage() {
               onMarqueeSelect={designer.marqueeSelect}
               onMoveGroup={designer.moveSelectedGroup}
               onCalibrationCaptured={setCalibrationDrawnLength}
-              onCancelCalibration={cancelCalibration}
-            />
+                onCancelCalibration={cancelCalibration}
+              />
+              <DesignerWorkflowGuide
+                mode={designer.mode}
+                selectedBed={designer.selectedBed}
+                selectedAnnotation={designer.selectedAnnotation}
+                onAddBed={() => {
+                  void designer.addBed('rect');
+                }}
+                onCancelMode={() => {
+                  if (isCalibrating) {
+                    cancelCalibration();
+                  } else {
+                    designer.setMode('idle');
+                  }
+                }}
+              />
+            </div>
 
             {isCalibrating && calibrationDrawnLength !== null && (
               <CalibrateScaleModal

--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { PlannerPage } from './PlannerPage';
 import { getMe, listMyCrops } from '../services/api';
 import type { GrowerCropItem } from '../types/listing';
@@ -54,9 +54,15 @@ function renderPage() {
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
         <PlannerPage />
+        <LocationDisplay />
       </MemoryRouter>
     </QueryClientProvider>
   );
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}</output>;
 }
 
 describe('PlannerPage', () => {
@@ -125,6 +131,14 @@ describe('PlannerPage', () => {
     await waitFor(() =>
       expect(screen.getByRole('img', { name: /plan score \d+ out of 100/i })).toBeInTheDocument()
     );
+  });
+
+  it('connects planning directly to the garden map', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'Open garden map' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/garden');
   });
 
   it('shows the selected layer detail and switches when another band is clicked', async () => {

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -110,6 +110,12 @@ export function PlannerPage() {
               ))}
             </div>
             <p className="grn-planner__guidance">{planGuidance(evaluation)}</p>
+            <div className="grn-planner__map-link">
+              <span>Ready to give your plan a place?</span>
+              <Button variant="outline" size="sm" onClick={() => navigate('/garden')}>
+                Open garden map
+              </Button>
+            </div>
           </div>
         </div>
       </Card>

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1629,6 +1629,15 @@ body {
   min-width: 14rem;
 }
 
+.grn-planner__map-link {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.84rem;
+}
+
 .grn-plan-score {
   display: flex;
   flex-direction: column;

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1991,6 +1991,16 @@ body {
   flex: 1;
 }
 
+.grn-designer-page__canvas-stage {
+  position: relative;
+  min-width: 0;
+  min-height: 520px;
+}
+
+.grn-designer-page__canvas-stage > .grn-designer-canvas {
+  height: 100%;
+}
+
 .grn-designer-page.has-inspector .grn-designer-page__layout {
   grid-template-columns: auto minmax(0, 1fr) clamp(300px, 26vw, 380px);
 }
@@ -2003,6 +2013,10 @@ body {
   }
   .grn-designer-page.has-inspector .grn-designer-page__layout {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .grn-designer-page__canvas-stage {
+    min-height: 65vh;
   }
 }
 
@@ -2198,6 +2212,19 @@ body {
 .grn-designer-toolbar__btn.is-active {
   background: var(--og-color-moss);
   border-color: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-toolbar__btn--primary {
+  background: var(--og-color-moss);
+  border-color: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-toolbar__btn--primary:hover:not(:disabled),
+.grn-designer-toolbar__btn--primary:focus-visible {
+  background: #426a35;
+  border-color: #426a35;
   color: var(--og-color-paper);
 }
 
@@ -3553,6 +3580,73 @@ body {
 .mp-design__btn:hover:not(:disabled),
 .mp-design__btn:focus-visible {
   background: rgba(91, 140, 74, 0.12);
+  outline: none;
+}
+
+.grn-designer-workflow {
+  position: absolute;
+  z-index: 4;
+  top: 0.8rem;
+  left: 0.8rem;
+  width: min(19rem, calc(100% - 6rem));
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(91, 58, 28, 0.16);
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 252, 244, 0.96);
+  box-shadow: 0 8px 22px rgba(66, 45, 23, 0.14);
+}
+
+.grn-designer-workflow.is-mode {
+  border-color: rgba(91, 140, 74, 0.42);
+}
+
+.grn-designer-workflow__eyebrow {
+  margin: 0;
+  color: var(--og-color-moss);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.grn-designer-workflow__title,
+.grn-designer-workflow__copy {
+  margin: 0;
+}
+
+.grn-designer-workflow__title {
+  color: var(--og-color-ink);
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.grn-designer-workflow__copy {
+  color: var(--og-color-soil);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.grn-designer-workflow__action {
+  justify-self: start;
+  margin-top: 0.15rem;
+  padding: 0.4rem 0.65rem;
+  border: 1px solid var(--og-color-moss);
+  border-radius: var(--og-radius-sm);
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.grn-designer-workflow__action:hover,
+.grn-designer-workflow__action:focus-visible {
+  background: #426a35;
+  border-color: #426a35;
   outline: none;
 }
 

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -3556,6 +3556,18 @@ body {
   outline: none;
 }
 
+.mp-design__btn--primary {
+  color: #fffdf8;
+  background: var(--og-color-moss);
+  box-shadow: 0 2px 5px rgba(55, 82, 43, 0.2);
+}
+
+.mp-design__btn--primary:hover:not(:disabled),
+.mp-design__btn--primary:focus-visible {
+  color: #fffdf8;
+  background: #456d3b;
+}
+
 .mp-design__btn:disabled {
   opacity: 0.4;
   cursor: default;
@@ -3581,6 +3593,10 @@ body {
   cursor: pointer;
 }
 
+.mp-design__field--shape select {
+  max-width: 8rem;
+}
+
 .mp-design__saving {
   font-size: 0.76rem;
   font-weight: 600;
@@ -3592,6 +3608,10 @@ body {
   .mp-design__btn-label,
   .mp-design__field-label {
     display: none;
+  }
+
+  .mp-design__field--shape select {
+    max-width: 6.8rem;
   }
 }
 
@@ -3771,9 +3791,80 @@ body {
   white-space: nowrap;
 }
 
+/* A quiet orientation card that only appears when the editable map has no
+   active selection. It turns a beautiful-but-open-ended canvas into a clear
+   next step without competing with the selected element's detail panel. */
+.mp-explorer__coach {
+  position: absolute;
+  top: 3.75rem;
+  left: 0.75rem;
+  z-index: 5;
+  display: grid;
+  justify-items: start;
+  gap: 0.35rem;
+  width: min(18rem, calc(100% - 7rem));
+  padding: 0.8rem 0.9rem;
+  border: 1px solid rgba(91, 58, 28, 0.14);
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 253, 248, 0.92);
+  box-shadow: 0 6px 16px rgba(91, 58, 28, 0.1);
+}
+
+.mp-explorer__coach-kicker,
+.mp-explorer__coach-summary,
+.mp-explorer__coach-copy {
+  margin: 0;
+}
+
+.mp-explorer__coach-kicker {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--og-color-sage);
+}
+
+.mp-explorer__coach-summary {
+  font-family: var(--og-font-display);
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--og-color-soil);
+}
+
+.mp-explorer__coach-copy {
+  color: rgba(79, 56, 37, 0.76);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.mp-explorer__coach-action {
+  margin-top: 0.15rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--og-color-moss);
+  border-radius: var(--og-radius-pill);
+  color: #fffdf8;
+  background: var(--og-color-moss);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.mp-explorer__coach-action:hover,
+.mp-explorer__coach-action:focus-visible {
+  background: #456d3b;
+  outline: none;
+}
+
 @media (max-width: 768px) {
   .mp-explorer__hint {
     display: none;
+  }
+
+  .mp-explorer__coach {
+    top: 3.85rem;
+    left: 0.5rem;
+    width: min(17rem, calc(100% - 5.25rem));
   }
 }
 


### PR DESCRIPTION
## Summary

- add a calm at-a-glance design prompt with a direct next action when no map element is selected
- simplify the masterplan dock around one-tap bed creation while keeping alternate shapes available
- preserve the illustrated map, direct manipulation, detailed inspectors, and existing mobile layout

## Verification

- `npm test` (528 passing)
- `npm run lint`
- `npm run build`
- `npm run lint && npm test` in `services/grn-api`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bins --all-features`

`cargo fmt --all -- --check` reports pre-existing Windows newline-style warnings in untouched GRN API files; no backend formatting was modified.
