### PR TITLE
Add real context and delight to the garden pyramid planner

### DIFF
--- a/apps/grn/src/components/CropPlanner/gardenPyramid.ts
+++ b/apps/grn/src/components/CropPlanner/gardenPyramid.ts
@@ -28,8 +28,15 @@ export interface PyramidTierMeta {
   /** Stable key used for class names + test ids. */
   key: string;
   name: string;
-  /** One-line hook shown on the pyramid band. */
+  /** Plain-language "what actually lives here" — the concrete context that
+   * de-abstracts the evocative name. Shown as the pyramid band subtitle. */
+  descriptor: string;
+  /** One-line hook shown in guidance copy. */
   tagline: string;
+  /** The one concrete thing this layer gives you (the "why it matters"). */
+  contribution: string;
+  /** A quick read on how much work/space this layer asks for. */
+  effort: string;
   /** Longer explanation shown in the tier detail panel. */
   description: string;
   /** Accent color for the band + cards (harmonizes with the GRN palette). */
@@ -44,7 +51,10 @@ export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
     level: 1,
     key: 'foundation',
     name: 'Foundation',
+    descriptor: 'Staples & storage crops',
     tagline: 'Staples you can feed yourself with',
+    contribution: 'Calories that keep for months',
+    effort: 'Plant once, harvest big',
     description:
       'Calorie-dense crops that store for months and form the base of a self-reliant garden. If you grow nothing else, grow these.',
     accent: '#7a533c',
@@ -61,7 +71,10 @@ export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
     level: 2,
     key: 'workhorse',
     name: 'Workhorse',
+    descriptor: 'Everyday vegetables',
     tagline: 'Where the garden replaces the grocery store',
+    contribution: 'The crops that shrink your grocery bill',
+    effort: 'Steady pickings all season',
     description:
       'High-yield, everyday vegetables that show up in most meals. These are the crops that start shrinking your grocery bill.',
     accent: '#426b3f',
@@ -78,7 +91,10 @@ export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
     level: 3,
     key: 'fresh',
     name: 'Fresh',
+    descriptor: 'Fast-growing greens',
     tagline: 'Grab-something-fresh-from-the-garden greens',
+    contribution: 'Salad minutes after picking',
+    effort: 'Quick wins, sow often',
     description:
       'Fast-growing greens you pick minutes before eating. Quick wins that keep you visiting the garden all season.',
     accent: '#6f8f5f',
@@ -95,7 +111,10 @@ export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
     level: 4,
     key: 'flavor',
     name: 'Flavor',
+    descriptor: 'Kitchen herbs',
     tagline: 'Herbs that make every meal sing',
+    contribution: 'The seasoning that lifts every meal',
+    effort: 'A little space goes far',
     description:
       'A little space goes a long way. Fresh herbs add the flavor that turns homegrown produce into great cooking.',
     accent: '#d8a741',
@@ -111,7 +130,10 @@ export const PYRAMID_TIERS: readonly PyramidTierMeta[] = [
     level: 5,
     key: 'joy',
     name: 'Joy',
+    descriptor: 'Fruit, berries & treats',
     tagline: 'Berries, treats, and experiments',
+    contribution: 'The crops you grow just for happy',
+    effort: 'Pure upside',
     description:
       'The fun layer. Berries, novelties, and the crops you grow just because they make you happy. Pure upside once the rest is in place.',
     accent: '#a3527e',

--- a/apps/grn/src/components/Planner/GardenPyramid.test.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.test.tsx
@@ -19,12 +19,14 @@ const EMPTY: Record<PyramidTier, PyramidCropVisual[]> = {
 function renderPyramid(args?: {
   cropsByTier?: Partial<Record<PyramidTier, PyramidCropVisual[]>>;
   activeTier?: PyramidTier;
+  nextTier?: PyramidTier | null;
   onSelectTier?: (tier: PyramidTier) => void;
 }) {
   return render(
     <GardenPyramid
       cropsByTier={{ ...EMPTY, ...args?.cropsByTier }}
       activeTier={args?.activeTier ?? 1}
+      nextTier={args?.nextTier}
       onSelectTier={args?.onSelectTier ?? (() => {})}
     />
   );
@@ -97,6 +99,27 @@ describe('GardenPyramid (isometric)', () => {
       'aria-pressed',
       'false'
     );
+  });
+
+  it('labels each band with its concrete descriptor for context', () => {
+    renderPyramid();
+    // The evocative name is paired with a plain-language descriptor so the
+    // pyramid reads without needing the side panel.
+    expect(screen.getByText('Staples & storage crops')).toBeInTheDocument();
+    expect(screen.getByText('Everyday vegetables')).toBeInTheDocument();
+    expect(screen.getByText('Kitchen herbs')).toBeInTheDocument();
+  });
+
+  it('gently highlights the recommended next tier', () => {
+    const { container } = renderPyramid({ activeTier: 1, nextTier: 3 });
+    const halos = container.querySelectorAll('.grn-iso-pyramid__next-halo');
+    // Exactly one halo, on the recommended (not the active) band.
+    expect(halos).toHaveLength(1);
+  });
+
+  it('does not highlight a next tier that is already active', () => {
+    const { container } = renderPyramid({ activeTier: 2, nextTier: 2 });
+    expect(container.querySelectorAll('.grn-iso-pyramid__next-halo')).toHaveLength(0);
   });
 
   it('previews ghost suggestions on empty tiers', () => {

--- a/apps/grn/src/components/Planner/GardenPyramid.tsx
+++ b/apps/grn/src/components/Planner/GardenPyramid.tsx
@@ -31,6 +31,9 @@ interface GardenPyramidProps {
   cropsByTier: Record<PyramidTier, PyramidCropVisual[]>;
   /** Currently focused layer. */
   activeTier: PyramidTier;
+  /** The layer the plan recommends growing next — gently highlighted so the
+   * pyramid itself points the way. */
+  nextTier?: PyramidTier | null;
   onSelectTier: (tier: PyramidTier) => void;
 }
 
@@ -102,7 +105,12 @@ function StandingCropRow({
  * hovering or selecting a band steps its full planting forward across
  * the band's width. Empty bands preview faded suggestions.
  */
-export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenPyramidProps) {
+export function GardenPyramid({
+  cropsByTier,
+  activeTier,
+  nextTier,
+  onSelectTier,
+}: GardenPyramidProps) {
   const metrics = pyramidMetrics();
   const [hoverTier, setHoverTier] = useState<PyramidTier | null>(null);
   const lawn = lawnRing();
@@ -162,6 +170,7 @@ export function GardenPyramid({ cropsByTier, activeTier, onSelectTier }: GardenP
             tier={tier}
             crops={cropsByTier[tier.level] ?? []}
             isActive={activeTier === tier.level}
+            isNext={nextTier === tier.level && activeTier !== tier.level}
             isShowcased={showcaseTier === tier.level}
             // The showcased planting below stands in front of this band's
             // lower edge; quiet the tagline there so the two never fight.
@@ -197,6 +206,7 @@ interface PyramidBandProps {
   tier: PyramidTierMeta;
   crops: PyramidCropVisual[];
   isActive: boolean;
+  isNext: boolean;
   isShowcased: boolean;
   taglineQuieted: boolean;
   onSelect: () => void;
@@ -207,6 +217,7 @@ function PyramidBand({
   tier,
   crops,
   isActive,
+  isNext,
   isShowcased,
   taglineQuieted,
   onSelect,
@@ -245,9 +256,11 @@ function PyramidBand({
   const restingOverflow = covered ? count - resting.length : 0;
   const hideResting = isShowcased && covered;
 
-  // Copy layout inside the band: the two widest bands fit a tagline.
-  const showTagline = tier.level <= 3;
-  const nameY = band.y + (showTagline ? 27 : band.h / 2 + 5);
+  // Copy layout inside the band: every band except the narrow apex fits a
+  // concrete descriptor beneath its name, so the context reads straight off
+  // the pyramid rather than only in the side panel.
+  const showDescriptor = tier.level <= 4;
+  const nameY = band.y + (showDescriptor ? 26 : band.h / 2 + 5);
   const badgeCx = band.x + band.w - 24;
 
   function handleKeyDown(event: KeyboardEvent) {
@@ -279,7 +292,11 @@ function PyramidBand({
       {ledges.map((quad, idx) => (
         <path key={idx} d={toPath(quad)} fill={tint(body, 0.28)} />
       ))}
-      {!covered && (
+      {/* Empty-state dashed frame — only on the narrow apex, where there is
+          no descriptor line for it to cut through. The wider empty bands
+          already read as empty from their paper fill, ghost suggestions and
+          "+" badge. */}
+      {!covered && !showDescriptor && (
         <rect
           x={band.x + 7}
           y={band.y + 7}
@@ -301,14 +318,14 @@ function PyramidBand({
       >
         {tier.name}
       </text>
-      {showTagline && (
+      {showDescriptor && (
         <text
           className={`grn-iso-pyramid__tagline ${taglineQuieted ? 'is-quiet' : ''}`.trim()}
           x={band.x + 18}
-          y={band.y + 45}
+          y={band.y + 44}
           fill={ink.subtitle}
         >
-          {tier.tagline}
+          {tier.descriptor}
         </text>
       )}
 
@@ -347,6 +364,21 @@ function PyramidBand({
           {covered ? count : '+'}
         </text>
       </g>
+
+      {isNext && (
+        <rect
+          className="grn-iso-pyramid__next-halo"
+          x={band.x - 4}
+          y={band.y - RELIEF.dy - 4}
+          width={band.w + RELIEF.dx + 8}
+          height={band.h + RELIEF.dy + 8}
+          rx={7}
+          fill="none"
+          stroke={tier.accent}
+          strokeWidth={2}
+          aria-hidden="true"
+        />
+      )}
 
       {isActive && (
         <rect

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -8,6 +8,7 @@ import { GardenPyramid, type PyramidCropVisual } from '../components/Planner/Gar
 import { PlanScore } from '../components/Planner/PlanScore';
 import { CropIcon } from '../components/CropPlanner/cropIcons';
 import { visualForCrop } from '../components/CropPlanner/cropVisuals';
+import { shade } from '../components/GardenMasterplan/palette';
 import {
   bucketCropsByTier,
   evaluatePlan,
@@ -145,6 +146,7 @@ export function PlannerPage() {
             <GardenPyramid
               cropsByTier={cropsByTier}
               activeTier={activeTier}
+              nextTier={evaluation.nextFocusTier}
               onSelectTier={setActiveTier}
             />
           </section>
@@ -182,6 +184,14 @@ export function PlannerPage() {
   );
 }
 
+// Ties each layer back to the "build from the base up" philosophy, so the
+// order of the pyramid reads as intentional rather than decorative.
+function positionNote(level: PyramidTier): string {
+  if (level === 1) return 'The base of the pyramid — everything else builds on this layer.';
+  if (level === 5) return 'The top of the pyramid — pure upside once the layers below are growing.';
+  return 'Grow this once the layers beneath it are underway — each layer rests on the one below.';
+}
+
 function toCropVisual(crop: GrowerCropItem): PyramidCropVisual {
   const visual = visualForCrop(crop.cropName, null);
   return {
@@ -212,21 +222,40 @@ function TierDetail({ tier, crops, isLoading, hasError, onRetry, onAddCrop }: Ti
   );
 
   return (
-    <div className="grn-planner__detail">
-      <header
-        className="grn-planner__detail-head"
-        style={{ ['--tier-accent' as string]: meta.accent }}
-      >
+    <div
+      className="grn-planner__detail"
+      style={{
+        ['--tier-accent' as string]: meta.accent,
+        // A darker shade of the same accent, used for small label text so it
+        // stays legible on the pale card even for the light gold/sage tiers.
+        ['--tier-ink' as string]: shade(meta.accent, 0.4),
+      }}
+    >
+      <header className="grn-planner__detail-head">
         <span className="grn-planner__detail-level" aria-hidden="true">
           {meta.level}
         </span>
         <div>
+          <p className="grn-planner__detail-position">Layer {meta.level} of 5</p>
           <h3 className="grn-planner__detail-name">{meta.name}</h3>
-          <p className="grn-planner__detail-tagline">{meta.tagline}</p>
+          <p className="grn-planner__detail-tagline">{meta.descriptor}</p>
         </div>
       </header>
 
+      <dl className="grn-planner__detail-facts">
+        <div className="grn-planner__fact">
+          <dt>Gives you</dt>
+          <dd>{meta.contribution}</dd>
+        </div>
+        <div className="grn-planner__fact">
+          <dt>Effort</dt>
+          <dd>{meta.effort}</dd>
+        </div>
+      </dl>
+
       <p className="grn-planner__detail-desc">{meta.description}</p>
+
+      <p className="grn-planner__detail-note">{positionNote(meta.level)}</p>
 
       <div className="grn-planner__detail-section">
         <h4 className="grn-planner__detail-subhead">

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -1840,21 +1840,47 @@ body {
   }
 }
 
+/* Soft, breathing halo on the layer the plan recommends growing next, so
+   the pyramid itself points to where to go. */
+.grn-iso-pyramid__next-halo {
+  opacity: 0.9;
+  stroke-dasharray: 3 5;
+  stroke-linecap: round;
+  animation: grn-next-halo 2.4s var(--easing-in-out, ease-in-out) infinite;
+  pointer-events: none;
+}
+
+@keyframes grn-next-halo {
+  0%,
+  100% {
+    opacity: 0.85;
+    stroke-width: 2;
+  }
+  50% {
+    opacity: 0.35;
+    stroke-width: 3;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .grn-iso-pyramid__showcase .mp-crop {
     animation: none;
+  }
+  .grn-iso-pyramid__next-halo {
+    animation: none;
+    opacity: 0.6;
   }
 }
 
 /* ── Tier detail panel ───────────────────────────────────────────── */
 
 .grn-planner__detail {
+  --tier-accent: var(--og-color-moss);
   display: grid;
   gap: 0.85rem;
 }
 
 .grn-planner__detail-head {
-  --tier-accent: var(--og-color-moss);
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -1873,6 +1899,15 @@ body {
   font-size: 1.2rem;
 }
 
+.grn-planner__detail-position {
+  margin: 0 0 0.15rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tier-ink, var(--tier-accent));
+}
+
 .grn-planner__detail-name {
   margin: 0;
   font-family: var(--og-font-display);
@@ -1886,10 +1921,53 @@ body {
   color: rgba(79, 56, 37, 0.75);
 }
 
+/* At-a-glance context: what the layer gives you and what it asks of you. */
+.grn-planner__detail-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.grn-planner__fact {
+  flex: 1 1 10rem;
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 0.7rem;
+  background: rgba(79, 56, 37, 0.045);
+  border: 1px solid rgba(79, 56, 37, 0.1);
+  border-left: 3px solid var(--tier-accent);
+}
+
+.grn-planner__fact dt {
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--tier-ink, var(--tier-accent));
+}
+
+.grn-planner__fact dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--og-color-soil);
+}
+
 .grn-planner__detail-desc {
   margin: 0;
   color: rgba(79, 56, 37, 0.85);
   max-width: 44rem;
+}
+
+.grn-planner__detail-note {
+  margin: 0;
+  padding-left: 0.7rem;
+  border-left: 2px solid var(--tier-accent, var(--og-color-moss));
+  font-size: 0.82rem;
+  font-style: italic;
+  color: rgba(79, 56, 37, 0.7);
 }
 
 .grn-planner__detail-section {


### PR DESCRIPTION
Each pyramid layer was labelled but the label alone (Foundation,
Workhorse, ...) is evocative rather than informative, and the only real
explanation lived in the side panel for the selected tier. This enriches
the concept without dropping the names people already find helpful.

Data model (gardenPyramid.ts):
- Add `descriptor` (plain-language "what actually lives here"),
  `contribution` (the one concrete benefit) and `effort` (a quick
  work/space read) to every tier.

Pyramid (GardenPyramid.tsx):
- Show the concrete descriptor as the band subtitle on all bands except
  the narrow apex, so the context reads straight off the illustration.
- Gently highlight the layer the plan recommends growing next with a
  soft, reduced-motion-aware halo, so the pyramid itself points the way.
- Drop the empty-state inner dashed frame on bands that now carry a
  descriptor (it collided with the subtitle); the paper fill, ghost
  suggestions and "+" badge already read as empty.

Detail panel (PlannerPage.tsx):
- Rework the tier card into a context card: a "Layer N of 5" position
  caption, the descriptor, a facts strip (gives you / effort) and an
  italic note tying each layer back to the build-from-the-base idea.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CHzDuXzJ2B5KAMTBjCSKqP