### PR TITLE
Fix atomic masterplan dimension editing and viewport stability

### DIFF
--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -126,8 +126,14 @@ function renderMasterplan(args?: {
   crops?: GrowerCropItem[];
   selected?: { kind: 'bed' | 'annotation'; id: string } | null;
   onSelect?: (next: unknown) => void;
-  onPatchBed?: (bedId: string, patch: Partial<GardenBed>) => void;
-  onPatchAnnotation?: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
+  onPatchBed?: (
+    bedId: string,
+    patch: Partial<GardenBed>
+  ) => void | Promise<boolean>;
+  onPatchAnnotation?: (
+    annotationId: string,
+    patch: Partial<GardenAnnotation>
+  ) => void | Promise<boolean>;
   onApplyTemplate?: (templateId: string) => Promise<void>;
   editing?: Partial<MasterplanEditing>;
 }) {
@@ -163,6 +169,7 @@ function renderMasterplan(args?: {
         onUndo: () => {},
         onRedo: () => {},
         isSaving: false,
+        saveError: null,
         ...args.editing,
       }
     : undefined;
@@ -263,18 +270,96 @@ describe('GardenMasterplan', () => {
     expect(panel).not.toHaveTextContent(/of this bed/);
   });
 
-  it('edits a bed dimension inline from the detail panel', async () => {
-    const onPatchBed = vi.fn();
+  it('keeps tabbed dimension edits together and applies one complete payload', async () => {
+    const user = userEvent.setup();
+    const onPatchBed = vi.fn().mockResolvedValue(true);
     renderMasterplan({
       selected: { kind: 'bed', id: 'bed-1' },
       onPatchBed,
       editing: {},
     });
     const lengthField = screen.getByLabelText(/length \(in\)/i);
-    await userEvent.clear(lengthField);
-    await userEvent.type(lengthField, '120');
-    fireEvent.blur(lengthField);
-    expect(onPatchBed).toHaveBeenCalledWith('bed-1', { lengthInches: 120 });
+    await user.clear(lengthField);
+    await user.type(lengthField, '120');
+    await user.tab();
+
+    expect(screen.getByLabelText(/length \(in\)/i)).toHaveValue(120);
+    expect(screen.getByLabelText(/width \(in\)/i)).toHaveFocus();
+    expect(onPatchBed).not.toHaveBeenCalled();
+
+    const widthField = screen.getByLabelText(/width \(in\)/i);
+    await user.clear(widthField);
+    await user.type(widthField, '72');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() =>
+      expect(onPatchBed).toHaveBeenCalledWith('bed-1', {
+        lengthInches: 120,
+        widthInches: 72,
+        rotationDeg: 0,
+      })
+    );
+  });
+
+  it('keeps an invalid dimension editable with an actionable error', async () => {
+    const user = userEvent.setup();
+    const onPatchBed = vi.fn().mockResolvedValue(true);
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      onPatchBed,
+      editing: {},
+    });
+
+    const lengthField = screen.getByLabelText(/length \(in\)/i);
+    await user.clear(lengthField);
+    await user.click(screen.getByRole('button', { name: /apply dimensions/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid length/i);
+    expect(lengthField).toHaveValue(null);
+    expect(onPatchBed).not.toHaveBeenCalled();
+  });
+
+  it('retains the complete dimension draft when saving fails', async () => {
+    const user = userEvent.setup();
+    const onPatchBed = vi.fn().mockResolvedValue(false);
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      onPatchBed,
+      editing: {},
+    });
+
+    const lengthField = screen.getByLabelText(/length \(in\)/i);
+    await user.clear(lengthField);
+    await user.type(lengthField, '120');
+    await user.click(screen.getByRole('button', { name: /apply dimensions/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn.t save/i);
+    expect(lengthField).toHaveValue(120);
+    expect(screen.getByRole('button', { name: /apply dimensions/i })).toBeEnabled();
+  });
+
+  it('applies overall garden width and height as one mobile-friendly action', async () => {
+    const user = userEvent.setup();
+    const onPatchCanvas = vi.fn().mockResolvedValue(true);
+    renderMasterplan({ editing: { onPatchCanvas } });
+
+    const widthField = screen.getByLabelText(/garden width/i);
+    await user.clear(widthField);
+    await user.type(widthField, '40 ft');
+    await user.tab();
+    expect(onPatchCanvas).not.toHaveBeenCalled();
+
+    const heightField = screen.getByLabelText(/garden height/i);
+    await user.clear(heightField);
+    await user.type(heightField, '30 ft');
+    await user.click(screen.getByRole('button', { name: /apply size/i }));
+
+    await waitFor(() =>
+      expect(onPatchCanvas).toHaveBeenCalledWith({
+        widthInches: 480,
+        heightInches: 360,
+      })
+    );
   });
 
   it('offers precise resize/rotate handles only for an editable selection', () => {

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -62,12 +62,16 @@ export interface MasterplanEditing {
   onAddCrop: (input: QuickAddCropInput) => Promise<void>;
   onDuplicate: () => void;
   /** Edit garden-level scale from the masterplan design bar. */
-  onPatchCanvas: (patch: { widthInches?: number; heightInches?: number }) => void;
+  onPatchCanvas: (patch: {
+    widthInches?: number;
+    heightInches?: number;
+  }) => void | Promise<boolean>;
   canUndo: boolean;
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
   isSaving: boolean;
+  saveError: string | null;
 }
 
 interface GardenMasterplanProps {
@@ -79,8 +83,14 @@ interface GardenMasterplanProps {
   selectedBed: GardenBed | undefined;
   selectedAnnotation: GardenAnnotation | undefined;
   onSelect: (next: SelectedItem) => void;
-  onPatchBed: (bedId: string, patch: Partial<GardenBed>) => void;
-  onPatchAnnotation: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
+  onPatchBed: (
+    bedId: string,
+    patch: Partial<GardenBed>
+  ) => void | Promise<boolean>;
+  onPatchAnnotation: (
+    annotationId: string,
+    patch: Partial<GardenAnnotation>
+  ) => void | Promise<boolean>;
   onApplyTemplate: (templateId: string) => Promise<void>;
   /** Present when the plan is an editable design surface. */
   editing?: MasterplanEditing;
@@ -169,7 +179,12 @@ export function GardenMasterplan({
     zoomOut,
     fitToScreen,
     shouldIgnoreClick,
-  } = useMapViewport(metrics.width, metrics.height);
+  } = useMapViewport(
+    metrics.width,
+    metrics.height,
+    metrics.originX,
+    metrics.originY
+  );
   const isEmpty = beds.length === 0 && annotations.length === 0;
   const plantedBedCount = useMemo(
     () => beds.filter((bed) => (cropsByBedId.get(bed.id)?.length ?? 0) > 0).length,
@@ -252,6 +267,7 @@ export function GardenMasterplan({
             onUndo={editing.onUndo}
             onRedo={editing.onRedo}
             isSaving={editing.isSaving}
+            saveError={editing.saveError}
             widthInches={canvas.widthInches}
             heightInches={canvas.heightInches}
             onPatchCanvas={editing.onPatchCanvas}
@@ -495,17 +511,19 @@ export function GardenMasterplan({
             editing
               ? {
                   isSaving: editing.isSaving,
+                  saveError: editing.saveError,
                   isVertexEditing: editing.mode === 'editing-vertices',
                   onToggleVertexEditing: () =>
                     editing.onSetMode(
                       editing.mode === 'editing-vertices' ? 'idle' : 'editing-vertices'
                     ),
                   onPatchBed: (patch) => {
-                    if (selectedBed) onPatchBed(selectedBed.id, patch);
+                    if (!selectedBed) return Promise.resolve(false);
+                    return onPatchBed(selectedBed.id, patch);
                   },
                   onPatchAnnotation: (patch) => {
-                    if (selectedAnnotation)
-                      onPatchAnnotation(selectedAnnotation.id, patch);
+                    if (!selectedAnnotation) return Promise.resolve(false);
+                    return onPatchAnnotation(selectedAnnotation.id, patch);
                   },
                   onDuplicate: editing.onDuplicate,
                   onDelete: () => {

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDesignBar.tsx
@@ -14,9 +14,18 @@ interface MasterplanDesignBarProps {
   onUndo: () => void;
   onRedo: () => void;
   isSaving: boolean;
+  saveError: string | null;
   widthInches: number;
   heightInches: number;
-  onPatchCanvas: (patch: { widthInches?: number; heightInches?: number }) => void;
+  onPatchCanvas: (patch: {
+    widthInches?: number;
+    heightInches?: number;
+  }) => void | Promise<boolean>;
+}
+
+interface SizeDraft {
+  width: string;
+  height: string;
 }
 
 // Accept "12", "12ft", "12 ft", "12'", or explicit inches like "144in".
@@ -55,31 +64,74 @@ export function MasterplanDesignBar({
   onUndo,
   onRedo,
   isSaving,
+  saveError,
   widthInches,
   heightInches,
   onPatchCanvas,
 }: MasterplanDesignBarProps) {
-  const [widthInput, setWidthInput] = useState(formatFeetFromInches(widthInches));
-  const [heightInput, setHeightInput] = useState(formatFeetFromInches(heightInches));
+  const [sizeDraft, setSizeDraft] = useState<SizeDraft | null>(null);
+  const [sizeError, setSizeError] = useState<string | null>(null);
+  const [isApplyingSize, setIsApplyingSize] = useState(false);
 
-  // Draft-on-focus: while a field is focused the local draft wins; on blur
-  // it commits (clamped) and re-formats, or reverts to the current value.
-  const widthValue = widthInput;
-  const heightValue = heightInput;
+  const widthValue = sizeDraft?.width ?? formatFeetFromInches(widthInches);
+  const heightValue = sizeDraft?.height ?? formatFeetFromInches(heightInches);
 
-  function commitScale(
-    field: 'widthInches' | 'heightInches',
-    raw: string,
-    current: number,
-    setInput: (value: string) => void
-  ) {
-    const next = parseFeetInches(raw);
-    if (next === null || next < 12 || next > 12_000) {
-      setInput(formatFeetFromInches(current));
+  function currentSizeDraft(): SizeDraft {
+    return {
+      width: formatFeetFromInches(widthInches),
+      height: formatFeetFromInches(heightInches),
+    };
+  }
+
+  function beginSizeEdit() {
+    setSizeDraft((current) => current ?? currentSizeDraft());
+  }
+
+  function updateSizeDraft(field: keyof SizeDraft, value: string) {
+    setSizeError(null);
+    setSizeDraft((current) => ({
+      ...(current ?? currentSizeDraft()),
+      [field]: value,
+    }));
+  }
+
+  function cancelSizeEdit() {
+    setSizeDraft(null);
+    setSizeError(null);
+  }
+
+  async function applySize() {
+    if (!sizeDraft || isApplyingSize) return;
+    const width = parseFeetInches(sizeDraft.width);
+    const height = parseFeetInches(sizeDraft.height);
+    if (width === null || width < 12 || width > 12_000) {
+      setSizeError('Enter a garden width between 1 ft and 1,000 ft.');
       return;
     }
-    setInput(formatFeetFromInches(next));
-    if (next !== current) onPatchCanvas({ [field]: next });
+    if (height === null || height < 12 || height > 12_000) {
+      setSizeError('Enter a garden height between 1 ft and 1,000 ft.');
+      return;
+    }
+
+    if (width === widthInches && height === heightInches) {
+      cancelSizeEdit();
+      return;
+    }
+
+    setIsApplyingSize(true);
+    try {
+      const saved = await onPatchCanvas({ widthInches: width, heightInches: height });
+      if (saved === false) {
+        setSizeError('We couldn\u2019t save the garden size. Check your connection and retry.');
+      } else {
+        setSizeDraft(null);
+        setSizeError(null);
+      }
+    } catch {
+      setSizeError('We couldn\u2019t save the garden size. Check your connection and retry.');
+    } finally {
+      setIsApplyingSize(false);
+    }
   }
 
   return (
@@ -177,7 +229,18 @@ export function MasterplanDesignBar({
 
       <span className="mp-design__divider" aria-hidden="true" />
 
-      <div className="mp-design__field mp-design__field--scale">
+      <div
+        className="mp-design__field mp-design__field--scale"
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            void applySize();
+          } else if (event.key === 'Escape') {
+            event.preventDefault();
+            cancelSizeEdit();
+          }
+        }}
+      >
         <span className="mp-design__field-label">Garden size</span>
         <div className="mp-design__scale">
           <input
@@ -186,13 +249,10 @@ export function MasterplanDesignBar({
             value={widthValue}
             aria-label="Garden width"
             inputMode="decimal"
-            onChange={(event) => setWidthInput(event.target.value)}
-            onBlur={(event) =>
-              commitScale('widthInches', event.target.value, widthInches, setWidthInput)
-            }
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') (event.target as HTMLInputElement).blur();
-            }}
+            onFocus={beginSizeEdit}
+            onChange={(event) => updateSizeDraft('width', event.target.value)}
+            aria-invalid={sizeError !== null}
+            aria-describedby={sizeError ? 'mp-garden-size-error' : undefined}
           />
           <span className="mp-design__scale-x" aria-hidden="true">
             ×
@@ -203,20 +263,42 @@ export function MasterplanDesignBar({
             value={heightValue}
             aria-label="Garden height"
             inputMode="decimal"
-            onChange={(event) => setHeightInput(event.target.value)}
-            onBlur={(event) =>
-              commitScale('heightInches', event.target.value, heightInches, setHeightInput)
-            }
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') (event.target as HTMLInputElement).blur();
-            }}
+            onFocus={beginSizeEdit}
+            onChange={(event) => updateSizeDraft('height', event.target.value)}
+            aria-invalid={sizeError !== null}
+            aria-describedby={sizeError ? 'mp-garden-size-error' : undefined}
           />
         </div>
+        {sizeError && (
+          <span id="mp-garden-size-error" className="mp-design__field-error" role="alert">
+            {sizeError}
+          </span>
+        )}
+        {sizeDraft && (
+          <div className="mp-design__scale-actions">
+            <button
+              type="button"
+              className="mp-design__scale-cancel"
+              onClick={cancelSizeEdit}
+              disabled={isApplyingSize}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="mp-design__scale-apply"
+              onClick={() => void applySize()}
+              disabled={isApplyingSize}
+            >
+              {isApplyingSize ? 'Applying…' : 'Apply size'}
+            </button>
+          </div>
+        )}
       </div>
 
-      {isSaving && (
-        <span className="mp-design__saving" role="status">
-          Saving…
+      {(isSaving || saveError) && (
+        <span className="mp-design__saving" role="status" data-error={!!saveError}>
+          {saveError ?? 'Saving…'}
         </span>
       )}
     </div>

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
@@ -55,13 +55,20 @@ function formatFeet(inches: number | null): string {
  */
 export interface MasterplanPanelEditing {
   isSaving: boolean;
+  saveError: string | null;
   isVertexEditing: boolean;
   onToggleVertexEditing: () => void;
-  onPatchBed: (patch: Partial<GardenBed>) => void;
-  onPatchAnnotation: (patch: Partial<GardenAnnotation>) => void;
+  onPatchBed: (patch: Partial<GardenBed>) => void | Promise<boolean>;
+  onPatchAnnotation: (patch: Partial<GardenAnnotation>) => void | Promise<boolean>;
   onDuplicate: () => void;
   onDelete: () => void;
   onAddCrop: (input: QuickAddCropInput) => Promise<void>;
+}
+
+interface DimensionDraft {
+  length: string;
+  width: string;
+  rotation: string;
 }
 
 interface MasterplanDetailPanelProps {
@@ -99,16 +106,15 @@ export function MasterplanDetailPanel({
   editing,
 }: MasterplanDetailPanelProps) {
   // The parent re-keys this panel on the selected element's id, so initial
-  // state is the right snapshot without a syncing effect. Length/width/
-  // rotation use draft-on-focus: while the field is focused the local draft
-  // wins; otherwise the input reads straight from the element, so
-  // handle-driven resizes show up live in the numbers.
+  // state is the right snapshot without a syncing effect. Length, width, and
+  // rotation become one local draft on focus; outside an active draft the
+  // inputs keep reflecting handle-driven changes from the scene.
   const [name, setName] = useState(bed?.name ?? annotation?.label ?? '');
   const [icon, setIcon] = useState(annotation?.icon ?? '');
   const [notes, setNotes] = useState(bed?.locationNotes ?? '');
-  const [draftLength, setDraftLength] = useState<string | null>(null);
-  const [draftWidth, setDraftWidth] = useState<string | null>(null);
-  const [draftRotation, setDraftRotation] = useState<string | null>(null);
+  const [dimensionDraft, setDimensionDraft] = useState<DimensionDraft | null>(null);
+  const [dimensionError, setDimensionError] = useState<string | null>(null);
+  const [isApplyingDimensions, setIsApplyingDimensions] = useState(false);
   const [soils, setSoils] = useState<string[]>(parseSoilField(bed?.soilType));
 
   if (!bed && !annotation) return null;
@@ -135,44 +141,102 @@ export function MasterplanDetailPanel({
   const capacity = bed ? bedCapacitySummary(bed, crops) : null;
 
   const lengthValue =
-    draftLength !== null
-      ? draftLength
+    dimensionDraft !== null
+      ? dimensionDraft.length
       : el.lengthInches !== null
         ? String(el.lengthInches)
         : '';
   const widthValue =
-    draftWidth !== null
-      ? draftWidth
+    dimensionDraft !== null
+      ? dimensionDraft.width
       : el.widthInches !== null
         ? String(el.widthInches)
         : '';
   const rotationValue =
-    draftRotation !== null ? draftRotation : String(Math.round(el.rotationDeg));
+    dimensionDraft !== null
+      ? dimensionDraft.rotation
+      : String(Math.round(el.rotationDeg));
 
-  function patch(next: Partial<GardenBed> & Partial<GardenAnnotation>) {
-    if (!editing) return;
-    if (bed) editing.onPatchBed(next);
-    else if (annotation) editing.onPatchAnnotation(next);
-  }
-
-  function commitDimension(field: 'lengthInches' | 'widthInches', raw: string) {
-    const trimmed = raw.trim();
-    if (trimmed === '') return;
-    const value = Number(trimmed);
-    if (!Number.isFinite(value) || value < 0) return;
-    if (isCircle) {
-      // Circles stay round: a single diameter drives both axes.
-      patch({ lengthInches: value, widthInches: value });
-    } else {
-      patch({ [field]: value });
+  async function patch(
+    next: Partial<GardenBed> & Partial<GardenAnnotation>
+  ): Promise<boolean> {
+    if (!editing) return false;
+    try {
+      const saved = bed
+        ? await editing.onPatchBed(next)
+        : annotation
+          ? await editing.onPatchAnnotation(next)
+          : false;
+      return saved !== false;
+    } catch {
+      return false;
     }
   }
 
-  function commitRotation(raw: string) {
-    const value = Number(raw.trim());
-    if (!Number.isFinite(value)) return;
-    const normalized = ((Math.round(value) % 360) + 360) % 360;
-    patch({ rotationDeg: normalized });
+  function currentDimensionDraft(): DimensionDraft {
+    return {
+      length: el.lengthInches !== null ? String(el.lengthInches) : '',
+      width: el.widthInches !== null ? String(el.widthInches) : '',
+      rotation: String(Math.round(el.rotationDeg)),
+    };
+  }
+
+  function beginDimensionEdit() {
+    setDimensionDraft((current) => current ?? currentDimensionDraft());
+  }
+
+  function updateDimensionDraft(field: keyof DimensionDraft, value: string) {
+    setDimensionError(null);
+    setDimensionDraft((current) => ({
+      ...(current ?? currentDimensionDraft()),
+      [field]: value,
+    }));
+  }
+
+  function cancelDimensionEdit() {
+    setDimensionDraft(null);
+    setDimensionError(null);
+  }
+
+  async function applyDimensions() {
+    if (!dimensionDraft || isApplyingDimensions) return;
+
+    const rotationRaw = dimensionDraft.rotation.trim();
+    const rotation = Number(rotationRaw);
+    if (rotationRaw === '' || !Number.isFinite(rotation)) {
+      setDimensionError('Enter a valid rotation in degrees.');
+      return;
+    }
+
+    const next: Partial<GardenBed> & Partial<GardenAnnotation> = {
+      rotationDeg: ((Math.round(rotation) % 360) + 360) % 360,
+    };
+    if (annotation?.shape !== 'line') {
+      const lengthRaw = dimensionDraft.length.trim();
+      const widthRaw = dimensionDraft.width.trim();
+      const length = Number(lengthRaw);
+      const width = Number(widthRaw);
+      if (lengthRaw === '' || !Number.isFinite(length) || length < 0) {
+        setDimensionError(`Enter a valid ${isCircle ? 'diameter' : 'length'} in inches.`);
+        return;
+      }
+      if (!isCircle && (widthRaw === '' || !Number.isFinite(width) || width < 0)) {
+        setDimensionError('Enter a valid width in inches.');
+        return;
+      }
+      next.lengthInches = length;
+      next.widthInches = isCircle ? length : width;
+    }
+
+    setIsApplyingDimensions(true);
+    const saved = await patch(next);
+    setIsApplyingDimensions(false);
+    if (saved) {
+      setDimensionDraft(null);
+      setDimensionError(null);
+    } else {
+      setDimensionError('We couldn\u2019t save these dimensions. Check your connection and retry.');
+    }
   }
 
   function convertToPolygon() {
@@ -276,73 +340,102 @@ export function MasterplanDetailPanel({
               </label>
             )}
 
-            {annotation?.shape === 'line' ? null : isCircle ? (
-              <label className="grn-designer-inspector__field">
-                <span>Diameter (in)</span>
-                <input
-                  type="number"
-                  min={0}
-                  value={lengthValue}
-                  onFocus={() =>
-                    setDraftLength(el.lengthInches !== null ? String(el.lengthInches) : '')
-                  }
-                  onChange={(e) => setDraftLength(e.target.value)}
-                  onBlur={(e) => {
-                    commitDimension('lengthInches', e.target.value);
-                    setDraftLength(null);
-                  }}
-                />
-              </label>
-            ) : (
-              <div className="grn-designer-inspector__row">
+            <div
+              className="mp-panel__dimension-editor"
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void applyDimensions();
+                } else if (event.key === 'Escape') {
+                  event.preventDefault();
+                  cancelDimensionEdit();
+                }
+              }}
+            >
+              {annotation?.shape === 'line' ? null : isCircle ? (
                 <label className="grn-designer-inspector__field">
-                  <span>Length (in)</span>
+                  <span>Diameter (in)</span>
                   <input
                     type="number"
                     min={0}
                     value={lengthValue}
-                    onFocus={() =>
-                      setDraftLength(el.lengthInches !== null ? String(el.lengthInches) : '')
+                    onFocus={beginDimensionEdit}
+                    onChange={(event) =>
+                      updateDimensionDraft('length', event.target.value)
                     }
-                    onChange={(e) => setDraftLength(e.target.value)}
-                    onBlur={(e) => {
-                      commitDimension('lengthInches', e.target.value);
-                      setDraftLength(null);
-                    }}
+                    aria-invalid={dimensionError !== null}
                   />
                 </label>
-                <label className="grn-designer-inspector__field">
-                  <span>Width (in)</span>
-                  <input
-                    type="number"
-                    min={0}
-                    value={widthValue}
-                    onFocus={() =>
-                      setDraftWidth(el.widthInches !== null ? String(el.widthInches) : '')
-                    }
-                    onChange={(e) => setDraftWidth(e.target.value)}
-                    onBlur={(e) => {
-                      commitDimension('widthInches', e.target.value);
-                      setDraftWidth(null);
-                    }}
-                  />
-                </label>
-              </div>
-            )}
+              ) : (
+                <div className="grn-designer-inspector__row">
+                  <label className="grn-designer-inspector__field">
+                    <span>Length (in)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={lengthValue}
+                      onFocus={beginDimensionEdit}
+                      onChange={(event) =>
+                        updateDimensionDraft('length', event.target.value)
+                      }
+                      aria-invalid={dimensionError !== null}
+                    />
+                  </label>
+                  <label className="grn-designer-inspector__field">
+                    <span>Width (in)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={widthValue}
+                      onFocus={beginDimensionEdit}
+                      onChange={(event) =>
+                        updateDimensionDraft('width', event.target.value)
+                      }
+                      aria-invalid={dimensionError !== null}
+                    />
+                  </label>
+                </div>
+              )}
 
-            <label className="grn-designer-inspector__field">
-              <span>Rotation (°)</span>
-              <input
-                type="number"
-                value={rotationValue}
-                onFocus={() => setDraftRotation(String(Math.round(el.rotationDeg)))}
-                onChange={(e) => setDraftRotation(e.target.value)}
-                onBlur={(e) => {
-                  commitRotation(e.target.value);
-                  setDraftRotation(null);
-                }}
-              />
-            </label>
+              <label className="grn-designer-inspector__field">
+                <span>Rotation (°)</span>
+                <input
+                  type="number"
+                  value={rotationValue}
+                  onFocus={beginDimensionEdit}
+                  onChange={(event) =>
+                    updateDimensionDraft('rotation', event.target.value)
+                  }
+                  aria-invalid={dimensionError !== null}
+                />
+              </label>
+
+              {dimensionError && (
+                <p className="mp-panel__field-error" role="alert">
+                  {dimensionError}
+                </p>
+              )}
+              {dimensionDraft && (
+                <div className="mp-panel__dimension-actions">
+                  <button
+                    type="button"
+                    className="mp-panel__dimension-cancel"
+                    onClick={cancelDimensionEdit}
+                    disabled={isApplyingDimensions}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="mp-panel__dimension-apply"
+                    onClick={() => void applyDimensions()}
+                    disabled={isApplyingDimensions}
+                  >
+                    {isApplyingDimensions ? 'Applying…' : 'Apply dimensions'}
+                  </button>
+                </div>
+              )}
+            </div>
 
             {bed && (
               <div className="grn-designer-inspector__field">
@@ -611,8 +704,13 @@ export function MasterplanDetailPanel({
               className="mp-panel__save-status"
               aria-live="polite"
               data-saving={editing.isSaving}
+              data-error={editing.saveError !== null}
             >
-              {editing.isSaving ? 'Saving…' : 'Saved'}
+              {editing.saveError
+                ? editing.saveError
+                : editing.isSaving
+                  ? 'Saving…'
+                  : 'Saved'}
             </span>
           </>
         )}

--- a/apps/grn/src/components/GardenMasterplan/footprints.ts
+++ b/apps/grn/src/components/GardenMasterplan/footprints.ts
@@ -67,6 +67,8 @@ const PAD_BOTTOM = 90;
 export interface SceneMetrics {
   width: number;
   height: number;
+  originX: number;
+  originY: number;
   viewBox: string;
 }
 
@@ -82,9 +84,13 @@ export function sceneMetrics(canvas: GardenCanvas): SceneMetrics {
   const b = boundsOf(corners);
   const width = b.maxX - b.minX + PAD_X * 2;
   const height = b.maxY - b.minY + PAD_TOP + PAD_BOTTOM;
+  const originX = b.minX - PAD_X;
+  const originY = b.minY - PAD_TOP;
   return {
     width,
     height,
-    viewBox: `${b.minX - PAD_X} ${b.minY - PAD_TOP} ${width} ${height}`,
+    originX,
+    originY,
+    viewBox: `${originX} ${originY} ${width} ${height}`,
   };
 }

--- a/apps/grn/src/components/GardenMasterplan/useMapViewport.test.ts
+++ b/apps/grn/src/components/GardenMasterplan/useMapViewport.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { preserveWorldPointAfterOriginChange } from './useMapViewport';
+
+describe('preserveWorldPointAfterOriginChange', () => {
+  it('keeps a projected garden point at the same screen position', () => {
+    const transform = { scale: 1.4, x: -210, y: 85 };
+    const previousOrigin = { x: -80, y: -160 };
+    const nextOrigin = { x: -320, y: -40 };
+    const worldPoint = { x: 125, y: 340 };
+    const before = {
+      x: transform.x + (worldPoint.x - previousOrigin.x) * transform.scale,
+      y: transform.y + (worldPoint.y - previousOrigin.y) * transform.scale,
+    };
+
+    const next = preserveWorldPointAfterOriginChange(
+      transform,
+      previousOrigin,
+      nextOrigin
+    );
+    const after = {
+      x: next.x + (worldPoint.x - nextOrigin.x) * next.scale,
+      y: next.y + (worldPoint.y - nextOrigin.y) * next.scale,
+    };
+
+    expect(after.x).toBeCloseTo(before.x);
+    expect(after.y).toBeCloseTo(before.y);
+    expect(next.scale).toBe(transform.scale);
+  });
+});

--- a/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
+++ b/apps/grn/src/components/GardenMasterplan/useMapViewport.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -27,10 +28,22 @@ const DRAG_THRESHOLD_PX = 6;
 // entirely off screen.
 const MIN_VISIBLE_PX = 90;
 
-interface Transform {
+export interface ViewportTransform {
   scale: number;
   x: number;
   y: number;
+}
+
+export function preserveWorldPointAfterOriginChange(
+  transform: ViewportTransform,
+  previousOrigin: { x: number; y: number },
+  nextOrigin: { x: number; y: number }
+): ViewportTransform {
+  return {
+    ...transform,
+    x: transform.x + (nextOrigin.x - previousOrigin.x) * transform.scale,
+    y: transform.y + (nextOrigin.y - previousOrigin.y) * transform.scale,
+  };
 }
 
 export interface MapViewport {
@@ -49,8 +62,13 @@ export interface MapViewport {
   shouldIgnoreClick: () => boolean;
 }
 
-export function useMapViewport(contentWidth: number, contentHeight: number): MapViewport {
-  const [transform, setTransform] = useState<Transform>({ scale: 1, x: 0, y: 0 });
+export function useMapViewport(
+  contentWidth: number,
+  contentHeight: number,
+  contentOriginX = 0,
+  contentOriginY = 0
+): MapViewport {
+  const [transform, setTransform] = useState<ViewportTransform>({ scale: 1, x: 0, y: 0 });
   // Latest-value mirror for gesture handlers. Synced in an effect (not
   // during render) per the react-hooks/refs rule; every consumer is an
   // event handler, which always fires after the commit that updates it.
@@ -64,6 +82,7 @@ export function useMapViewport(contentWidth: number, contentHeight: number): Map
   const sizeRef = useRef({ width: 0, height: 0 });
   const observerRef = useRef<ResizeObserver | null>(null);
   const fittedRef = useRef(false);
+  const originRef = useRef({ x: contentOriginX, y: contentOriginY });
 
   // Active pointers for pan/pinch. Pinch state snapshots the transform at
   // gesture start so each move is computed absolutely (no drift).
@@ -73,11 +92,11 @@ export function useMapViewport(contentWidth: number, contentHeight: number): Map
   const pinchRef = useRef<{
     startDistance: number;
     startMid: { x: number; y: number };
-    start: Transform;
+    start: ViewportTransform;
   } | null>(null);
 
   const clampTransform = useCallback(
-    (next: Transform): Transform => {
+    (next: ViewportTransform): ViewportTransform => {
       const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, next.scale));
       const { width, height } = sizeRef.current;
       if (width === 0 || height === 0) return { ...next, scale };
@@ -113,6 +132,24 @@ export function useMapViewport(contentWidth: number, contentHeight: number): Map
       y: (height - contentHeight * scale) / 2,
     });
   }, [contentWidth, contentHeight]);
+
+  // A changed garden size shifts the SVG viewBox origin. Compensate for that
+  // coordinate shift before paint so the same world point stays under the
+  // viewport center. Fitting remains an initial or explicit user action.
+  useLayoutEffect(() => {
+    const previousOrigin = originRef.current;
+    const nextOrigin = { x: contentOriginX, y: contentOriginY };
+    originRef.current = nextOrigin;
+    if (
+      !fittedRef.current ||
+      (previousOrigin.x === nextOrigin.x && previousOrigin.y === nextOrigin.y)
+    ) {
+      return;
+    }
+    setTransform((current) =>
+      preserveWorldPointAfterOriginChange(current, previousOrigin, nextOrigin)
+    );
+  }, [contentOriginX, contentOriginY]);
 
   const zoomAt = useCallback(
     (cx: number, cy: number, factor: number) => {

--- a/apps/grn/src/hooks/serialMutationQueue.test.ts
+++ b/apps/grn/src/hooks/serialMutationQueue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSerialMutationQueue } from './serialMutationQueue';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createSerialMutationQueue', () => {
+  it('waits for the older edit before sending the newer edit for the same entity', async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const worker = vi
+      .fn<(key: string, value: number) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const queue = createSerialMutationQueue(worker);
+
+    const older = queue.enqueue('bed-1', 120);
+    const newer = queue.enqueue('bed-1', 144);
+
+    await vi.waitFor(() => expect(worker).toHaveBeenCalledTimes(1));
+    expect(worker).toHaveBeenLastCalledWith('bed-1', 120);
+    expect(queue.hasPending('bed-1')).toBe(true);
+
+    first.resolve('older saved');
+    await older;
+    await Promise.resolve();
+
+    expect(worker).toHaveBeenCalledTimes(2);
+    expect(worker).toHaveBeenLastCalledWith('bed-1', 144);
+
+    second.resolve('newer saved');
+    await newer;
+    expect(queue.hasPending('bed-1')).toBe(false);
+  });
+
+  it('continues with the newest edit after an older edit fails', async () => {
+    const first = deferred<string>();
+    const worker = vi
+      .fn<(key: string, value: number) => Promise<string>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce('newest saved');
+    const queue = createSerialMutationQueue(worker);
+
+    const older = queue.enqueue('canvas', 360);
+    const newer = queue.enqueue('canvas', 480);
+    first.reject(new Error('network error'));
+
+    await expect(older).rejects.toThrow('network error');
+    await expect(newer).resolves.toBe('newest saved');
+    expect(worker).toHaveBeenNthCalledWith(2, 'canvas', 480);
+    expect(queue.hasPending()).toBe(false);
+  });
+
+  it('allows different entities to save in parallel', async () => {
+    const worker = vi.fn(async (key: string) => key);
+    const queue = createSerialMutationQueue(worker);
+
+    await Promise.all([queue.enqueue('bed-1', 120), queue.enqueue('bed-2', 144)]);
+
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/grn/src/hooks/serialMutationQueue.ts
+++ b/apps/grn/src/hooks/serialMutationQueue.ts
@@ -1,0 +1,42 @@
+/**
+ * Serializes mutations that target the same entity while allowing unrelated
+ * entities to save in parallel. This keeps an older response from arriving
+ * after and overwriting a newer edit to the same bed, annotation, or canvas.
+ */
+export interface SerialMutationQueue<Key, Payload, Result> {
+  enqueue: (key: Key, payload: Payload) => Promise<Result>;
+  hasPending: (key?: Key) => boolean;
+}
+
+export function createSerialMutationQueue<Key, Payload, Result>(
+  worker: (key: Key, payload: Payload) => Promise<Result>
+): SerialMutationQueue<Key, Payload, Result> {
+  const tails = new Map<Key, Promise<void>>();
+  const pending = new Map<Key, number>();
+
+  return {
+    enqueue(key, payload) {
+      pending.set(key, (pending.get(key) ?? 0) + 1);
+
+      const previous = tails.get(key) ?? Promise.resolve();
+      const result = previous.catch(() => undefined).then(() => worker(key, payload));
+      const tail = result.then(
+        () => undefined,
+        () => undefined
+      );
+      tails.set(key, tail);
+
+      return result.finally(() => {
+        const remaining = (pending.get(key) ?? 1) - 1;
+        if (remaining > 0) pending.set(key, remaining);
+        else pending.delete(key);
+        if (tails.get(key) === tail) tails.delete(key);
+      });
+    },
+
+    hasPending(key) {
+      if (key !== undefined) return (pending.get(key) ?? 0) > 0;
+      return pending.size > 0;
+    },
+  };
+}

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -55,6 +55,7 @@ import {
   rotateGeometry,
   type ElementGeometry,
 } from '../components/GardenMasterplan/isoTransform';
+import { createSerialMutationQueue } from './serialMutationQueue';
 
 const CANVAS_QUERY_KEY = ['my-garden-canvas'];
 const BEDS_QUERY_KEY = ['my-garden-beds'];
@@ -102,6 +103,7 @@ export interface UseGardenDesignerResult {
   isMobile: boolean;
   isEditable: boolean;
   isSaving: boolean;
+  saveError: string | null;
   addBed: (shape: BedShape) => Promise<void>;
   addCrop: (input: QuickAddCropPayload) => Promise<void>;
   duplicateSelected: () => Promise<void>;
@@ -118,7 +120,7 @@ export interface UseGardenDesignerResult {
       points: BedPolygonPoint[] | null;
     }
   ) => void;
-  patchBed: (bedId: string, patch: Partial<GardenBed>) => void;
+  patchBed: (bedId: string, patch: Partial<GardenBed>) => Promise<boolean>;
   updateBedPoints: (bedId: string, points: BedPolygonPoint[]) => void;
   deleteBed: (bedId: string) => Promise<void>;
   addAnnotation: (presetId: string) => Promise<void>;
@@ -134,9 +136,12 @@ export interface UseGardenDesignerResult {
       points: BedPolygonPoint[] | null;
     }
   ) => void;
-  patchAnnotation: (annotationId: string, patch: Partial<GardenAnnotation>) => void;
+  patchAnnotation: (
+    annotationId: string,
+    patch: Partial<GardenAnnotation>
+  ) => Promise<boolean>;
   deleteAnnotation: (annotationId: string) => Promise<void>;
-  patchCanvas: (patch: UpsertGardenCanvasRequest) => void;
+  patchCanvas: (patch: UpsertGardenCanvasRequest) => Promise<boolean>;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -284,12 +289,32 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   // count in state (rather than a ref) so React schedules a re-render
   // each time it changes.
   const [pendingMutations, setPendingMutations] = useState(0);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const startMutation = useCallback(() => {
     setPendingMutations((count) => count + 1);
   }, []);
   const endMutation = useCallback(() => {
     setPendingMutations((count) => Math.max(0, count - 1));
   }, []);
+
+  // Updates for one entity must reach the API in the same order the grower
+  // made them. Separate queues still let different beds save concurrently.
+  const [bedUpdateQueue] = useState(() =>
+    createSerialMutationQueue(
+      (bedId: string, payload: UpsertGardenBedRequest) => updateMyBed(bedId, payload)
+    )
+  );
+  const [annotationUpdateQueue] = useState(() =>
+    createSerialMutationQueue(
+      (annotationId: string, payload: UpsertGardenAnnotationRequest) =>
+        updateMyAnnotation(annotationId, payload)
+    )
+  );
+  const [canvasUpdateQueue] = useState(() =>
+    createSerialMutationQueue((_key: 'canvas', payload: UpsertGardenCanvasRequest) =>
+      updateMyGardenCanvas(payload)
+    )
+  );
 
   const createBedMutation = useMutation({
     mutationFn: createMyBed,
@@ -302,12 +327,13 @@ export function useGardenDesigner(): UseGardenDesignerResult {
 
   const updateBedMutation = useMutation({
     mutationFn: ({ bedId, payload }: { bedId: string; payload: UpsertGardenBedRequest }) =>
-      updateMyBed(bedId, payload),
+      bedUpdateQueue.enqueue(bedId, payload),
     onMutate: ({ bedId, payload }) => {
       startMutation();
-      const previous = queryClient.getQueryData<GardenBed[]>(BEDS_QUERY_KEY);
-      if (previous) {
-        const next = previous.map((bed) =>
+      setSaveError(null);
+      const current = queryClient.getQueryData<GardenBed[]>(BEDS_QUERY_KEY);
+      if (current) {
+        const next = current.map((bed) =>
           bed.id === bedId
             ? {
                 ...bed,
@@ -331,16 +357,18 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         );
         queryClient.setQueryData(BEDS_QUERY_KEY, next);
       }
-      return { previous };
     },
-    onError: (_err, _vars, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(BEDS_QUERY_KEY, context.previous);
-      }
+    onError: () => {
+      setSaveError('We couldn\u2019t save that change. Your edits are still available to retry.');
     },
-    onSettled: () => {
+    onSuccess: (_data, { bedId }) => {
+      if (!bedUpdateQueue.hasPending(bedId)) setSaveError(null);
+    },
+    onSettled: (_data, _error, { bedId }) => {
       endMutation();
-      void queryClient.invalidateQueries({ queryKey: BEDS_QUERY_KEY });
+      if (!bedUpdateQueue.hasPending(bedId)) {
+        void queryClient.invalidateQueries({ queryKey: BEDS_QUERY_KEY });
+      }
     },
   });
 
@@ -434,12 +462,13 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     }: {
       annotationId: string;
       payload: UpsertGardenAnnotationRequest;
-    }) => updateMyAnnotation(annotationId, payload),
+    }) => annotationUpdateQueue.enqueue(annotationId, payload),
     onMutate: ({ annotationId, payload }) => {
       startMutation();
-      const previous = queryClient.getQueryData<GardenAnnotation[]>(ANNOTATIONS_QUERY_KEY);
-      if (previous) {
-        const next = previous.map((a) =>
+      setSaveError(null);
+      const current = queryClient.getQueryData<GardenAnnotation[]>(ANNOTATIONS_QUERY_KEY);
+      if (current) {
+        const next = current.map((a) =>
           a.id === annotationId
             ? {
                 ...a,
@@ -459,16 +488,18 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         );
         queryClient.setQueryData(ANNOTATIONS_QUERY_KEY, next);
       }
-      return { previous };
     },
-    onError: (_err, _vars, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(ANNOTATIONS_QUERY_KEY, context.previous);
-      }
+    onError: () => {
+      setSaveError('We couldn\u2019t save that change. Your edits are still available to retry.');
     },
-    onSettled: () => {
+    onSuccess: (_data, { annotationId }) => {
+      if (!annotationUpdateQueue.hasPending(annotationId)) setSaveError(null);
+    },
+    onSettled: (_data, _error, { annotationId }) => {
       endMutation();
-      void queryClient.invalidateQueries({ queryKey: ANNOTATIONS_QUERY_KEY });
+      if (!annotationUpdateQueue.hasPending(annotationId)) {
+        void queryClient.invalidateQueries({ queryKey: ANNOTATIONS_QUERY_KEY });
+      }
     },
   });
 
@@ -497,9 +528,11 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   });
 
   const updateCanvasMutation = useMutation({
-    mutationFn: updateMyGardenCanvas,
+    mutationFn: (payload: UpsertGardenCanvasRequest) =>
+      canvasUpdateQueue.enqueue('canvas', payload),
     onMutate: (payload) => {
       startMutation();
+      setSaveError(null);
       const previous = queryClient.getQueryData<GardenCanvas>(CANVAS_QUERY_KEY);
       if (previous) {
         queryClient.setQueryData<GardenCanvas>(CANVAS_QUERY_KEY, {
@@ -514,16 +547,18 @@ export function useGardenDesigner(): UseGardenDesignerResult {
           northOffsetDeg: payload.northOffsetDeg ?? previous.northOffsetDeg,
         });
       }
-      return { previous };
     },
-    onError: (_err, _vars, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(CANVAS_QUERY_KEY, context.previous);
-      }
+    onError: () => {
+      setSaveError('We couldn\u2019t save that change. Your edits are still available to retry.');
+    },
+    onSuccess: () => {
+      if (!canvasUpdateQueue.hasPending('canvas')) setSaveError(null);
     },
     onSettled: () => {
       endMutation();
-      void queryClient.invalidateQueries({ queryKey: CANVAS_QUERY_KEY });
+      if (!canvasUpdateQueue.hasPending('canvas')) {
+        void queryClient.invalidateQueries({ queryKey: CANVAS_QUERY_KEY });
+      }
     },
   });
 
@@ -542,7 +577,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
   const commitBedUpdate = useCallback(
     (bed: GardenBed, payload: UpsertGardenBedRequest, coalesceKey?: string) => {
       const before = bedToUpsertPayload(bed);
-      if (JSON.stringify(before) === JSON.stringify(payload)) return;
+      if (JSON.stringify(before) === JSON.stringify(payload)) return Promise.resolve(true);
       record({
         kind: 'bed-update',
         id: bed.id,
@@ -551,7 +586,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         at: Date.now(),
         coalesceKey,
       });
-      updateBedMutation.mutate({ bedId: bed.id, payload });
+      return updateBedMutation
+        .mutateAsync({ bedId: bed.id, payload })
+        .then(() => true, () => false);
     },
     [record, updateBedMutation]
   );
@@ -563,7 +600,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
       coalesceKey?: string
     ) => {
       const before = annotationToUpsertPayload(annotation);
-      if (JSON.stringify(before) === JSON.stringify(payload)) return;
+      if (JSON.stringify(before) === JSON.stringify(payload)) return Promise.resolve(true);
       record({
         kind: 'annotation-update',
         id: annotation.id,
@@ -572,7 +609,9 @@ export function useGardenDesigner(): UseGardenDesignerResult {
         at: Date.now(),
         coalesceKey,
       });
-      updateAnnotationMutation.mutate({ annotationId: annotation.id, payload });
+      return updateAnnotationMutation
+        .mutateAsync({ annotationId: annotation.id, payload })
+        .then(() => true, () => false);
     },
     [record, updateAnnotationMutation]
   );
@@ -758,12 +797,13 @@ export function useGardenDesigner(): UseGardenDesignerResult {
 
   const patchBed = useCallback(
     (bedId: string, patch: Partial<GardenBed>) => {
-      const bed = beds.find((b) => b.id === bedId);
-      if (!bed) return;
+      const current = queryClient.getQueryData<GardenBed[]>(BEDS_QUERY_KEY) ?? beds;
+      const bed = current.find((b) => b.id === bedId);
+      if (!bed) return Promise.resolve(false);
       const payload = bedToUpsertPayload({ ...bed, ...patch });
-      commitBedUpdate(bed, payload);
+      return commitBedUpdate(bed, payload);
     },
-    [beds, commitBedUpdate]
+    [beds, commitBedUpdate, queryClient]
   );
 
   // Vertex edits arrive as the full reshaped point list (in the bed's
@@ -886,12 +926,14 @@ export function useGardenDesigner(): UseGardenDesignerResult {
 
   const patchAnnotation = useCallback(
     (annotationId: string, patch: Partial<GardenAnnotation>) => {
-      const annotation = annotations.find((a) => a.id === annotationId);
-      if (!annotation) return;
+      const current =
+        queryClient.getQueryData<GardenAnnotation[]>(ANNOTATIONS_QUERY_KEY) ?? annotations;
+      const annotation = current.find((a) => a.id === annotationId);
+      if (!annotation) return Promise.resolve(false);
       const payload = annotationToUpsertPayload({ ...annotation, ...patch });
-      commitAnnotationUpdate(annotation, payload);
+      return commitAnnotationUpdate(annotation, payload);
     },
-    [annotations, commitAnnotationUpdate]
+    [annotations, commitAnnotationUpdate, queryClient]
   );
 
   const deleteAnnotation = useCallback(
@@ -916,7 +958,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
 
   const patchCanvas = useCallback(
     (patch: UpsertGardenCanvasRequest) => {
-      updateCanvasMutation.mutate(patch);
+      return updateCanvasMutation.mutateAsync(patch).then(() => true, () => false);
     },
     [updateCanvasMutation]
   );
@@ -1500,6 +1542,7 @@ export function useGardenDesigner(): UseGardenDesignerResult {
     isMobile,
     isEditable,
     isSaving,
+    saveError,
     addBed,
     addCrop,
     duplicateSelected,

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -98,6 +98,7 @@ export function GardenDesignerPage() {
                 onUndo: designer.undo,
                 onRedo: designer.redo,
                 isSaving: designer.isSaving,
+                saveError: designer.saveError,
               }
             : undefined
         }

--- a/apps/grn/src/pages/SharedGardenPage.tsx
+++ b/apps/grn/src/pages/SharedGardenPage.tsx
@@ -181,7 +181,12 @@ function SharedGardenView({ snapshot }: { snapshot: SharedGardenSnapshot }) {
     zoomOut,
     fitToScreen,
     shouldIgnoreClick,
-  } = useMapViewport(metrics.width, metrics.height);
+  } = useMapViewport(
+    metrics.width,
+    metrics.height,
+    metrics.originX,
+    metrics.originY
+  );
 
   return (
     <div className="grn-shared-page">

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -3960,11 +3960,64 @@ body {
   color: rgba(79, 56, 37, 0.55);
 }
 
+.mp-design__field--scale {
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.mp-design__scale-actions {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.mp-design__scale-cancel,
+.mp-design__scale-apply {
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+  border-radius: var(--og-radius-pill);
+  padding: 0.28rem 0.55rem;
+  cursor: pointer;
+}
+
+.mp-design__scale-cancel {
+  color: var(--og-color-soil);
+  background: transparent;
+  border: 1px solid rgba(91, 58, 28, 0.22);
+}
+
+.mp-design__scale-apply {
+  color: #fffdf8;
+  background: var(--og-color-moss);
+  border: 1px solid var(--og-color-moss);
+}
+
+.mp-design__scale-cancel:disabled,
+.mp-design__scale-apply:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.mp-design__field-error {
+  flex-basis: 100%;
+  max-width: 18rem;
+  color: var(--og-color-error, #9d352b);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-align: center;
+}
+
 .mp-design__saving {
   font-size: 0.76rem;
   font-weight: 600;
   color: rgba(79, 56, 37, 0.6);
   padding-right: 0.25rem;
+}
+
+.mp-design__saving[data-error='true'] {
+  max-width: 18rem;
+  color: var(--og-color-error, #9d352b);
+  opacity: 1;
 }
 
 @media (max-width: 768px) {
@@ -4106,6 +4159,57 @@ body {
   margin: 0 0 0.75rem;
 }
 
+.mp-panel__dimension-editor {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0.2rem 0;
+  padding: 0.65rem;
+  border: 1px solid rgba(91, 58, 28, 0.14);
+  border-radius: var(--og-radius-md, 0.75rem);
+  background: rgba(91, 140, 74, 0.05);
+}
+
+.mp-panel__dimension-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.mp-panel__dimension-cancel,
+.mp-panel__dimension-apply {
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  border-radius: var(--og-radius-pill);
+  padding: 0.42rem 0.72rem;
+  cursor: pointer;
+}
+
+.mp-panel__dimension-cancel {
+  color: var(--og-color-soil);
+  background: transparent;
+  border: 1px solid rgba(91, 58, 28, 0.22);
+}
+
+.mp-panel__dimension-apply {
+  color: #fffdf8;
+  background: var(--og-color-moss);
+  border: 1px solid var(--og-color-moss);
+}
+
+.mp-panel__dimension-cancel:disabled,
+.mp-panel__dimension-apply:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.mp-panel__field-error {
+  margin: 0;
+  color: var(--og-color-error, #9d352b);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
 .mp-panel__save-status {
   display: block;
   margin-top: 0.5rem;
@@ -4115,6 +4219,11 @@ body {
 }
 
 .mp-panel__save-status[data-saving='true'] {
+  opacity: 1;
+}
+
+.mp-panel__save-status[data-error='true'] {
+  color: var(--og-color-error, #9d352b);
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary

- keep length, width, and rotation in one local draft while tabbing, then persist them in one explicit Apply action
- apply overall garden width and height as one validated payload, with retryable errors that do not discard the grower's draft
- serialize updates per bed, annotation, and canvas so older network responses cannot overtake newer edits
- preserve the viewed garden world point when canvas dimensions shift the isometric SVG origin
- retain existing undo/redo behavior and add keyboard, mobile-action, failure, ordering, and viewport regression coverage

Closes #370

## Verification

- `npm run typecheck --workspace @olivias/grn`
- `npm run lint --workspace @olivias/grn`
- `npm test --workspace @olivias/grn` (504 tests)
- `npm run build --workspace @olivias/grn`
- `cargo test` (GRN API)
- `cargo clippy --all-targets -- -D warnings` (GRN API)
- `git diff --check`

Postman was not run because this change does not add or modify an API endpoint or payload contract.

## Local environment note

`cargo fmt --all --check` is blocked in this Windows worktree because Git checked every existing Rust source file out with CRLF while the repository formatter requires LF. No Rust file is changed by this PR, and I left those files untouched to avoid a repository-wide newline rewrite. Please confirm the Linux formatting check is green before merging.
