### PR TITLE
Simplify GRN navigation around Today, Garden, and Share

### DIFF
--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -93,7 +93,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
           <p>
             Add your first crop and start mapping out beds, planting dates, and what you&apos;d like to grow.
           </p>
-          <Button variant="primary" size="md" onClick={() => navigate('/crops/new')}>
+          <Button variant="primary" size="md" onClick={() => navigate('/garden/plants/new')}>
             Add a crop
           </Button>
           {beds.length === 0 ? (
@@ -117,7 +117,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
               {beds.length ? ` · ${beds.length} bed${beds.length === 1 ? '' : 's'}` : ''}
             </p>
           </div>
-          <Button variant="primary" size="sm" onClick={() => navigate('/crops/new')}>
+          <Button variant="primary" size="sm" onClick={() => navigate('/garden/plants/new')}>
             + Add crop
           </Button>
         </div>
@@ -246,7 +246,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => navigate(`/crops/new?edit=${crop.id}`)}
+                    onClick={() => navigate(`/garden/plants/new?edit=${crop.id}`)}
                     disabled
                     title="Editing comes next — for now, remove and re-add"
                   >

--- a/apps/grn/src/pages/ConnectPage.test.tsx
+++ b/apps/grn/src/pages/ConnectPage.test.tsx
@@ -31,7 +31,7 @@ describe('ConnectPage', () => {
     renderPage();
     await userEvent.click(screen.getByRole('button', { name: /post a listing/i }));
     await waitFor(() => {
-      expect(screen.getByTestId('location')).toHaveTextContent('/listings');
+      expect(screen.getByTestId('location')).toHaveTextContent('/share/listings');
     });
   });
 
@@ -39,7 +39,7 @@ describe('ConnectPage', () => {
     renderPage();
     await userEvent.click(screen.getByRole('button', { name: /discover food/i }));
     await waitFor(() => {
-      expect(screen.getByTestId('location')).toHaveTextContent('/requests');
+      expect(screen.getByTestId('location')).toHaveTextContent('/share/find');
     });
   });
 });

--- a/apps/grn/src/pages/ConnectPage.tsx
+++ b/apps/grn/src/pages/ConnectPage.tsx
@@ -11,7 +11,7 @@ interface ConnectOption {
   to: string;
 }
 
-// The Connect hub is the single optional door to GRN's social surfaces. Each
+// The Share hub is the single optional door to GRN's social surfaces. Each
 // card routes to an existing page — nothing here is required for individual
 // growing, it's all opt-in.
 const options: ConnectOption[] = [
@@ -21,7 +21,7 @@ const options: ConnectOption[] = [
     title: 'Share your surplus',
     body: 'Post what’s ready to give away so nearby neighbors can pick it up before it goes to waste.',
     cta: 'Post a listing',
-    to: '/listings',
+    to: '/share/listings',
   },
   {
     id: 'find',
@@ -29,7 +29,7 @@ const options: ConnectOption[] = [
     title: 'Find food nearby',
     body: 'Browse fresh food shared by growers around you and request what your household needs.',
     cta: 'Discover food',
-    to: '/requests',
+    to: '/share/find',
   },
   {
     id: 'insights',
@@ -37,7 +37,7 @@ const options: ConnectOption[] = [
     title: 'What neighbors need',
     body: 'See what’s abundant and what’s scarce near you, and get ideas for what to plant next.',
     cta: 'View insights',
-    to: '/recommendations',
+    to: '/garden/plan/recommendations',
   },
   {
     id: 'garden-link',
@@ -68,8 +68,7 @@ export function ConnectPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Connect"
-        title="Connect with people nearby"
+        title="Share with people nearby"
         body="Growing is better together. Share what you have, find what you need, and stay in touch with your local food community — all optional."
       />
       <div className="grn-connect-grid">

--- a/apps/grn/src/pages/DashboardPage.test.tsx
+++ b/apps/grn/src/pages/DashboardPage.test.tsx
@@ -93,7 +93,7 @@ describe('DashboardPage', () => {
 
     await userEvent.click(cta);
     await waitFor(() => {
-      expect(screen.getByTestId('location')).toHaveTextContent('/crops/new');
+      expect(screen.getByTestId('location')).toHaveTextContent('/garden/plants/new');
     });
   });
 

--- a/apps/grn/src/pages/DashboardPage.tsx
+++ b/apps/grn/src/pages/DashboardPage.tsx
@@ -154,21 +154,21 @@ export function DashboardPage() {
             Add your first crop to track planting dates, beds, and harvests — and
             we&apos;ll surface what needs your attention right here.
           </p>
-          <Button variant="primary" size="md" onClick={() => navigate('/crops/new')}>
+          <Button variant="primary" size="md" onClick={() => navigate('/garden/plants/new')}>
             Add your first crop
           </Button>
         </Card>
       ) : (
         <div className="grn-stat-grid">
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/crops')}>
+          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plants')}>
             <span className="grn-stat-tile__value">{stats.growing.length}</span>
             <span className="grn-stat-tile__label">Growing now</span>
           </button>
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/crops')}>
+          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plants')}>
             <span className="grn-stat-tile__value">{stats.readySoon.length}</span>
             <span className="grn-stat-tile__label">Ready to harvest</span>
           </button>
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/planner')}>
+          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plan')}>
             <span className="grn-stat-tile__value">{stats.planning.length}</span>
             <span className="grn-stat-tile__label">Planning &amp; interested</span>
           </button>
@@ -180,7 +180,7 @@ export function DashboardPage() {
           <Card padding="6" className="grn-dashboard__panel">
             <div className="grn-dashboard__panel-head">
               <h3>Upcoming harvests</h3>
-              <Button variant="ghost" size="sm" onClick={() => navigate('/crops')}>
+              <Button variant="ghost" size="sm" onClick={() => navigate('/garden/plants')}>
                 My garden
               </Button>
             </div>
@@ -227,7 +227,7 @@ export function DashboardPage() {
           <Card padding="6" className="grn-dashboard__panel">
             <div className="grn-dashboard__panel-head">
               <h3>Upcoming reminders</h3>
-              <Button variant="ghost" size="sm" onClick={() => navigate('/reminders')}>
+              <Button variant="ghost" size="sm" onClick={() => navigate('/today/reminders')}>
                 Reminders
               </Button>
             </div>
@@ -260,8 +260,8 @@ export function DashboardPage() {
             all optional, whenever you&apos;re ready.
           </p>
         </div>
-        <Button variant="secondary" size="md" onClick={() => navigate('/connect')}>
-          Explore Connect
+        <Button variant="secondary" size="md" onClick={() => navigate('/share')}>
+          Explore Share
         </Button>
       </Card>
     </section>

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -61,8 +61,8 @@ export function NewCropPage() {
       <CropForm
         lockedBed={lockedBed}
         initialBedId={requestedBedId}
-        onCancel={() => navigate('/crops')}
-        onSuccess={() => navigate('/crops', { replace: true })}
+        onCancel={() => navigate('/garden/plants')}
+        onSuccess={() => navigate('/garden/plants', { replace: true })}
       />
     </section>
   );

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -158,7 +158,7 @@ export function PlannerPage() {
               isLoading={isLoadingCrops}
               hasError={isCropsError}
               onRetry={() => void refetchCrops()}
-              onAddCrop={() => navigate('/crops/new')}
+              onAddCrop={() => navigate('/garden/plants/new')}
             />
           </section>
         </div>

--- a/apps/grn/src/pages/SettingsPage.test.tsx
+++ b/apps/grn/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { UserProfile } from '../types/user';
+import { SettingsPage } from './SettingsPage';
+
+vi.mock('../components/Settings/ApiKeysPanel', () => ({
+  ApiKeysPanel: () => <div>API key management</div>,
+}));
+
+const user: UserProfile = {
+  id: 'grower-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  userType: 'grower',
+  onboardingCompleted: true,
+  subscription: { tier: 'supporter', subscriptionStatus: 'active' },
+  growerProfile: {
+    homeZone: '8a',
+    address: 'Redacted',
+    geoKey: 'geo',
+    shareRadiusMiles: 5,
+    isOrganization: false,
+    units: 'imperial',
+    locale: 'en-US',
+  },
+};
+
+describe('SettingsPage', () => {
+  it('provides addressable profile, membership, settings, and API key surfaces', () => {
+    const { container } = render(<SettingsPage user={user} />);
+
+    expect(container.querySelector('#profile')).toHaveTextContent('Ada Lovelace');
+    expect(container.querySelector('#membership')).toHaveTextContent('Supporter');
+    expect(container.querySelector('#api-keys')).toHaveTextContent('API key management');
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/pages/SettingsPage.tsx
+++ b/apps/grn/src/pages/SettingsPage.tsx
@@ -1,14 +1,59 @@
-import { SectionHeading } from '@olivias/ui';
+import { Card, Panel, SectionHeading } from '@olivias/ui';
 import { ApiKeysPanel } from '../components/Settings/ApiKeysPanel';
+import type { UserProfile } from '../types/user';
 
-export function SettingsPage() {
+const membershipLabels = {
+  free: 'Free',
+  supporter: 'Supporter',
+  pro: 'Pro',
+} as const;
+
+export interface SettingsPageProps {
+  user: UserProfile | null;
+}
+
+export function SettingsPage({ user }: SettingsPageProps) {
   return (
     <section className="grn-section">
       <SectionHeading
         title="Settings"
-        body="Manage your account and programmatic access to Good Roots Network."
+        body="Manage your profile, membership, and programmatic access to Good Roots Network."
       />
-      <ApiKeysPanel />
+
+      {user ? (
+        <div className="grn-settings-grid">
+          <Card id="profile" padding="6" className="grn-settings-card">
+            <h2>Profile</h2>
+            <dl className="grn-settings-details">
+              <dt>Name</dt>
+              <dd>{user.displayName?.trim() || 'Not provided'}</dd>
+              <dt>Email</dt>
+              <dd>{user.email || 'Not provided'}</dd>
+              <dt>Home zone</dt>
+              <dd>{user.growerProfile?.homeZone || 'Not provided'}</dd>
+            </dl>
+          </Card>
+
+          <Card id="membership" padding="6" className="grn-settings-card">
+            <h2>Membership</h2>
+            <dl className="grn-settings-details">
+              <dt>Plan</dt>
+              <dd>{membershipLabels[user.subscription.tier]}</dd>
+              <dt>Status</dt>
+              <dd>{user.subscription.subscriptionStatus || 'Active'}</dd>
+            </dl>
+          </Card>
+        </div>
+      ) : (
+        <Panel className="grn-page-error">
+          <h2>Profile unavailable</h2>
+          <p>Refresh the page to load your profile and membership details.</p>
+        </Panel>
+      )}
+
+      <div id="api-keys">
+        <ApiKeysPanel />
+      </div>
     </section>
   );
 }

--- a/apps/grn/src/shell/AppShell.test.tsx
+++ b/apps/grn/src/shell/AppShell.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { UserProfile } from '../types/user';
+import { AppShell } from './AppShell';
+
+const signOut = vi.fn();
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ signOut }),
+}));
+
+const user: UserProfile = {
+  id: 'grower-1',
+  email: 'ada@example.com',
+  displayName: 'Ada Lovelace',
+  userType: 'grower',
+  onboardingCompleted: true,
+  subscription: { tier: 'supporter' },
+};
+
+function renderShell(pathname = '/') {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <AppShell user={user}>
+        <p>Page content</p>
+      </AppShell>
+    </MemoryRouter>
+  );
+}
+
+describe('AppShell navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('renders the same three primary destinations in the desktop rail and mobile bar', () => {
+    renderShell();
+
+    const navigationRegions = screen.getAllByRole('navigation', { name: 'Primary navigation' });
+    expect(navigationRegions).toHaveLength(2);
+
+    for (const navigation of navigationRegions) {
+      const links = within(navigation).getAllByRole('link');
+      expect(links.map((link) => link.textContent?.trim())).toEqual(['Today', 'Garden', 'Share']);
+    }
+
+    expect(screen.queryByRole('link', { name: 'Planner' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /open sections/i })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['/today/reminders', 'Today'],
+    ['/garden/plants/new', 'Garden'],
+    ['/garden/plan/recommendations', 'Garden'],
+    ['/share/find', 'Share'],
+  ])('keeps %s nested under %s', (pathname, activeLabel) => {
+    renderShell(pathname);
+
+    const currentLinks = screen.getAllByRole('link', { current: 'page' });
+    expect(currentLinks).toHaveLength(2);
+    expect(currentLinks.every((link) => link.textContent?.trim() === activeLabel)).toBe(true);
+  });
+
+  it('keeps profile, membership, settings, and API keys in the avatar menu', async () => {
+    renderShell('/garden');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Ada Lovelace' }));
+
+    expect(screen.getByRole('menuitem', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Membership' })).toHaveAttribute(
+      'href',
+      '/settings#membership'
+    );
+    expect(screen.getByRole('menuitem', { name: 'Settings' })).toHaveAttribute('href', '/settings');
+    expect(screen.getByRole('menuitem', { name: 'API keys' })).toHaveAttribute(
+      'href',
+      '/settings#api-keys'
+    );
+  });
+
+  it('logs only the selected destination and navigation surface', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    renderShell();
+
+    const mobileNavigation = screen.getAllByRole('navigation', { name: 'Primary navigation' })[1];
+    await userEvent.click(within(mobileNavigation).getByRole('link', { name: 'Garden' }));
+
+    expect(info).toHaveBeenCalledWith(
+      '[navigation]',
+      'Primary navigation selected',
+      { destination: 'garden', source: 'mobile_bottom_nav' }
+    );
+    info.mockRestore();
+  });
+});

--- a/apps/grn/src/shell/AppShell.tsx
+++ b/apps/grn/src/shell/AppShell.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { AvatarMenu, SiteFooter, SiteHeader } from '@olivias/ui';
 import { brandConfig } from '../config/brand';
 import { useAuth } from '../hooks/useAuth';
 import type { UserProfile } from '../types/user';
+import { createLogger } from '../utils/logging';
+import {
+  PRIMARY_NAVIGATION,
+  isPrimaryDestinationActive,
+  type PrimaryDestinationId,
+} from './navigation';
 
 const NAV_EXPANDED_STORAGE_KEY = 'og-grn-nav-expanded';
+const navigationLogger = createLogger('navigation');
 
 const foundationLogo = '/images/icons/logo.svg';
 
@@ -19,132 +26,29 @@ const adminUrl = (import.meta.env.VITE_ADMIN_URL as string | undefined)?.replace
 const instagramUrl = 'https://instagram.com/oliviasgardentx';
 const facebookUrl = 'https://www.facebook.com/profile.php?id=100087146659606#';
 
-type NavItem = {
-  id: string;
-  path: string;
-  label: string;
-  icon: ReactNode;
+const navigationIcons: Record<PrimaryDestinationId, ReactNode> = {
+  today: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 3 3 10.5V21h6v-6h6v6h6V10.5L12 3Z" fill="currentColor" />
+    </svg>
+  ),
+  garden: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M12 3c-3.5 3-5 6-5 9a5 5 0 0 0 4 4.9V21a1 1 0 1 0 2 0v-4.1a5 5 0 0 0 4-4.9c0-3-1.5-6-5-9Zm0 12a3 3 0 0 1-3-3c0-1.7.8-3.6 3-5.7 2.2 2.1 3 4 3 5.7a3 3 0 0 1-3 3Z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  share: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        d="M18 16a3 3 0 0 0-2.4 1.2l-6.8-3.4a3.3 3.3 0 0 0 0-1.6l6.8-3.4A3 3 0 1 0 15 7a3.3 3.3 0 0 0 .1.8L8.4 11.2a3 3 0 1 0 0 3.6l6.7 3.4A3 3 0 1 0 18 16Z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
 };
-
-type NavSection = {
-  id: string;
-  /** Group heading shown when the rail is expanded; omit for the pinned utility group. */
-  title?: string;
-  /** Pins the group to the bottom of the rail (used for account/settings). */
-  pinBottom?: boolean;
-  items: NavItem[];
-};
-
-// Individual growing is the primary experience: everyone sees the same
-// "Your garden" tools, no participation-mode branching. "Connect" is a single
-// optional door to the social surfaces (share surplus, find food, community
-// insights, share garden) that used to be scattered across the menu.
-const gardenNavItems: NavItem[] = [
-  {
-    id: 'dashboard',
-    path: '/',
-    label: 'Home',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M12 3 3 10.5V21h6v-6h6v6h6V10.5L12 3Z" fill="currentColor" />
-      </svg>
-    ),
-  },
-  {
-    id: 'crops',
-    path: '/crops',
-    label: 'My garden',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M12 3c-3.5 3-5 6-5 9a5 5 0 0 0 4 4.9V21a1 1 0 1 0 2 0v-4.1a5 5 0 0 0 4-4.9c0-3-1.5-6-5-9Zm0 12a3 3 0 0 1-3-3c0-1.7.8-3.6 3-5.7 2.2 2.1 3 4 3 5.7a3 3 0 0 1-3 3Z"
-          fill="currentColor"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'planner',
-    path: '/planner',
-    label: 'Planner',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M12 3 2 20h20L12 3Zm0 4.6 2.1 3.6H9.9L12 7.6ZM8.7 13.2h6.6l1.5 2.6H7.2l1.5-2.6ZM5.6 18.6 6.6 17h10.8l1 1.6H5.6Z"
-          fill="currentColor"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'garden',
-    path: '/garden',
-    label: 'Designer',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M3 4h8v8H3V4Zm0 10h8v6H3v-6Zm10-10h8v6h-8V4Zm0 8h8v8h-8v-8Z"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.6"
-          strokeLinejoin="round"
-        />
-      </svg>
-    ),
-  },
-  {
-    id: 'reminders',
-    path: '/reminders',
-    label: 'Reminders',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M12 2a7 7 0 0 0-7 7v3.6L3 16h18l-2-3.4V9a7 7 0 0 0-7-7Zm0 19a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3Z"
-          fill="currentColor"
-        />
-      </svg>
-    ),
-  },
-];
-
-const connectNavItems: NavItem[] = [
-  {
-    id: 'connect',
-    path: '/connect',
-    label: 'Connect',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm0 2c-2.7 0-6 1.34-6 4v2h8v-2c0-.98.45-1.86 1.2-2.56A9.6 9.6 0 0 0 8 13Zm8 0c-.35 0-.74.02-1.15.06C16.16 13.9 17 15 17 16.5V19h7v-2c0-2.66-3.3-4-6-4Z"
-          fill="currentColor"
-        />
-      </svg>
-    ),
-  },
-];
-
-const settingsNavItems: NavItem[] = [
-  {
-    id: 'settings',
-    path: '/settings',
-    label: 'Settings',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path
-          d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Zm8.94 5a7.9 7.9 0 0 0 0-2l2-1.6-2-3.4-2.4 1a8 8 0 0 0-1.7-1l-.4-2.5H9.6l-.4 2.5a8 8 0 0 0-1.7 1l-2.4-1-2 3.4 2 1.6a7.9 7.9 0 0 0 0 2l-2 1.6 2 3.4 2.4-1a8 8 0 0 0 1.7 1l.4 2.5h4.8l.4-2.5a8 8 0 0 0 1.7-1l2.4 1 2-3.4-2-1.6Z"
-          fill="currentColor"
-        />
-      </svg>
-    ),
-  },
-];
-
-// Same structure for everyone — no dependence on user type.
-const navSections: NavSection[] = [
-  { id: 'garden', title: 'Your garden', items: gardenNavItems },
-  { id: 'connect', title: 'Connect', items: connectNavItems },
-  { id: 'account', pinBottom: true, items: settingsNavItems },
-];
 
 const footerLinks = [
   { id: 'home', label: 'Foundation home', href: `${foundationHomeUrl}/` },
@@ -194,51 +98,32 @@ export interface AppShellProps {
 export function AppShell({ user, children }: AppShellProps) {
   const { signOut } = useAuth();
   const [expanded, setExpanded] = useState<boolean>(() => readStoredExpanded());
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     try {
       window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, String(expanded));
     } catch {
-      // ignore storage errors
+      // Ignore storage errors; the rail remains usable for this session.
     }
   }, [expanded]);
-
-  // Close the mobile drawer whenever the route changes.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMobileNavOpen(false);
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (!mobileNavOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setMobileNavOpen(false);
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [mobileNavOpen]);
 
   const handleLogout = async () => {
     try {
       await signOut();
     } catch {
-      // ignore — page reload clears local session
+      // The foundation login navigation clears any remaining local session.
     }
     window.location.assign(`${foundationHomeUrl}/login`);
   };
 
-  const headerNavItems = foundationHeaderNav.map((item) => ({
-    id: item.id,
-    label: item.label,
-    href: item.href,
-  }));
+  const logDestination = (
+    destination: PrimaryDestinationId,
+    source: 'desktop_rail' | 'mobile_bottom_nav'
+  ) => {
+    navigationLogger.info('Primary navigation selected', { destination, source });
+  };
 
   const initials = getInitials(user?.displayName, user?.email);
   const displayName = user?.displayName?.trim() || user?.email || 'Member';
@@ -251,12 +136,19 @@ export function AppShell({ user, children }: AppShellProps) {
         brandEyebrow="Olivia's Garden Foundation"
         brandTitle={brandConfig.name.full}
         brandHref={`${foundationHomeUrl}/`}
-        navItems={headerNavItems}
+        navItems={foundationHeaderNav}
         utility={(
           <div className="og-auth-utility">
             <AvatarMenu
               initials={initials}
               label={displayName}
+              onProfile={() => navigate('/settings#profile')}
+              profileLabel="Profile"
+              personalLinks={[
+                { id: 'membership', label: 'Membership', href: '/settings#membership' },
+                { id: 'settings', label: 'Settings', href: '/settings' },
+                { id: 'api-keys', label: 'API keys', href: '/settings#api-keys' },
+              ]}
               appLinks={[
                 { id: 'foundation', label: 'Foundation home', href: foundationHomeUrl },
                 { id: 'admin', label: 'Admin console', href: adminUrl },
@@ -266,85 +158,33 @@ export function AppShell({ user, children }: AppShellProps) {
           </div>
         )}
       />
-      <div
-        className={`grn-shell-body ${expanded ? 'is-expanded' : 'is-collapsed'} ${mobileNavOpen ? 'is-mobile-nav-open' : ''}`.trim()}
-      >
-        <button
-          type="button"
-          className="grn-mobile-nav-trigger"
-          aria-expanded={mobileNavOpen}
-          aria-controls="grn-vertical-nav"
-          aria-label="Open sections"
-          onClick={() => setMobileNavOpen(true)}
+
+      <div className={`grn-shell-body ${expanded ? 'is-expanded' : 'is-collapsed'}`}>
+        <nav
+          className={`grn-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'}`}
+          aria-label="Primary navigation"
         >
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M4 7h16v2H4V7Zm0 4h16v2H4v-2Zm0 4h16v2H4v-2Z" fill="currentColor" />
-          </svg>
-          <span>Sections</span>
-        </button>
-
-        <button
-          type="button"
-          className="grn-mobile-nav-backdrop"
-          aria-label="Close sections"
-          tabIndex={mobileNavOpen ? 0 : -1}
-          onClick={() => setMobileNavOpen(false)}
-        />
-
-        <aside
-          id="grn-vertical-nav"
-          className={`grn-vertical-nav ${expanded ? 'is-expanded' : 'is-collapsed'} ${mobileNavOpen ? 'is-mobile-open' : ''}`.trim()}
-          aria-label="Good Roots Network sections"
-        >
-          <div className="grn-vertical-nav__mobile-header">
-            <span className="grn-vertical-nav__mobile-title">Sections</span>
-            <button
-              type="button"
-              className="grn-vertical-nav__mobile-close"
-              aria-label="Close sections"
-              onClick={() => setMobileNavOpen(false)}
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path
-                  d="M6.4 5 5 6.4 10.6 12 5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4L13.4 12 19 6.4 17.6 5 12 10.6 6.4 5Z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-
-          <div className="grn-vertical-nav__scroll">
-            {navSections.map((section) => (
-              <div
-                key={section.id}
-                className={`grn-vertical-nav__section ${section.pinBottom ? 'grn-vertical-nav__section--pinned' : ''}`.trim()}
-              >
-                {section.title ? (
-                  <p className="grn-vertical-nav__section-title" aria-hidden="true">
-                    {section.title}
-                  </p>
-                ) : null}
-                <ul className="grn-vertical-nav__list" role="list" aria-label={section.title}>
-                  {section.items.map((item) => (
-                    <li key={item.id}>
-                      <NavLink
-                        to={item.path}
-                        end={item.path === '/'}
-                        className={({ isActive }) =>
-                          `grn-vertical-nav__link ${isActive ? 'is-active' : ''}`.trim()
-                        }
-                        title={expanded ? undefined : item.label}
-                        onClick={() => setMobileNavOpen(false)}
-                      >
-                        <span className="grn-vertical-nav__icon" aria-hidden="true">{item.icon}</span>
-                        <span className="grn-vertical-nav__label">{item.label}</span>
-                      </NavLink>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
+          <ul className="grn-vertical-nav__list" role="list">
+            {PRIMARY_NAVIGATION.map((item) => {
+              const isActive = isPrimaryDestinationActive(item.id, location.pathname);
+              return (
+                <li key={item.id}>
+                  <Link
+                    to={item.path}
+                    className={`grn-vertical-nav__link ${isActive ? 'is-active' : ''}`.trim()}
+                    aria-current={isActive ? 'page' : undefined}
+                    title={expanded ? undefined : item.label}
+                    onClick={() => logDestination(item.id, 'desktop_rail')}
+                  >
+                    <span className="grn-vertical-nav__icon" aria-hidden="true">
+                      {navigationIcons[item.id]}
+                    </span>
+                    <span className="grn-vertical-nav__label">{item.label}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
 
           <button
             type="button"
@@ -363,14 +203,33 @@ export function AppShell({ user, children }: AppShellProps) {
               />
             </svg>
           </button>
-        </aside>
+        </nav>
 
         <main className="grn-shell-main">
-          <div className="grn-shell-main__inner">
-            {children}
-          </div>
+          <div className="grn-shell-main__inner">{children}</div>
         </main>
       </div>
+
+      <nav className="grn-bottom-nav" aria-label="Primary navigation">
+        {PRIMARY_NAVIGATION.map((item) => {
+          const isActive = isPrimaryDestinationActive(item.id, location.pathname);
+          return (
+            <Link
+              key={item.id}
+              to={item.path}
+              className={`grn-bottom-nav__link ${isActive ? 'is-active' : ''}`.trim()}
+              aria-current={isActive ? 'page' : undefined}
+              onClick={() => logDestination(item.id, 'mobile_bottom_nav')}
+            >
+              <span className="grn-bottom-nav__icon" aria-hidden="true">
+                {navigationIcons[item.id]}
+              </span>
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
       <SiteFooter
         meta={`${new Date().getFullYear()} Olivia's Garden Foundation. All rights reserved.`}
         links={footerLinks}

--- a/apps/grn/src/shell/AuthenticatedRoot.test.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.test.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import { AuthenticatedRoot } from './AuthenticatedRoot';
+
+vi.mock('../hooks/useUser', () => ({
+  useUser: () => ({
+    user: {
+      id: 'grower-1',
+      email: 'ada@example.com',
+      displayName: 'Ada Lovelace',
+      userType: 'grower',
+      onboardingCompleted: true,
+      subscription: { tier: 'free' },
+    },
+    isLoading: false,
+    refreshUser: vi.fn(),
+  }),
+}));
+
+vi.mock('./AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/Onboarding/OnboardingGuard', () => ({
+  OnboardingGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../pages/DashboardPage', () => ({ DashboardPage: () => <h1>Today page</h1> }));
+vi.mock('../pages/CropsPage', () => ({ CropsPage: () => <h1>Plants page</h1> }));
+vi.mock('../pages/NewCropPage', () => ({ NewCropPage: () => <h1>New plant page</h1> }));
+vi.mock('../pages/PlannerPage', () => ({ PlannerPage: () => <h1>Plan page</h1> }));
+vi.mock('../pages/RecommendationsPage', () => ({
+  RecommendationsPage: () => <h1>Recommendations page</h1>,
+}));
+vi.mock('../pages/GardenDesignerPage', () => ({
+  GardenDesignerPage: () => <h1>Garden map page</h1>,
+}));
+vi.mock('../pages/ConnectPage', () => ({ ConnectPage: () => <h1>Share page</h1> }));
+vi.mock('../pages/ListingsPage', () => ({ ListingsPage: () => <h1>Listings page</h1> }));
+vi.mock('../pages/RequestsPage', () => ({ RequestsPage: () => <h1>Find food page</h1> }));
+vi.mock('../pages/RemindersPage', () => ({ RemindersPage: () => <h1>Reminders page</h1> }));
+vi.mock('../pages/SettingsPage', () => ({ SettingsPage: () => <h1>Settings page</h1> }));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>;
+}
+
+function BackButton() {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate(-1)}>Back</button>;
+}
+
+function renderRoot(initialEntries: string[], initialIndex = initialEntries.length - 1) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      <AuthenticatedRoot />
+      <LocationDisplay />
+      <BackButton />
+    </MemoryRouter>
+  );
+}
+
+describe('AuthenticatedRoot routes', () => {
+  it.each([
+    ['/today/reminders', 'Reminders page'],
+    ['/garden', 'Garden map page'],
+    ['/garden/plants', 'Plants page'],
+    ['/garden/plants/new', 'New plant page'],
+    ['/garden/plan', 'Plan page'],
+    ['/garden/plan/recommendations', 'Recommendations page'],
+    ['/share', 'Share page'],
+    ['/share/listings', 'Listings page'],
+    ['/share/find', 'Find food page'],
+    ['/settings', 'Settings page'],
+  ])('supports a direct visit to %s', async (pathname, heading) => {
+    renderRoot([pathname]);
+    expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+  });
+
+  it('moves a legacy deep link to its canonical page without losing state', async () => {
+    renderRoot(['/planner?season=fall#workhorses']);
+
+    expect(await screen.findByRole('heading', { name: 'Plan page' })).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plan?season=fall#workhorses'
+    );
+  });
+
+  it('replaces a legacy history entry so Back returns to the previous page', async () => {
+    renderRoot(['/', '/requests']);
+
+    expect(await screen.findByRole('heading', { name: 'Find food page' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Today page' })).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('location')).toHaveTextContent(/^\/$/);
+  });
+});

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -4,6 +4,8 @@ import { useUser } from '../hooks/useUser';
 import { PlantLoader } from '../components/branding/PlantLoader';
 import { AppShell } from './AppShell';
 import { OnboardingGuard } from '../components/Onboarding/OnboardingGuard';
+import { LegacyRouteRedirect } from './LegacyRouteRedirect';
+import { LEGACY_ROUTE_REDIRECTS } from './navigation';
 
 const DashboardPage = lazy(() =>
   import('../pages/DashboardPage').then((m) => ({ default: m.DashboardPage }))
@@ -67,16 +69,19 @@ export function AuthenticatedRoot() {
           <OnboardingGuard user={user} refreshUser={refreshUser}>
             <Routes>
               <Route path="/" element={<DashboardPage />} />
-              <Route path="/crops" element={<CropsPage />} />
-              <Route path="/crops/new" element={<NewCropPage />} />
-              <Route path="/planner" element={<PlannerPage />} />
-              <Route path="/recommendations" element={<RecommendationsPage />} />
+              <Route path="/today/reminders" element={<RemindersPage />} />
               <Route path="/garden" element={<GardenDesignerPage />} />
-              <Route path="/listings" element={<ListingsPage />} />
-              <Route path="/connect" element={<ConnectPage />} />
-              <Route path="/requests" element={<RequestsPage />} />
-              <Route path="/reminders" element={<RemindersPage />} />
-              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/garden/plants" element={<CropsPage />} />
+              <Route path="/garden/plants/new" element={<NewCropPage />} />
+              <Route path="/garden/plan" element={<PlannerPage />} />
+              <Route path="/garden/plan/recommendations" element={<RecommendationsPage />} />
+              <Route path="/share" element={<ConnectPage />} />
+              <Route path="/share/listings" element={<ListingsPage />} />
+              <Route path="/share/find" element={<RequestsPage />} />
+              <Route path="/settings" element={<SettingsPage user={user} />} />
+              {Object.entries(LEGACY_ROUTE_REDIRECTS).map(([from, to]) => (
+                <Route key={from} path={from} element={<LegacyRouteRedirect to={to} />} />
+              ))}
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </OnboardingGuard>

--- a/apps/grn/src/shell/LegacyRouteRedirect.test.tsx
+++ b/apps/grn/src/shell/LegacyRouteRedirect.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { LegacyRouteRedirect } from './LegacyRouteRedirect';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>;
+}
+
+describe('LegacyRouteRedirect', () => {
+  it('replaces the old route while preserving query parameters and anchors', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter initialEntries={['/crops/new?edit=crop-1#details']}>
+        <Routes>
+          <Route path="/crops/new" element={<LegacyRouteRedirect to="/garden/plants/new" />} />
+          <Route path="*" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/garden/plants/new?edit=crop-1#details'
+      );
+    });
+    expect(info).toHaveBeenCalledWith(
+      '[navigation]',
+      'Legacy route redirected',
+      expect.objectContaining({
+        fromRoute: '/crops/new',
+        toRoute: '/garden/plants/new',
+      })
+    );
+
+    info.mockRestore();
+  });
+});

--- a/apps/grn/src/shell/LegacyRouteRedirect.tsx
+++ b/apps/grn/src/shell/LegacyRouteRedirect.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { createLogger } from '../utils/logging';
+
+const navigationLogger = createLogger('navigation');
+
+export interface LegacyRouteRedirectProps {
+  to: string;
+}
+
+/** Preserve query parameters and anchors when moving old bookmarks to the new IA. */
+export function LegacyRouteRedirect({ to }: LegacyRouteRedirectProps) {
+  const location = useLocation();
+  const destination = `${to}${location.search}${location.hash}`;
+
+  useEffect(() => {
+    navigationLogger.info('Legacy route redirected', {
+      fromRoute: location.pathname,
+      toRoute: to,
+    });
+  }, [location.pathname, to]);
+
+  return <Navigate to={destination} replace />;
+}

--- a/apps/grn/src/shell/navigation.test.ts
+++ b/apps/grn/src/shell/navigation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LEGACY_ROUTE_REDIRECTS,
+  PRIMARY_NAVIGATION,
+  isPrimaryDestinationActive,
+} from './navigation';
+
+describe('primary navigation', () => {
+  it('exposes only the three grower destinations', () => {
+    expect(PRIMARY_NAVIGATION).toEqual([
+      { id: 'today', label: 'Today', path: '/' },
+      { id: 'garden', label: 'Garden', path: '/garden' },
+      { id: 'share', label: 'Share', path: '/share' },
+    ]);
+  });
+
+  it.each([
+    ['today', '/', true],
+    ['today', '/today/reminders', true],
+    ['today', '/garden', false],
+    ['garden', '/garden', true],
+    ['garden', '/garden/plants/new', true],
+    ['garden', '/garden/plan/recommendations', true],
+    ['garden', '/share', false],
+    ['share', '/share', true],
+    ['share', '/share/find', true],
+    ['share', '/settings', false],
+  ] as const)('marks %s active for %s as %s', (destination, pathname, expected) => {
+    expect(isPrimaryDestinationActive(destination, pathname)).toBe(expected);
+  });
+
+  it('keeps every prior feature path addressable through a canonical destination', () => {
+    expect(LEGACY_ROUTE_REDIRECTS).toEqual({
+      '/crops': '/garden/plants',
+      '/crops/new': '/garden/plants/new',
+      '/planner': '/garden/plan',
+      '/recommendations': '/garden/plan/recommendations',
+      '/listings': '/share/listings',
+      '/connect': '/share',
+      '/requests': '/share/find',
+      '/reminders': '/today/reminders',
+    });
+  });
+});

--- a/apps/grn/src/shell/navigation.ts
+++ b/apps/grn/src/shell/navigation.ts
@@ -1,0 +1,43 @@
+export type PrimaryDestinationId = 'today' | 'garden' | 'share';
+
+export interface PrimaryNavigationItem {
+  id: PrimaryDestinationId;
+  label: string;
+  path: string;
+}
+
+/**
+ * The signed-in information architecture has three stable destinations.
+ * Feature pages remain nested beneath these paths instead of becoming
+ * additional top-level menu choices.
+ */
+export const PRIMARY_NAVIGATION: readonly PrimaryNavigationItem[] = [
+  { id: 'today', label: 'Today', path: '/' },
+  { id: 'garden', label: 'Garden', path: '/garden' },
+  { id: 'share', label: 'Share', path: '/share' },
+];
+
+export const LEGACY_ROUTE_REDIRECTS = {
+  '/crops': '/garden/plants',
+  '/crops/new': '/garden/plants/new',
+  '/planner': '/garden/plan',
+  '/recommendations': '/garden/plan/recommendations',
+  '/listings': '/share/listings',
+  '/connect': '/share',
+  '/requests': '/share/find',
+  '/reminders': '/today/reminders',
+} as const;
+
+export function isPrimaryDestinationActive(
+  destination: PrimaryDestinationId,
+  pathname: string
+): boolean {
+  switch (destination) {
+    case 'today':
+      return pathname === '/' || pathname.startsWith('/today/');
+    case 'garden':
+      return pathname === '/garden' || pathname.startsWith('/garden/');
+    case 'share':
+      return pathname === '/share' || pathname.startsWith('/share/');
+  }
+}

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -61,100 +61,6 @@ body {
   align-content: start;
 }
 
-/* ── Mobile drawer trigger + backdrop (hidden on desktop) ─────────── */
-
-.grn-mobile-nav-trigger {
-  display: none;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.85rem;
-  border: 1px solid rgba(79, 56, 37, 0.16);
-  border-radius: 999px;
-  background: rgba(255, 252, 246, 0.95);
-  color: var(--og-color-soil);
-  font: inherit;
-  font-weight: 600;
-  font-size: 0.9rem;
-  cursor: pointer;
-  box-shadow: 0 4px 14px rgba(38, 23, 15, 0.08);
-  touch-action: manipulation;
-}
-
-.grn-mobile-nav-trigger:hover,
-.grn-mobile-nav-trigger:focus-visible {
-  background: var(--og-color-paper);
-  border-color: var(--og-color-moss);
-  color: var(--og-color-moss);
-  outline: none;
-}
-
-.grn-mobile-nav-trigger svg {
-  width: 1.15rem;
-  height: 1.15rem;
-}
-
-.grn-mobile-nav-backdrop {
-  display: none;
-  position: fixed;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-  padding: 0;
-  background: rgba(38, 23, 15, 0.45);
-  cursor: pointer;
-  z-index: 40;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--duration-base, 200ms) var(--easing-out, ease);
-}
-
-.grn-shell-body.is-mobile-nav-open .grn-mobile-nav-backdrop {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.grn-vertical-nav__mobile-header {
-  display: none;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.25rem 0.35rem 0.85rem;
-  border-bottom: 1px solid rgba(79, 56, 37, 0.08);
-  margin-bottom: 0.5rem;
-}
-
-.grn-vertical-nav__mobile-title {
-  font-family: var(--og-font-display);
-  font-size: 1.1rem;
-  color: var(--og-color-soil);
-}
-
-.grn-vertical-nav__mobile-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  border: none;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--og-color-soil);
-  cursor: pointer;
-  touch-action: manipulation;
-}
-
-.grn-vertical-nav__mobile-close:hover,
-.grn-vertical-nav__mobile-close:focus-visible {
-  background: rgba(79, 56, 37, 0.08);
-  outline: none;
-}
-
-.grn-vertical-nav__mobile-close svg {
-  width: 1.25rem;
-  height: 1.25rem;
-}
-
 /* ── Left-docked vertical nav ─────────────────────────────────────── */
 
 .grn-vertical-nav {
@@ -176,50 +82,6 @@ body {
 
 .grn-vertical-nav.is-expanded {
   width: var(--grn-nav-width-expanded);
-}
-
-.grn-vertical-nav__scroll {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.grn-vertical-nav__section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-/* Pin the account/settings group to the bottom of the rail. */
-.grn-vertical-nav__section--pinned {
-  margin-top: auto;
-  padding-top: 0.35rem;
-}
-
-.grn-vertical-nav__section-title {
-  margin: 0;
-  padding: 0.5rem 0.85rem 0.15rem;
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: rgba(79, 56, 37, 0.55);
-  white-space: nowrap;
-}
-
-/* When collapsed there's no room for the heading text; render it as a thin
-   divider so the groups stay visually separated behind the icon rail. */
-.grn-vertical-nav.is-collapsed .grn-vertical-nav__section-title {
-  height: 1px;
-  margin: 0.4rem 0.55rem;
-  padding: 0;
-  overflow: hidden;
-  text-indent: -999px;
-  background: rgba(79, 56, 37, 0.14);
 }
 
 .grn-vertical-nav__list {
@@ -352,7 +214,13 @@ body {
   height: 0.8rem;
 }
 
-/* ── Mobile: off-canvas drawer (matches admin's 799px breakpoint) ─── */
+/* Mobile primary navigation is rendered alongside the rail so both surfaces
+   share the same destinations and active-state logic. */
+.grn-bottom-nav {
+  display: none;
+}
+
+/* ── Mobile: persistent three-destination bottom navigation ───────── */
 
 @media (max-width: 799px) {
   /* Drop the desktop body-level-scroll model on mobile. With it, the
@@ -366,6 +234,7 @@ body {
     min-height: 100vh;
     min-height: 100dvh;
     overflow: visible;
+    padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
   }
 
   .grn-shell-body {
@@ -377,99 +246,77 @@ body {
     overflow: visible;
   }
 
-  .grn-mobile-nav-trigger {
-    display: inline-flex;
-    align-self: flex-start;
-    margin: 0.85rem 0 0 clamp(0.75rem, 3vw, 1.25rem);
-    z-index: 30;
-  }
-
-  .grn-mobile-nav-backdrop {
-    display: block;
-  }
-
   .grn-vertical-nav,
   .grn-vertical-nav.is-expanded,
   .grn-vertical-nav.is-collapsed {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    height: 100dvh;
-    width: min(18rem, 84vw);
-    flex-direction: column;
-    padding: calc(env(safe-area-inset-top, 0px) + 1rem) 0.85rem
-             calc(env(safe-area-inset-bottom, 0px) + 1rem);
-    border-right: 1px solid rgba(79, 56, 37, 0.12);
-    border-bottom: none;
-    box-shadow: 6px 0 24px rgba(38, 23, 15, 0.18);
-    transform: translateX(-100%);
-    transition: transform var(--duration-base, 200ms) var(--easing-out, ease);
-    z-index: 50;
-    overflow-y: auto;
-  }
-
-  .grn-vertical-nav.is-mobile-open {
-    transform: translateX(0);
-  }
-
-  .grn-vertical-nav__mobile-header {
-    display: flex;
-  }
-
-  .grn-vertical-nav__toggle {
     display: none;
   }
 
-  .grn-vertical-nav__scroll {
-    flex: 0 0 auto;
-    overflow: visible;
+  .grn-shell-main__inner {
+    padding: 1rem clamp(0.75rem, 3vw, 1.5rem) 2rem;
   }
 
-  .grn-vertical-nav__section--pinned {
-    margin-top: 1rem;
+  .grn-bottom-nav {
+    position: fixed;
+    inset: auto 0 0;
+    z-index: 50;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-height: 4.5rem;
+    padding: 0.35rem max(0.5rem, env(safe-area-inset-right, 0px))
+      calc(0.35rem + env(safe-area-inset-bottom, 0px))
+      max(0.5rem, env(safe-area-inset-left, 0px));
+    border-top: 1px solid rgba(79, 56, 37, 0.14);
+    background: rgba(255, 252, 246, 0.97);
+    box-shadow: 0 -6px 24px rgba(38, 23, 15, 0.1);
+    backdrop-filter: blur(14px);
   }
 
-  /* The mobile drawer always shows labels, so restore the heading text even
-     when the desktop rail state is "collapsed". */
-  .grn-vertical-nav.is-collapsed .grn-vertical-nav__section-title,
-  .grn-vertical-nav__section-title {
-    height: auto;
-    margin: 0;
-    padding: 0.6rem 0.85rem 0.15rem;
-    overflow: visible;
-    text-indent: 0;
-    background: none;
-  }
-
-  .grn-vertical-nav__list {
-    flex: 0 0 auto;
-    gap: 0.25rem;
-    overflow: visible;
-  }
-
-  .grn-vertical-nav__link {
-    justify-content: flex-start;
-    gap: 0.85rem;
-    width: 100%;
-    min-height: 3rem;
-    padding: 0.65rem 0.85rem;
+  .grn-bottom-nav__link {
+    display: flex;
+    min-width: 0;
+    min-height: 3.5rem;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.3rem 0.4rem;
+    border-radius: 0.75rem;
+    color: rgba(79, 56, 37, 0.78);
+    font-size: 0.76rem;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
     touch-action: manipulation;
   }
 
-  .grn-vertical-nav__label {
-    display: inline;
-    opacity: 1;
-    transform: none;
+  .grn-bottom-nav__link:hover,
+  .grn-bottom-nav__link:focus-visible {
+    background: rgba(79, 56, 37, 0.08);
+    color: var(--og-color-soil);
+    outline: none;
   }
 
-  .grn-vertical-nav__icon {
-    width: 1.6rem;
-    height: 1.6rem;
+  .grn-bottom-nav__link:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--og-color-moss);
   }
 
-  .grn-shell-main__inner {
-    padding: 0.5rem clamp(0.75rem, 3vw, 1.5rem) 2rem;
+  .grn-bottom-nav__link.is-active {
+    background: rgba(66, 107, 63, 0.14);
+    color: var(--og-color-moss);
+  }
+
+  .grn-bottom-nav__icon {
+    display: inline-flex;
+    width: 1.35rem;
+    height: 1.35rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .grn-bottom-nav__icon svg {
+    width: 100%;
+    height: 100%;
   }
 }
 
@@ -500,6 +347,51 @@ body {
 .grn-stack {
   display: grid;
   gap: 1rem;
+}
+
+.grn-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.grn-settings-card {
+  scroll-margin-top: 1rem;
+}
+
+.grn-settings-card h2 {
+  margin: 0 0 0.75rem;
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  font-size: 1.2rem;
+}
+
+.grn-settings-details {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.grn-settings-details dt {
+  color: rgba(79, 56, 37, 0.7);
+  font-weight: 600;
+}
+
+.grn-settings-details dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+#api-keys {
+  scroll-margin-top: 1rem;
+}
+
+@media (max-width: 639px) {
+  .grn-settings-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Profile overview card */


### PR DESCRIPTION
## Summary

- replace the seven-item GRN feature menu and mobile Sections drawer with the shared Today, Garden, and Share destination model
- add a persistent three-item mobile bottom navigation with nested active states and one-tap access to the garden designer
- group existing feature pages beneath canonical Today, Garden, and Share routes while preserving old bookmarks, query strings, anchors, and browser history behavior
- move profile, membership, settings, API keys, and sign-out access into the avatar menu
- add privacy-safe observability for primary destination selection and legacy route redirects

## Product contract

Issue #371 predates the merged grower-only direction in #369. The current product vision defines every GRN user as a grower, so this implements Today, Garden, and Share for all signed-in users and does not retain the obsolete gatherer-only navigation branch.

## Route compatibility

- `/crops` -> `/garden/plants`
- `/crops/new` -> `/garden/plants/new`
- `/planner` -> `/garden/plan`
- `/recommendations` -> `/garden/plan/recommendations`
- `/listings` -> `/share/listings`
- `/connect` -> `/share`
- `/requests` -> `/share/find`
- `/reminders` -> `/today/reminders`

Redirects use history replacement and retain the original query string and hash.

## Verification

- `npm test` in `apps/grn`: 61 files, 537 tests passed
- `npm run lint` in `apps/grn`
- `npm run typecheck` in `apps/grn`
- `npm run build` in `apps/grn`
- `npm run perf:budget` in `apps/grn`: 787,822 bytes total
- responsive browser check at 390x844 and 1280x800; mobile renders three 60px-tall tap targets and desktop renders only the rail
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bins --all-features`: 244 tests passed
- `cargo test --test integration_test`: 9 passed, 3 database-dependent tests ignored
- GitHub frontend checks, shared staging deploy, smoke tests, and contract/utility/e2e Postman validations pass

`cargo fmt --all -- --check` cannot be validated from this Windows checkout because rustfmt rejects the CRLF newline style in unchanged backend files. GitHub correctly skipped backend static checks for this frontend-only change, and no backend files are changed in this PR. Please confirm no additional backend formatter validation is required before merge. No API contract changed, so Postman source updates are not applicable.

Closes #371
