### PR TITLE
Make Today an action-first garden queue

### DIFF
--- a/apps/grn/src/components/Harvests/HarvestLogModal.tsx
+++ b/apps/grn/src/components/Harvests/HarvestLogModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@olivias/ui';
+import { completeTodayAction } from '../../utils/todayActionTracking';
 import {
   deleteHarvest,
   listHarvests,
@@ -69,6 +70,7 @@ export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: Harv
       recordHarvest(cropId, input),
     onSuccess: () => {
       invalidate();
+      completeTodayAction('harvest');
       setAmount('');
       setNotes('');
       setHarvestedOn(todayIsoDate());

--- a/apps/grn/src/components/Listings/ClaimStatusList.tsx
+++ b/apps/grn/src/components/Listings/ClaimStatusList.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { Claim, ClaimStatus } from '../../types/claim';
 import { Button } from '@olivias/ui';
 
@@ -11,6 +12,7 @@ interface ClaimStatusListProps {
   emptyMessage: string;
   getActions: (claim: Claim) => ClaimStatus[];
   onTransition: (claimId: string, status: ClaimStatus) => Promise<void>;
+  highlightedClaimId?: string | null;
 }
 
 const actionLabels: Record<ClaimStatus, string> = {
@@ -35,7 +37,15 @@ export function ClaimStatusList({
   emptyMessage,
   getActions,
   onTransition,
+  highlightedClaimId,
 }: ClaimStatusListProps) {
+  useEffect(() => {
+    if (!highlightedClaimId || claims.length === 0) return;
+    const element = document.getElementById(`claim-${highlightedClaimId}`);
+    element?.focus();
+    element?.scrollIntoView?.({ block: 'center' });
+  }, [claims, highlightedClaimId]);
+
   return (
     <div className="rounded-base border border-neutral-200 bg-white px-4 py-4 space-y-3">
       <div className="space-y-1">
@@ -61,7 +71,17 @@ export function ClaimStatusList({
         const actions = getActions(claim);
 
         return (
-          <div key={claim.id} className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-3">
+          <div
+            key={claim.id}
+            id={`claim-${claim.id}`}
+            tabIndex={-1}
+            aria-current={highlightedClaimId === claim.id ? 'true' : undefined}
+            className={`rounded-base border px-3 py-3 ${
+              highlightedClaimId === claim.id
+                ? 'border-primary-500 bg-primary-50'
+                : 'border-neutral-200 bg-neutral-50'
+            }`}
+          >
             <div className="space-y-2">
               <p className="text-sm text-neutral-800">
                 Claim <span className="font-medium">{claim.id}</span>

--- a/apps/grn/src/components/Listings/FindFoodPanel.test.tsx
+++ b/apps/grn/src/components/Listings/FindFoodPanel.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { FindFoodPanel } from './FindFoodPanel';
 import {
   createCheckoutSession,
@@ -13,7 +14,7 @@ import {
   listCatalogCrops,
   updateRequest,
 } from '../../services/api';
-import { createClaim, updateClaimStatus } from '../../services/claims';
+import { createClaim, listClaims, updateClaimStatus } from '../../services/claims';
 
 vi.mock('../../services/api', () => ({
   createCheckoutSession: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('../../services/api', () => ({
 
 vi.mock('../../services/claims', () => ({
   createClaim: vi.fn(),
+  listClaims: vi.fn(),
   updateClaimStatus: vi.fn(),
 }));
 
@@ -41,6 +43,7 @@ const mockListCatalogCrops = vi.mocked(listCatalogCrops);
 const mockUpdateRequest = vi.mocked(updateRequest);
 const mockCreateClaim = vi.mocked(createClaim);
 const mockUpdateClaimStatus = vi.mocked(updateClaimStatus);
+const mockListClaims = vi.mocked(listClaims);
 
 function setOnlineStatus(isOnline: boolean) {
   Object.defineProperty(window.navigator, 'onLine', {
@@ -49,7 +52,7 @@ function setOnlineStatus(isOnline: boolean) {
   });
 }
 
-function renderPanel() {
+function renderPanel(initialEntry = '/') {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -60,13 +63,15 @@ function renderPanel() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <FindFoodPanel
-        viewerUserId="grower-2"
-        originGeoKey="9v6kn"
-        defaultLat={30.2672}
-        defaultLng={-97.7431}
-        defaultRadiusMiles={10}
-      />
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <FindFoodPanel
+          viewerUserId="grower-2"
+          originGeoKey="9v6kn"
+          defaultLat={30.2672}
+          defaultLng={-97.7431}
+          defaultRadiusMiles={10}
+        />
+      </MemoryRouter>
     </QueryClientProvider>
   );
 }
@@ -77,6 +82,14 @@ describe('FindFoodPanel', () => {
     window.localStorage.clear();
 
     setOnlineStatus(true);
+
+    mockListClaims.mockResolvedValue({
+      items: [],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
 
     mockListCatalogCrops.mockResolvedValue([
       {
@@ -540,5 +553,36 @@ describe('FindFoodPanel', () => {
     await waitFor(() => {
       expect(mockCreateRequest).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('loads and highlights the exact pickup claim from a Today deep link', async () => {
+    mockListClaims.mockResolvedValue({
+      items: [
+        {
+          id: 'claim-server',
+          listingId: 'listing-1',
+          requestId: null,
+          claimerId: 'grower-2',
+          listingOwnerId: 'grower-1',
+          quantityClaimed: '1',
+          status: 'confirmed',
+          notes: null,
+          claimedAt: '2026-07-14T09:00:00Z',
+          confirmedAt: '2026-07-14T10:00:00Z',
+          completedAt: null,
+          cancelledAt: null,
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    renderPanel('/share/find?claim=claim-server');
+
+    const claimId = await screen.findByText('claim-server');
+    expect(claimId.closest('[aria-current="true"]')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /^complete$/i })).toBeInTheDocument();
   });
 });

--- a/apps/grn/src/components/Listings/FindFoodPanel.tsx
+++ b/apps/grn/src/components/Listings/FindFoodPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
 import {
   createCheckoutSession,
   createRequest,
@@ -10,11 +11,12 @@ import {
   listCatalogCrops,
   updateRequest,
 } from '../../services/api';
-import { createClaim, updateClaimStatus } from '../../services/claims';
+import { createClaim, listClaims, updateClaimStatus } from '../../services/claims';
 import type { Listing } from '../../types/listing';
 import type { RequestItem, UpsertRequestPayload } from '../../types/request';
 import type { Claim, ClaimStatus } from '../../types/claim';
 import { createLogger } from '../../utils/logging';
+import { completeTodayAction } from '../../utils/todayActionTracking';
 import { Button, Card, Input } from '@olivias/ui';
 import { ClaimStatusList } from './ClaimStatusList';
 import {
@@ -242,6 +244,9 @@ export function FindFoodPanel({
   defaultLng,
   defaultRadiusMiles = 15,
 }: FindFoodPanelProps) {
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const linkedClaimId = searchParams.get('claim');
   const [isOffline, setIsOffline] = useState<boolean>(() => !navigator.onLine);
   const [radiusMiles, setRadiusMiles] = useState<number>(defaultRadiusMiles);
   const [selectedCropId, setSelectedCropId] = useState<string>('all');
@@ -343,6 +348,12 @@ export function FindFoodPanel({
     queryKey: ['catalogCrops'],
     queryFn: listCatalogCrops,
     staleTime: 10 * 60 * 1000,
+  });
+
+  const claimsQuery = useQuery({
+    queryKey: ['claims', 'claimer'],
+    queryFn: () => listClaims({ limit: 50 }),
+    staleTime: 30 * 1000,
   });
 
   const discoveryQuery = useQuery({
@@ -474,10 +485,17 @@ export function FindFoodPanel({
     });
   }, [defaultLat, defaultLng, filteredListings]);
 
-  const visibleClaims = useMemo(
-    () => sessionClaims.filter((claim) => (viewerUserId ? claim.claimerId === viewerUserId : true)),
-    [sessionClaims, viewerUserId]
-  );
+  const visibleClaims = useMemo(() => {
+    const combinedClaims = new Map(
+      (claimsQuery.data?.items ?? []).map((claim) => [claim.id, claim])
+    );
+    for (const claim of sessionClaims) {
+      combinedClaims.set(claim.id, claim);
+    }
+    return [...combinedClaims.values()].filter((claim) =>
+      viewerUserId ? claim.claimerId === viewerUserId : true
+    );
+  }, [claimsQuery.data?.items, sessionClaims, viewerUserId]);
 
   const handleSelectListing = (listing: Listing) => {
     setSelectedListingId(listing.id);
@@ -642,6 +660,7 @@ export function FindFoodPanel({
       const createdClaim = await createClaimMutation.mutateAsync(payload);
 
       setSessionClaims((previous) => upsertSessionClaim(previous, createdClaim));
+      void queryClient.invalidateQueries({ queryKey: ['claims'] });
       setClaimSuccessMessage('Claim submitted.');
       logger.info('Claim created', { claimId: createdClaim.id, listingId: createdClaim.listingId });
     } catch (error) {
@@ -669,11 +688,10 @@ export function FindFoodPanel({
       return;
     }
 
-    const previousClaim = sessionClaims.find((claim) => claim.id === claimId) ?? null;
-
-    setSessionClaims((current) =>
-      current.map((claim) => (claim.id === claimId ? { ...claim, status } : claim))
-    );
+    const previousClaim = visibleClaims.find((claim) => claim.id === claimId) ?? null;
+    if (previousClaim) {
+      setSessionClaims((current) => upsertSessionClaim(current, { ...previousClaim, status }));
+    }
 
     try {
       if (isOffline) {
@@ -689,13 +707,13 @@ export function FindFoodPanel({
 
       const updated = await transitionClaimMutation.mutateAsync({ claimId: resolvedClaimId, status });
       setSessionClaims((current) => upsertSessionClaim(current, updated));
+      void queryClient.invalidateQueries({ queryKey: ['claims'] });
+      completeTodayAction('pickup');
       setClaimSuccessMessage('Claim updated.');
       logger.info('Claim updated', { claimId: updated.id, status: updated.status });
     } catch (error) {
       if (previousClaim) {
-        setSessionClaims((current) =>
-          current.map((claim) => (claim.id === claimId ? previousClaim : claim))
-        );
+        setSessionClaims((current) => upsertSessionClaim(current, previousClaim));
       }
 
       const message = error instanceof Error ? error.message : 'Failed to update claim';
@@ -1092,9 +1110,10 @@ export function FindFoodPanel({
         pendingClaimIds={pendingClaimIds}
         successMessage={claimSuccessMessage}
         errorMessage={claimError}
-        emptyMessage="No claims tracked in this session yet."
+        emptyMessage={claimsQuery.isLoading ? 'Loading your claims...' : 'No claims yet.'}
         getActions={(claim) => getClaimActions(claim.status)}
         onTransition={handleClaimTransition}
+        highlightedClaimId={linkedClaimId}
       />
 
       <Card className="space-y-3" padding="6">

--- a/apps/grn/src/components/Listings/GrowerListingPanel.test.tsx
+++ b/apps/grn/src/components/Listings/GrowerListingPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { GrowerListingPanel } from './GrowerListingPanel';
 import type { Listing } from '../../types/listing';
 import {
@@ -13,7 +14,7 @@ import {
   listMyListings,
   updateListing,
 } from '../../services/api';
-import { updateClaimStatus } from '../../services/claims';
+import { listClaims, updateClaimStatus } from '../../services/claims';
 
 vi.mock('../../services/api', () => ({
   createListing: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('../../services/api', () => ({
 }));
 
 vi.mock('../../services/claims', () => ({
+  listClaims: vi.fn(),
   updateClaimStatus: vi.fn(),
 }));
 
@@ -37,6 +39,7 @@ const mockGetMyListing = vi.mocked(getMyListing);
 const mockCreateListing = vi.mocked(createListing);
 const mockUpdateListing = vi.mocked(updateListing);
 const mockUpdateClaimStatus = vi.mocked(updateClaimStatus);
+const mockListClaims = vi.mocked(listClaims);
 
 function setOnlineStatus(isOnline: boolean) {
   Object.defineProperty(window.navigator, 'onLine', {
@@ -72,7 +75,7 @@ function makeListing(overrides: Partial<Listing>): Listing {
   };
 }
 
-function renderPanel() {
+function renderPanel(initialEntry = '/') {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -83,7 +86,9 @@ function renderPanel() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <GrowerListingPanel viewerUserId="user-1" defaultLat={30.2672} defaultLng={-97.7431} />
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <GrowerListingPanel viewerUserId="user-1" defaultLat={30.2672} defaultLng={-97.7431} />
+      </MemoryRouter>
     </QueryClientProvider>
   );
 }
@@ -108,6 +113,13 @@ describe('GrowerListingPanel', () => {
     mockListMyCrops.mockResolvedValue([]);
     mockCreateListing.mockResolvedValue(makeListing({ id: 'new-listing' }));
     mockUpdateListing.mockResolvedValue(makeListing({ id: 'updated-listing' }));
+    mockListClaims.mockResolvedValue({
+      items: [],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
     mockUpdateClaimStatus.mockResolvedValue({
       id: 'claim-1',
       listingId: 'listing-1',
@@ -314,5 +326,46 @@ describe('GrowerListingPanel', () => {
     expect(claimSection).not.toBeNull();
     expect(within(claimSection as HTMLElement).getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
     expect(within(claimSection as HTMLElement).queryByRole('button', { name: /^complete$/i })).not.toBeInTheDocument();
+  });
+
+  it('opens and highlights the exact listing claim from a Today deep link', async () => {
+    const listing = makeListing({ id: 'listing-1', title: 'Tomatoes Basket' });
+    mockListMyListings.mockResolvedValue({
+      items: [listing],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+    mockGetMyListing.mockResolvedValue(listing);
+    mockListClaims.mockResolvedValue({
+      items: [
+        {
+          id: 'claim-server',
+          listingId: 'listing-1',
+          requestId: null,
+          claimerId: 'grower-2',
+          listingOwnerId: 'user-1',
+          quantityClaimed: '1',
+          status: 'pending',
+          notes: null,
+          claimedAt: '2026-07-14T09:00:00Z',
+          confirmedAt: null,
+          completedAt: null,
+          cancelledAt: null,
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    renderPanel('/share/listings?listing=listing-1&claim=claim-server');
+
+    expect(await screen.findByRole('heading', { name: 'My Listings' })).toBeInTheDocument();
+    const claimId = await screen.findByText('claim-server');
+    expect(claimId.closest('[aria-current="true"]')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
   });
 });

--- a/apps/grn/src/components/Listings/GrowerListingPanel.tsx
+++ b/apps/grn/src/components/Listings/GrowerListingPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSearchParams } from 'react-router-dom';
 import {
   createListing,
   getMyListing,
@@ -9,12 +10,13 @@ import {
   listMyListings,
   updateListing,
 } from '../../services/api';
-import { createClaim, updateClaimStatus } from '../../services/claims';
+import { createClaim, listClaims, updateClaimStatus } from '../../services/claims';
 import type { Listing, UpsertListingRequest } from '../../types/listing';
 import type { Claim, ClaimStatus } from '../../types/claim';
 import { Button, Card } from '@olivias/ui';
 import { ListingForm, type ListingQuickPickOption } from './ListingForm';
 import { createLogger } from '../../utils/logging';
+import { completeTodayAction } from '../../utils/todayActionTracking';
 import { ClaimStatusList } from './ClaimStatusList';
 import {
   loadSessionClaims,
@@ -170,14 +172,19 @@ function ListingDetails({ listing }: { listing: Listing }) {
 
 export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: GrowerListingPanelProps) {
   const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const linkedListingId = searchParams.get('listing');
+  const linkedClaimId = searchParams.get('claim');
   const [isOffline, setIsOffline] = useState<boolean>(() => !navigator.onLine);
   const [selectedCropId, setSelectedCropId] = useState<string>('');
   const [editingListingId, setEditingListingId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [activeView, setActiveView] = useState<ListingsView>('create');
+  const [activeView, setActiveView] = useState<ListingsView>(() =>
+    linkedListingId ? 'my-listings' : 'create'
+  );
   const [myListingsFilter, setMyListingsFilter] = useState<MyListingsFilter>('all');
-  const [selectedListingId, setSelectedListingId] = useState<string | null>(null);
+  const [selectedListingId, setSelectedListingId] = useState<string | null>(linkedListingId);
   const [sessionClaims, setSessionClaims] = useState<Claim[]>(() => loadSessionClaims(viewerUserId));
   const [claimSuccessMessage, setClaimSuccessMessage] = useState<string | null>(null);
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -259,6 +266,13 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
     enabled: !!selectedListingId,
   });
 
+  const listingClaimsQuery = useQuery({
+    queryKey: ['claims', 'listing', selectedListingId],
+    queryFn: () => listClaims({ listingId: selectedListingId ?? '', limit: 50 }),
+    enabled: !!selectedListingId,
+    staleTime: 30 * 1000,
+  });
+
   const createMutation = useMutation({
     mutationFn: (request: UpsertListingRequest) => createListing(request),
   });
@@ -292,6 +306,12 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
   useEffect(() => {
     saveSessionClaims(sessionClaims, viewerUserId);
   }, [sessionClaims, viewerUserId]);
+
+  useEffect(() => {
+    if (!linkedListingId) return;
+    setActiveView('my-listings');
+    setSelectedListingId(linkedListingId);
+  }, [linkedListingId]);
 
   useEffect(() => {
     void replayClaimQueue();
@@ -461,14 +481,21 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       return [];
     }
 
-    return sessionClaims.filter((claim) => {
+    const combinedClaims = new Map(
+      (listingClaimsQuery.data?.items ?? []).map((claim) => [claim.id, claim])
+    );
+    for (const claim of sessionClaims) {
+      combinedClaims.set(claim.id, claim);
+    }
+
+    return [...combinedClaims.values()].filter((claim) => {
       if (claim.listingId !== selectedListing.id) {
         return false;
       }
 
       return viewerUserId ? claim.listingOwnerId === viewerUserId : true;
     });
-  }, [selectedListing, sessionClaims, viewerUserId]);
+  }, [listingClaimsQuery.data?.items, selectedListing, sessionClaims, viewerUserId]);
 
   const handleClaimTransition = async (claimId: string, status: ClaimStatus) => {
     setClaimError(null);
@@ -488,10 +515,10 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       return;
     }
 
-    const previousClaim = sessionClaims.find((claim) => claim.id === claimId) ?? null;
-    setSessionClaims((current) =>
-      current.map((claim) => (claim.id === claimId ? { ...claim, status } : claim))
-    );
+    const previousClaim = claimsForSelectedListing.find((claim) => claim.id === claimId) ?? null;
+    if (previousClaim) {
+      setSessionClaims((current) => upsertSessionClaim(current, { ...previousClaim, status }));
+    }
 
     try {
       if (isOffline) {
@@ -502,13 +529,13 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
 
       const updated = await transitionClaimMutation.mutateAsync({ claimId, status });
       setSessionClaims((current) => upsertSessionClaim(current, updated));
+      void queryClient.invalidateQueries({ queryKey: ['claims'] });
+      completeTodayAction('claim');
       setClaimSuccessMessage('Claim updated.');
       logger.info('Claim updated', { claimId: updated.id, status: updated.status });
     } catch (error) {
       if (previousClaim) {
-        setSessionClaims((current) =>
-          current.map((claim) => (claim.id === claimId ? previousClaim : claim))
-        );
+        setSessionClaims((current) => upsertSessionClaim(current, previousClaim));
       }
 
       const message = error instanceof Error ? error.message : 'Failed to update claim';
@@ -708,9 +735,14 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
                 pendingClaimIds={pendingClaimIds}
                 successMessage={claimSuccessMessage}
                 errorMessage={claimError}
-                emptyMessage="No claims tracked for this listing in this session yet."
+                emptyMessage={
+                  listingClaimsQuery.isLoading
+                    ? 'Loading claims for this listing...'
+                    : 'No claims for this listing yet.'
+                }
                 getActions={(claim) => getGrowerActions(claim.status)}
                 onTransition={handleClaimTransition}
+                highlightedClaimId={linkedClaimId}
               />
             </>
           )}
@@ -793,9 +825,14 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
                 pendingClaimIds={pendingClaimIds}
                 successMessage={claimSuccessMessage}
                 errorMessage={claimError}
-                emptyMessage="No claims tracked for this listing in this session yet."
+                emptyMessage={
+                  listingClaimsQuery.isLoading
+                    ? 'Loading claims for this listing...'
+                    : 'No claims for this listing yet.'
+                }
                 getActions={(claim) => getGrowerActions(claim.status)}
                 onTransition={handleClaimTransition}
+                highlightedClaimId={linkedClaimId}
               />
             </>
           )}

--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { CropLibraryPanel } from './CropLibraryPanel';
+import { listMyBeds, listMyCrops } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  deleteMyCrop: vi.fn(),
+  listMyBeds: vi.fn(),
+  listMyCrops: vi.fn(),
+}));
+
+vi.mock('../Harvests/HarvestLogModal', () => ({
+  HarvestLogModal: ({ cropName }: { cropName: string }) => (
+    <div role="dialog" aria-label={`Harvest ${cropName}`}>Harvest {cropName}</div>
+  ),
+}));
+
+describe('CropLibraryPanel deep links', () => {
+  it('opens the harvest workflow for the linked crop', async () => {
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(listMyCrops).mockResolvedValue([
+      {
+        id: 'crop-1',
+        userId: 'grower-1',
+        canonicalId: null,
+        cropName: 'Tomato',
+        varietyId: null,
+        status: 'growing',
+        visibility: 'private',
+        surplusEnabled: false,
+        nickname: 'Cherry tomatoes',
+        defaultUnit: 'lb',
+        notes: null,
+        bedId: null,
+        bedName: null,
+        plantingDate: null,
+        expectedHarvestDate: null,
+        plantCount: null,
+        spacingInches: null,
+        pyramidTier: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/garden/plants?crop=crop-1&action=harvest']}>
+          <CropLibraryPanel viewerUserId="grower-1" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByRole('dialog', { name: 'Harvest Cherry tomatoes' })).toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { listMyCrops, deleteMyCrop, listMyBeds } from '../../services/api';
 import type { GrowerCropItem } from '../../types/listing';
@@ -26,9 +26,11 @@ const STATUS_LABELS: Record<string, { label: string; emoji: string; tone: string
 export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
   void viewerUserId;
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<'all' | 'growing' | 'planning' | 'interested'>('all');
   const [harvestCrop, setHarvestCrop] = useState<GrowerCropItem | null>(null);
+  const [dismissedLinkedHarvestId, setDismissedLinkedHarvestId] = useState<string | null>(null);
 
   const { data: myCrops, isLoading: isLoadingCrops } = useQuery({
     queryKey: ['myCrops'],
@@ -39,6 +41,17 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
     queryKey: ['myBeds'],
     queryFn: listMyBeds,
   });
+
+  const linkedCropId = searchParams.get('crop');
+  const linkedAction = searchParams.get('action');
+
+  const linkedHarvestCrop = useMemo(() => {
+    if (linkedAction !== 'harvest' || !linkedCropId || !myCrops) return null;
+    return myCrops.find((crop) => crop.id === linkedCropId) ?? null;
+  }, [linkedAction, linkedCropId, myCrops]);
+  const activeHarvestCrop =
+    harvestCrop ??
+    (linkedHarvestCrop?.id !== dismissedLinkedHarvestId ? linkedHarvestCrop : null);
 
   const deleteMutation = useMutation({
     mutationFn: deleteMyCrop,
@@ -153,7 +166,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
             const progress = harvestProgress(crop.plantingDate, crop.expectedHarvestDate);
 
             return (
-              <article key={crop.id} className="grn-crop-card">
+              <article key={crop.id} id={`crop-${crop.id}`} className="grn-crop-card">
                 <header
                   className="grn-crop-card__header"
                   style={{
@@ -268,12 +281,17 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
         </div>
       </Card>
 
-      {harvestCrop ? (
+      {activeHarvestCrop ? (
         <HarvestLogModal
-          cropId={harvestCrop.id}
-          cropName={harvestCrop.nickname || harvestCrop.cropName}
-          defaultUnit={harvestCrop.defaultUnit}
-          onClose={() => setHarvestCrop(null)}
+          cropId={activeHarvestCrop.id}
+          cropName={activeHarvestCrop.nickname || activeHarvestCrop.cropName}
+          defaultUnit={activeHarvestCrop.defaultUnit}
+          onClose={() => {
+            setHarvestCrop(null);
+            if (activeHarvestCrop.id === linkedCropId) {
+              setDismissedLinkedHarvestId(activeHarvestCrop.id);
+            }
+          }}
         />
       ) : null}
     </div>

--- a/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReminderPanel } from './ReminderPanel';
+import { listReminders } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  createReminder: vi.fn(),
+  listReminders: vi.fn(),
+  updateReminderStatus: vi.fn(),
+}));
+
+describe('ReminderPanel deep links', () => {
+  it('focuses the linked reminder record', async () => {
+    vi.mocked(listReminders).mockResolvedValue({
+      items: [
+        {
+          id: 'reminder-1',
+          title: 'Water the raised beds',
+          reminderType: 'watering',
+          cadenceDays: 1,
+          startDate: '2026-07-14',
+          timezone: 'UTC',
+          status: 'active',
+          nextRunAt: '2026-07-14T09:00:00Z',
+          lastRunAt: null,
+          createdAt: '2026-07-01T00:00:00Z',
+        },
+      ],
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/today/reminders?reminder=reminder-1']}>
+          <ReminderPanel />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const reminder = await screen.findByText('Water the raised beds');
+    const reminderRow = reminder.closest('li');
+    expect(reminderRow).toHaveAttribute('aria-current', 'true');
+    await waitFor(() => expect(document.activeElement).toBe(reminderRow));
+  });
+});

--- a/apps/grn/src/components/Reminders/ReminderPanel.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createReminder,
@@ -7,6 +8,7 @@ import {
   updateReminderStatus,
 } from '../../services/api';
 import { Button } from '@olivias/ui';
+import { completeTodayAction } from '../../utils/todayActionTracking';
 
 const REMINDER_TYPES: Array<{ value: ReminderType; label: string }> = [
   { value: 'watering', label: 'Watering' },
@@ -22,6 +24,7 @@ function todayIsoDate(): string {
 
 export function ReminderPanel() {
   const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
   const [title, setTitle] = useState('');
   const [reminderType, setReminderType] = useState<ReminderType>('watering');
   const [cadenceDays, setCadenceDays] = useState(7);
@@ -54,6 +57,7 @@ export function ReminderPanel() {
       updateReminderStatus(reminderId, status),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['reminders'] });
+      completeTodayAction('reminder');
     },
   });
 
@@ -61,6 +65,14 @@ export function ReminderPanel() {
     const items = remindersQuery.data?.items ?? [];
     return [...items].sort((a, b) => a.nextRunAt.localeCompare(b.nextRunAt));
   }, [remindersQuery.data?.items]);
+  const linkedReminderId = searchParams.get('reminder');
+
+  useEffect(() => {
+    if (!linkedReminderId || sortedReminders.length === 0) return;
+    const element = document.getElementById(`reminder-${linkedReminderId}`);
+    element?.focus();
+    element?.scrollIntoView?.({ block: 'center' });
+  }, [linkedReminderId, sortedReminders]);
 
   const submit = () => {
     if (!title.trim()) {
@@ -160,7 +172,14 @@ export function ReminderPanel() {
             return (
               <li
                 key={reminder.id}
-                className="rounded-md border border-gray-200 px-3 py-2 flex items-center justify-between gap-3"
+                id={`reminder-${reminder.id}`}
+                tabIndex={-1}
+                aria-current={linkedReminderId === reminder.id ? 'true' : undefined}
+                className={`rounded-md border px-3 py-2 flex items-center justify-between gap-3 ${
+                  linkedReminderId === reminder.id
+                    ? 'border-primary-500 bg-primary-50'
+                    : 'border-gray-200'
+                }`}
               >
                 <div>
                   <p className="text-sm font-medium text-gray-900">{reminder.title}</p>

--- a/apps/grn/src/pages/DashboardPage.test.tsx
+++ b/apps/grn/src/pages/DashboardPage.test.tsx
@@ -1,26 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { DashboardPage } from './DashboardPage';
-import { getMe, listMyCrops, listReminders } from '../services/api';
+import { getDerivedFeed, listMyCrops, listReminders } from '../services/api';
+import { listClaims } from '../services/claims';
 import type { GrowerCropItem } from '../types/listing';
 import type { UserProfile } from '../types/user';
 
 vi.mock('../services/api', () => ({
-  getMe: vi.fn(),
+  getDerivedFeed: vi.fn(),
   listMyCrops: vi.fn(),
   listReminders: vi.fn(),
 }));
 
-vi.mock('../hooks/useAuth', () => ({
-  useAuth: () => ({ signOut: vi.fn() }),
+vi.mock('../services/claims', () => ({
+  listClaims: vi.fn(),
 }));
 
-const mockGetMe = vi.mocked(getMe);
+const mockGetDerivedFeed = vi.mocked(getDerivedFeed);
 const mockListMyCrops = vi.mocked(listMyCrops);
 const mockListReminders = vi.mocked(listReminders);
+const mockListClaims = vi.mocked(listClaims);
 
 const profile = {
   id: 'grower-1',
@@ -29,7 +31,7 @@ const profile = {
   userType: 'grower',
   onboardingCompleted: true,
   subscription: { tier: 'free' },
-} as unknown as UserProfile;
+} as UserProfile;
 
 function crop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
   return {
@@ -57,14 +59,14 @@ function crop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
   };
 }
 
-function renderPage() {
+function renderPage(user: UserProfile = profile) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <DashboardPage />
+        <DashboardPage user={user} />
         <LocationDisplay />
       </MemoryRouter>
     </QueryClientProvider>
@@ -73,73 +75,145 @@ function renderPage() {
 
 function LocationDisplay() {
   const location = useLocation();
-  return <output data-testid="location">{location.pathname}</output>;
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
 }
 
 describe('DashboardPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(window.navigator, 'onLine', { configurable: true, value: true });
+    mockListMyCrops.mockResolvedValue([]);
     mockListReminders.mockResolvedValue({ items: [] });
+    mockListClaims.mockResolvedValue({
+      items: [],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+    mockGetDerivedFeed.mockResolvedValue({
+      items: [],
+      signals: [],
+      freshness: {
+        asOf: '2026-07-14T00:00:00Z',
+        isStale: false,
+        staleFallbackUsed: false,
+        staleReason: null,
+      },
+      aiSummary: null,
+      growerGuidance: null,
+      limit: 1,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
   });
 
-  it('greets the user and shows the empty-state CTA when there are no crops', async () => {
-    mockGetMe.mockResolvedValue(profile);
-    mockListMyCrops.mockResolvedValue([]);
-
+  it('shows one clear first step when the garden is empty', async () => {
     renderPage();
 
-    expect(await screen.findByText(/Welcome back, Ada/i)).toBeInTheDocument();
-    const cta = await screen.findByRole('button', { name: /add your first crop/i });
+    expect(await screen.findByRole('heading', { name: 'Today, Ada' })).toBeInTheDocument();
+    const actionList = await screen.findByRole('list', { name: /top actions today/i });
+    expect(within(actionList).getAllByRole('listitem')).toHaveLength(1);
 
-    await userEvent.click(cta);
+    await userEvent.click(within(actionList).getByRole('button', { name: 'Add a crop' }));
     await waitFor(() => {
       expect(screen.getByTestId('location')).toHaveTextContent('/garden/plants/new');
     });
   });
 
-  it('summarizes crops and lists upcoming harvests and reminders', async () => {
-    mockGetMe.mockResolvedValue(profile);
+  it('ranks no more than three record-linked actions and preserves the harvest deep link', async () => {
     mockListMyCrops.mockResolvedValue([
-      crop({ id: 'c1', cropName: 'Tomato', status: 'growing', expectedHarvestDate: '2999-01-01' }),
-      crop({ id: 'c2', cropName: 'Basil', status: 'planning' }),
-      crop({ id: 'c3', cropName: 'Kale', status: 'interested' }),
+      crop({ id: 'crop-ready', nickname: 'Cherry tomatoes', expectedHarvestDate: '2000-01-01' }),
+      crop({ id: 'crop-plan', cropName: 'Kale', status: 'planning' }),
     ]);
     mockListReminders.mockResolvedValue({
       items: [
         {
-          id: 'r1',
-          title: 'Water the beds',
-          reminderType: 'custom',
+          id: 'reminder-due',
+          title: 'Water the raised beds',
+          reminderType: 'watering',
           cadenceDays: 1,
-          startDate: '2026-07-14',
+          startDate: '2000-01-01',
           timezone: 'UTC',
           status: 'active',
-          nextRunAt: '2999-07-15T09:00:00Z',
+          nextRunAt: '2000-01-01T09:00:00Z',
           lastRunAt: null,
-          createdAt: '2026-07-14T00:00:00Z',
+          createdAt: '2000-01-01T00:00:00Z',
         },
       ],
-    } as Awaited<ReturnType<typeof listReminders>>);
+    });
+    mockListClaims.mockResolvedValue({
+      items: [
+        {
+          id: 'claim-pending',
+          listingId: 'listing-1',
+          requestId: null,
+          claimerId: 'neighbor-1',
+          listingOwnerId: 'grower-1',
+          quantityClaimed: '1',
+          status: 'pending',
+          notes: null,
+          claimedAt: '2000-01-01T00:00:00Z',
+          confirmedAt: null,
+          completedAt: null,
+          cancelledAt: null,
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
 
     renderPage();
 
-    // "Growing now" = 1, "Planning & interested" = 2.
-    expect(await screen.findByText('Growing now')).toBeInTheDocument();
-    expect(screen.getByText('Planning & interested')).toBeInTheDocument();
-    expect(screen.getByText('Upcoming harvests')).toBeInTheDocument();
-    expect(screen.getByText('Tomato')).toBeInTheDocument();
-    expect(screen.getByText('Water the beds')).toBeInTheDocument();
+    const actionList = await screen.findByRole('list', { name: /top actions today/i });
+    const actions = within(actionList).getAllByRole('listitem');
+    expect(actions).toHaveLength(3);
+    expect(within(actions[0]).getByText('Review a sharing request')).toBeInTheDocument();
+    expect(within(actions[1]).getByText('Water the raised beds')).toBeInTheDocument();
+    expect(within(actions[2]).getByText('Check Cherry tomatoes')).toBeInTheDocument();
+
+    await userEvent.click(within(actions[2]).getByRole('button', { name: 'Log harvest' }));
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plants?crop=crop-ready&action=harvest'
+    );
   });
 
-  it('surfaces an error state when the profile fails to load', async () => {
-    mockGetMe.mockRejectedValue(new Error('boom'));
-    mockListMyCrops.mockResolvedValue([]);
+  it('keeps successful actions visible when another source fails', async () => {
+    mockListMyCrops.mockResolvedValue([
+      crop({ id: 'crop-ready', expectedHarvestDate: '2000-01-01' }),
+    ]);
+    mockListClaims.mockRejectedValue(new Error('claims unavailable'));
 
     renderPage();
 
-    // The profile query retries twice with backoff before failing.
-    expect(
-      await screen.findByText(/failed to load your garden/i, undefined, { timeout: 5000 })
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Check Tomato')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not refresh/i);
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+
+  it('shows an explicit offline state without hiding cached actions', async () => {
+    mockListMyCrops.mockResolvedValue([
+      crop({ id: 'crop-ready', expectedHarvestDate: '2000-01-01' }),
+    ]);
+    renderPage();
+
+    expect(await screen.findByText('Check Tomato')).toBeInTheDocument();
+    fireEvent(window, new Event('offline'));
+    expect(await screen.findByText(/showing the latest garden information/i)).toBeInTheDocument();
+    expect(screen.getByText('Check Tomato')).toBeInTheDocument();
+  });
+
+  it('shows a focused loader while the initial action sources are pending', () => {
+    mockListMyCrops.mockReturnValue(new Promise(() => undefined));
+    mockListReminders.mockReturnValue(new Promise(() => undefined));
+    mockListClaims.mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+
+    expect(screen.getByText('Finding your next steps…')).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: /top actions today/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/grn/src/pages/DashboardPage.tsx
+++ b/apps/grn/src/pages/DashboardPage.tsx
@@ -1,16 +1,20 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Button, Card, Panel, SectionHeading } from '@olivias/ui';
-import { getMe, listMyCrops, listReminders } from '../services/api';
-import type { GrowerCropItem } from '../types/listing';
-import type { ReminderItem } from '../services/api';
-import { useAuth } from '../hooks/useAuth';
+import { getDerivedFeed, listMyCrops, listReminders } from '../services/api';
+import { listClaims } from '../services/claims';
+import type { UserProfile } from '../types/user';
 import { PlantLoader } from '../components/branding/PlantLoader';
-import { daysUntil, formatDate, harvestProgress } from '../utils/cropTiming';
+import { createLogger } from '../utils/logging';
+import { recordTodayActionOpen } from '../utils/todayActionTracking';
+import { buildTodayActions } from './todayActions';
 
-/** A crop counts as "ready to harvest" once its window closes or is within a week. */
-const HARVEST_SOON_DAYS = 7;
+const logger = createLogger('today');
+
+interface DashboardPageProps {
+  user: UserProfile | null;
+}
 
 function firstName(displayName?: string | null, email?: string | null): string {
   const name = displayName?.trim();
@@ -19,249 +23,199 @@ function firstName(displayName?: string | null, email?: string | null): string {
   return local ? local.charAt(0).toUpperCase() + local.slice(1) : 'there';
 }
 
-function harvestLabel(days: number | null): string {
-  if (days === null) return 'Harvest window open';
-  if (days <= 0) return days === 0 ? 'Ready today' : `Ready ${Math.abs(days)}d ago`;
-  if (days === 1) return 'Ready tomorrow';
-  return `Ready in ${days} days`;
+function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() => typeof navigator === 'undefined' || navigator.onLine);
+
+  useEffect(() => {
+    const goOnline = () => setIsOnline(true);
+    const goOffline = () => setIsOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return isOnline;
 }
 
-function reminderLabel(nextRunAt: string): string {
-  const days = daysUntil(nextRunAt.slice(0, 10));
-  if (days === null) return formatDate(nextRunAt.slice(0, 10)) ?? 'Scheduled';
-  if (days <= 0) return 'Due now';
-  if (days === 1) return 'Tomorrow';
-  if (days <= 14) return `In ${days} days`;
-  return formatDate(nextRunAt.slice(0, 10)) ?? `In ${days} days`;
-}
-
-export function DashboardPage() {
-  const { signOut } = useAuth();
+export function DashboardPage({ user }: DashboardPageProps) {
   const navigate = useNavigate();
+  const isOnline = useOnlineStatus();
+  const lastImpression = useRef('');
 
-  const {
-    data: profile,
-    isLoading: profileLoading,
-    isError: profileError,
-    error,
-    refetch,
-  } = useQuery({
-    queryKey: ['userProfile'],
-    queryFn: getMe,
-    staleTime: 5 * 60 * 1000,
-    retry: 2,
-  });
-
-  const { data: crops = [], isLoading: cropsLoading } = useQuery({
+  const cropsQuery = useQuery({
     queryKey: ['myCrops'],
     queryFn: listMyCrops,
     staleTime: 60 * 1000,
   });
 
-  const { data: reminderData } = useQuery({
+  const remindersQuery = useQuery({
     queryKey: ['reminders'],
     queryFn: listReminders,
     staleTime: 60 * 1000,
   });
 
+  const claimsQuery = useQuery({
+    queryKey: ['claims', 'today'],
+    queryFn: () => listClaims({ limit: 50 }),
+    staleTime: 30 * 1000,
+  });
+
+  const geoKey = user?.growerProfile?.geoKey;
+  const feedQuery = useQuery({
+    queryKey: ['todayDerivedFeed', geoKey, 7],
+    queryFn: () => getDerivedFeed({ geoKey: geoKey ?? '', windowDays: 7, limit: 1 }),
+    enabled: Boolean(geoKey),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const crops = useMemo(() => cropsQuery.data ?? [], [cropsQuery.data]);
+  const actions = useMemo(
+    () =>
+      buildTodayActions({
+        userId: user?.id,
+        crops,
+        cropsLoaded: cropsQuery.isSuccess,
+        reminders: remindersQuery.data?.items ?? [],
+        claims: claimsQuery.data?.items ?? [],
+        signals: feedQuery.data?.signals ?? [],
+      }),
+    [
+      claimsQuery.data?.items,
+      crops,
+      cropsQuery.isSuccess,
+      feedQuery.data?.signals,
+      remindersQuery.data?.items,
+      user?.id,
+    ]
+  );
+
   const stats = useMemo(() => {
-    const growing = crops.filter((c) => c.status === 'growing');
-    const planning = crops.filter((c) => c.status === 'planning' || c.status === 'interested');
-    const readySoon = growing.filter((c) => {
-      const progress = harvestProgress(c.plantingDate, c.expectedHarvestDate);
-      const days = daysUntil(c.expectedHarvestDate);
-      return progress === 100 || (days !== null && days <= HARVEST_SOON_DAYS);
+    const growing = crops.filter((crop) => crop.status === 'growing').length;
+    const planning = crops.filter(
+      (crop) => crop.status === 'planning' || crop.status === 'interested'
+    ).length;
+    const sharing = crops.filter((crop) => crop.surplusEnabled).length;
+    return { growing, planning, sharing };
+  }, [crops]);
+
+  const relevantQueries = geoKey
+    ? [cropsQuery, remindersQuery, claimsQuery, feedQuery]
+    : [cropsQuery, remindersQuery, claimsQuery];
+  const failedQueries = relevantQueries.filter((query) => query.isError);
+  const hasLoadedData =
+    cropsQuery.data !== undefined ||
+    remindersQuery.data !== undefined ||
+    claimsQuery.data !== undefined ||
+    feedQuery.data !== undefined;
+  const isInitialLoading = !hasLoadedData && relevantQueries.some((query) => query.isPending);
+  const greetingName = firstName(user?.displayName, user?.email);
+
+  useEffect(() => {
+    if (isInitialLoading) return;
+    const impression = actions.map((action) => action.kind).join(',');
+    if (!impression || impression === lastImpression.current) return;
+    lastImpression.current = impression;
+    logger.info('Today actions shown', {
+      actionKinds: actions.map((action) => action.kind),
+      actionCount: actions.length,
     });
-    return { growing, planning, readySoon };
-  }, [crops]);
+  }, [actions, isInitialLoading]);
 
-  const upcomingHarvests = useMemo<GrowerCropItem[]>(() => {
-    return crops
-      .filter((c) => c.expectedHarvestDate)
-      .sort((a, b) => (daysUntil(a.expectedHarvestDate) ?? 0) - (daysUntil(b.expectedHarvestDate) ?? 0))
-      .slice(0, 4);
-  }, [crops]);
-
-  const upcomingReminders = useMemo<ReminderItem[]>(() => {
-    return (reminderData?.items ?? [])
-      .filter((r) => r.status === 'active')
-      .sort((a, b) => a.nextRunAt.localeCompare(b.nextRunAt))
-      .slice(0, 4);
-  }, [reminderData]);
-
-  const handleSignOut = async () => {
-    try {
-      await signOut();
-    } catch (signOutError) {
-      console.error('Sign-out failed:', signOutError);
-    }
+  const retryFailed = () => {
+    void Promise.all(failedQueries.map((query) => query.refetch()));
   };
-
-  if (profileLoading) {
-    return (
-      <section className="grn-section">
-        <SectionHeading eyebrow="Overview" title="Your garden" />
-        <Panel className="grn-page-status">
-          <PlantLoader size="md" />
-          <p>Loading your garden…</p>
-        </Panel>
-      </section>
-    );
-  }
-
-  if (profileError || !profile) {
-    return (
-      <section className="grn-section">
-        <SectionHeading eyebrow="Overview" title="Your garden" />
-        <Panel className="grn-page-error">
-          <span className="grn-page-error__icon" aria-hidden="true">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-          </span>
-          <h2>Failed to load your garden</h2>
-          <p>{error instanceof Error ? error.message : 'An unexpected error occurred.'}</p>
-          <div className="grn-page-error__actions">
-            <Button onClick={() => void refetch()} variant="primary">Try again</Button>
-            <Button onClick={() => void handleSignOut()} variant="secondary">Sign out</Button>
-          </div>
-        </Panel>
-      </section>
-    );
-  }
-
-  const greetingName = firstName(profile.displayName, profile.email);
-  const hasCrops = crops.length > 0;
 
   return (
     <section className="grn-section grn-dashboard">
       <SectionHeading
-        eyebrow="Overview"
-        title={`Welcome back, ${greetingName}`}
-        body="Here's what's happening in your garden and what to do next."
+        title={`Today, ${greetingName}`}
+        body="A short, prioritized list of what will help your garden most right now."
       />
 
-      {!hasCrops && !cropsLoading ? (
-        <Card padding="6" className="grn-dashboard__empty">
-          <span className="grn-dashboard__empty-emoji" aria-hidden="true">🌱</span>
-          <h3>Start your garden</h3>
-          <p>
-            Add your first crop to track planting dates, beds, and harvests — and
-            we&apos;ll surface what needs your attention right here.
-          </p>
-          <Button variant="primary" size="md" onClick={() => navigate('/garden/plants/new')}>
-            Add your first crop
-          </Button>
-        </Card>
-      ) : (
-        <div className="grn-stat-grid">
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plants')}>
-            <span className="grn-stat-tile__value">{stats.growing.length}</span>
-            <span className="grn-stat-tile__label">Growing now</span>
-          </button>
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plants')}>
-            <span className="grn-stat-tile__value">{stats.readySoon.length}</span>
-            <span className="grn-stat-tile__label">Ready to harvest</span>
-          </button>
-          <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plan')}>
-            <span className="grn-stat-tile__value">{stats.planning.length}</span>
-            <span className="grn-stat-tile__label">Planning &amp; interested</span>
-          </button>
+      {!isOnline ? (
+        <div className="grn-today-notice" role="status">
+          You are offline. Showing the latest garden information saved on this device.
         </div>
+      ) : null}
+
+      {failedQueries.length > 0 ? (
+        <div className="grn-today-notice grn-today-notice--warning" role="alert">
+          <span>Some of Today could not refresh. The available actions are still shown.</span>
+          <Button variant="ghost" size="sm" onClick={retryFailed}>
+            Try again
+          </Button>
+        </div>
+      ) : null}
+
+      {isInitialLoading ? (
+        <Panel className="grn-page-status">
+          <PlantLoader size="md" />
+          <p>Finding your next steps…</p>
+        </Panel>
+      ) : (
+        <ol className="grn-today-actions" aria-label="Your top actions today">
+          {actions.map((action, index) => (
+            <li key={action.id}>
+              <Card padding="6" className="grn-today-action">
+                <div className="grn-today-action__topline">
+                  <span className="grn-today-action__rank" aria-label={`Priority ${index + 1}`}>
+                    {index + 1}
+                  </span>
+                  <span className="grn-today-action__label">{action.label}</span>
+                </div>
+                <h2>{action.title}</h2>
+                <p>{action.body}</p>
+                <Button
+                  variant={index === 0 ? 'primary' : 'secondary'}
+                  size="md"
+                  onClick={() => {
+                    recordTodayActionOpen(action.kind, index + 1, action.destination);
+                    navigate(action.to);
+                  }}
+                >
+                  {action.cta}
+                </Button>
+              </Card>
+            </li>
+          ))}
+        </ol>
       )}
 
-      {hasCrops ? (
-        <div className="grn-dashboard__columns">
-          <Card padding="6" className="grn-dashboard__panel">
-            <div className="grn-dashboard__panel-head">
-              <h3>Upcoming harvests</h3>
-              <Button variant="ghost" size="sm" onClick={() => navigate('/garden/plants')}>
-                My garden
-              </Button>
-            </div>
-            {upcomingHarvests.length === 0 ? (
-              <p className="grn-dashboard__muted">
-                No harvest dates set yet. Add planting and harvest dates to your crops to
-                see them here.
-              </p>
-            ) : (
-              <ul className="grn-dashboard__list" role="list">
-                {upcomingHarvests.map((crop) => {
-                  const days = daysUntil(crop.expectedHarvestDate);
-                  const progress = harvestProgress(crop.plantingDate, crop.expectedHarvestDate);
-                  return (
-                    <li key={crop.id} className="grn-dashboard__row">
-                      <div className="grn-dashboard__row-main">
-                        <span className="grn-dashboard__row-title">
-                          {crop.nickname || crop.cropName}
-                        </span>
-                        <span className="grn-dashboard__row-meta">{harvestLabel(days)}</span>
-                      </div>
-                      {progress !== null ? (
-                        <span
-                          className="grn-dashboard__progress"
-                          role="progressbar"
-                          aria-valuenow={progress}
-                          aria-valuemin={0}
-                          aria-valuemax={100}
-                          aria-label={`${crop.nickname || crop.cropName} harvest progress`}
-                        >
-                          <span
-                            className="grn-dashboard__progress-fill"
-                            style={{ width: `${progress}%` }}
-                          />
-                        </span>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </Card>
-
-          <Card padding="6" className="grn-dashboard__panel">
-            <div className="grn-dashboard__panel-head">
-              <h3>Upcoming reminders</h3>
-              <Button variant="ghost" size="sm" onClick={() => navigate('/today/reminders')}>
-                Reminders
-              </Button>
-            </div>
-            {upcomingReminders.length === 0 ? (
-              <p className="grn-dashboard__muted">
-                No active reminders. Set reminders to stay on top of watering, feeding,
-                and succession planting.
-              </p>
-            ) : (
-              <ul className="grn-dashboard__list" role="list">
-                {upcomingReminders.map((reminder) => (
-                  <li key={reminder.id} className="grn-dashboard__row">
-                    <div className="grn-dashboard__row-main">
-                      <span className="grn-dashboard__row-title">{reminder.title}</span>
-                      <span className="grn-dashboard__row-meta">{reminderLabel(reminder.nextRunAt)}</span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Card>
-        </div>
+      {cropsQuery.data !== undefined ? (
+        <section className="grn-dashboard__glance" aria-labelledby="garden-glance-heading">
+          <div className="grn-dashboard__panel-head">
+            <h2 id="garden-glance-heading">Garden at a glance</h2>
+            <Button variant="ghost" size="sm" onClick={() => navigate('/garden')}>
+              Open garden
+            </Button>
+          </div>
+          <div className="grn-stat-grid">
+            <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plants')}>
+              <span className="grn-stat-tile__value">{stats.growing}</span>
+              <span className="grn-stat-tile__label">Growing now</span>
+            </button>
+            <button type="button" className="grn-stat-tile" onClick={() => navigate('/garden/plan')}>
+              <span className="grn-stat-tile__value">{stats.planning}</span>
+              <span className="grn-stat-tile__label">Still planning</span>
+            </button>
+            <button type="button" className="grn-stat-tile" onClick={() => navigate('/share/listings')}>
+              <span className="grn-stat-tile__value">{stats.sharing}</span>
+              <span className="grn-stat-tile__label">Ready to share</span>
+            </button>
+          </div>
+        </section>
       ) : null}
 
       <Card padding="6" className="grn-dashboard__connect">
         <div className="grn-dashboard__connect-copy">
-          <h3>Grow better together</h3>
-          <p>
-            Share your surplus, find fresh food nearby, and see what your neighbors need —
-            all optional, whenever you&apos;re ready.
-          </p>
+          <h2>Share when you are ready</h2>
+          <p>Offer surplus, coordinate pickup, or see what people nearby need. Sharing is always optional.</p>
         </div>
         <Button variant="secondary" size="md" onClick={() => navigate('/share')}>
-          Explore Share
+          Open Share
         </Button>
       </Card>
     </section>

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -5,6 +5,7 @@ import { Panel, SectionHeading } from '@olivias/ui';
 import { CropForm } from '../components/CropPlanner/CropForm';
 import { PlantLoader } from '../components/branding/PlantLoader';
 import { getMe, listMyBeds } from '../services/api';
+import { completeTodayAction } from '../utils/todayActionTracking';
 
 /**
  * Standalone page wrapper around <CropForm/> — the full add-a-crop form
@@ -62,7 +63,10 @@ export function NewCropPage() {
         lockedBed={lockedBed}
         initialBedId={requestedBedId}
         onCancel={() => navigate('/garden/plants')}
-        onSuccess={() => navigate('/garden/plants', { replace: true })}
+        onSuccess={() => {
+          completeTodayAction('start');
+          navigate('/garden/plants', { replace: true });
+        }}
       />
     </section>
   );

--- a/apps/grn/src/pages/todayActions.test.ts
+++ b/apps/grn/src/pages/todayActions.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { GrowerCropItem } from '../types/listing';
+import { buildTodayActions } from './todayActions';
+
+function crop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
+  return {
+    id: 'crop-1',
+    userId: 'grower-1',
+    canonicalId: null,
+    cropName: 'Tomato',
+    varietyId: null,
+    status: 'growing',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: null,
+    bedName: null,
+    plantingDate: null,
+    expectedHarvestDate: null,
+    plantCount: null,
+    spacingInches: null,
+    pyramidTier: null,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...overrides,
+  };
+}
+
+describe('buildTodayActions', () => {
+  it('uses deterministic priority and caps the queue at three', () => {
+    const actions = buildTodayActions({
+      userId: 'grower-1',
+      now: new Date('2026-07-14T12:00:00Z'),
+      cropsLoaded: true,
+      crops: [
+        crop({ id: 'harvest', expectedHarvestDate: '2026-07-14' }),
+        crop({ id: 'plan', cropName: 'Kale', status: 'planning' }),
+      ],
+      reminders: [
+        {
+          id: 'reminder',
+          title: 'Water',
+          reminderType: 'watering',
+          cadenceDays: 1,
+          startDate: '2026-07-01',
+          timezone: 'UTC',
+          status: 'active',
+          nextRunAt: '2026-07-14T09:00:00Z',
+          lastRunAt: null,
+          createdAt: '2026-07-01T00:00:00Z',
+        },
+      ],
+      claims: [
+        {
+          id: 'claim',
+          listingId: 'listing',
+          requestId: null,
+          claimerId: 'neighbor',
+          listingOwnerId: 'grower-1',
+          quantityClaimed: '1',
+          status: 'pending',
+          notes: null,
+          claimedAt: '2026-07-14T08:00:00Z',
+          confirmedAt: null,
+          completedAt: null,
+          cancelledAt: null,
+        },
+      ],
+      signals: [],
+    });
+
+    expect(actions.map((action) => action.kind)).toEqual(['claim', 'reminder', 'harvest']);
+    expect(actions).toHaveLength(3);
+    expect(actions[0].to).toBe('/share/listings?listing=listing&claim=claim');
+  });
+
+  it('links a confirmed claim to the exact pickup record', () => {
+    const [action] = buildTodayActions({
+      userId: 'grower-1',
+      now: new Date('2026-07-14T12:00:00Z'),
+      crops: [],
+      cropsLoaded: true,
+      reminders: [],
+      signals: [],
+      claims: [
+        {
+          id: 'claim-1',
+          listingId: 'listing-1',
+          requestId: null,
+          claimerId: 'grower-1',
+          listingOwnerId: 'neighbor-1',
+          quantityClaimed: '1',
+          status: 'confirmed',
+          notes: null,
+          claimedAt: '2026-07-14T08:00:00Z',
+          confirmedAt: '2026-07-14T09:00:00Z',
+          completedAt: null,
+          cancelledAt: null,
+        },
+      ],
+    });
+
+    expect(action.kind).toBe('pickup');
+    expect(action.to).toBe('/share/find?claim=claim-1');
+  });
+
+  it('returns one clear start action for an empty, loaded garden', () => {
+    const actions = buildTodayActions({
+      crops: [],
+      cropsLoaded: true,
+      reminders: [],
+      claims: [],
+      signals: [],
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({ kind: 'start', to: '/garden/plants/new' });
+  });
+});

--- a/apps/grn/src/pages/todayActions.ts
+++ b/apps/grn/src/pages/todayActions.ts
@@ -1,0 +1,196 @@
+import type { ReminderItem } from '../services/api';
+import type { Claim } from '../types/claim';
+import type { DerivedFeedSignal } from '../types/feed';
+import type { GrowerCropItem } from '../types/listing';
+import type { TodayActionKind } from '../utils/todayActionTracking';
+
+export type { TodayActionKind } from '../utils/todayActionTracking';
+
+export interface TodayAction {
+  id: string;
+  kind: TodayActionKind;
+  label: string;
+  title: string;
+  body: string;
+  cta: string;
+  to: string;
+  destination: 'garden' | 'reminders' | 'share';
+  priority: number;
+}
+
+interface BuildTodayActionsInput {
+  userId?: string;
+  crops: GrowerCropItem[];
+  cropsLoaded: boolean;
+  reminders: ReminderItem[];
+  claims: Claim[];
+  signals: DerivedFeedSignal[];
+  now?: Date;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HARVEST_WINDOW_DAYS = 7;
+
+function timestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function cropName(crop: GrowerCropItem): string {
+  return crop.nickname?.trim() || crop.cropName;
+}
+
+function harvestBody(harvestAt: number, now: number): string {
+  const days = Math.ceil((harvestAt - now) / DAY_MS);
+  if (days < 0) return `Its harvest date was ${Math.abs(days)} day${days === -1 ? '' : 's'} ago.`;
+  if (days === 0) return 'Its harvest window is open today.';
+  if (days === 1) return 'Its harvest window opens tomorrow.';
+  return `Its harvest window opens in ${days} days.`;
+}
+
+/**
+ * Builds a record-linked, deterministic action queue. Lower priorities are
+ * more urgent; the page deliberately exposes no more than three at a time.
+ */
+export function buildTodayActions({
+  userId,
+  crops,
+  cropsLoaded,
+  reminders,
+  claims,
+  signals,
+  now = new Date(),
+}: BuildTodayActionsInput): TodayAction[] {
+  const nowMs = now.getTime();
+  const candidates: TodayAction[] = [];
+
+  for (const claim of claims) {
+    if (claim.status === 'pending' && userId && claim.listingOwnerId === userId) {
+      candidates.push({
+        id: `claim:${claim.id}`,
+        kind: 'claim',
+        label: 'Share',
+        title: 'Review a sharing request',
+        body: 'Someone is waiting for you to confirm pickup details.',
+        cta: 'Review request',
+        to: `/share/listings?listing=${encodeURIComponent(claim.listingId)}&claim=${encodeURIComponent(claim.id)}`,
+        destination: 'share',
+        priority: 10,
+      });
+    }
+  }
+
+  for (const reminder of reminders) {
+    const dueAt = timestamp(reminder.nextRunAt);
+    if (reminder.status !== 'active' || dueAt === null || dueAt > nowMs) continue;
+    candidates.push({
+      id: `reminder:${reminder.id}`,
+      kind: 'reminder',
+      label: 'Due now',
+      title: reminder.title,
+      body: `Your ${reminder.reminderType.replace('_', ' ')} reminder is ready.`,
+      cta: 'Open reminder',
+      to: `/today/reminders?reminder=${encodeURIComponent(reminder.id)}`,
+      destination: 'reminders',
+      priority: 20,
+    });
+  }
+
+  for (const crop of crops) {
+    if (crop.status !== 'growing') continue;
+    const harvestAt = timestamp(crop.expectedHarvestDate);
+    if (harvestAt === null || harvestAt > nowMs + HARVEST_WINDOW_DAYS * DAY_MS) continue;
+    candidates.push({
+      id: `harvest:${crop.id}`,
+      kind: 'harvest',
+      label: 'Harvest',
+      title: `Check ${cropName(crop)}`,
+      body: harvestBody(harvestAt, nowMs),
+      cta: 'Log harvest',
+      to: `/garden/plants?crop=${encodeURIComponent(crop.id)}&action=harvest`,
+      destination: 'garden',
+      priority: 30 + Math.max(-5, Math.ceil((harvestAt - nowMs) / DAY_MS)) / 100,
+    });
+  }
+
+  for (const claim of claims) {
+    if (claim.status === 'confirmed' && userId && claim.claimerId === userId) {
+      candidates.push({
+        id: `pickup:${claim.id}`,
+        kind: 'pickup',
+        label: 'Pickup',
+        title: 'Review a confirmed pickup',
+        body: 'Your shared-food claim is confirmed. Check the coordination details.',
+        cta: 'Review pickup',
+        to: `/share/find?claim=${encodeURIComponent(claim.id)}`,
+        destination: 'share',
+        priority: 40,
+      });
+    }
+  }
+
+  const planningCrop = crops.find((crop) => crop.status === 'planning' || crop.status === 'interested');
+  if (planningCrop) {
+    candidates.push({
+      id: `plan:${planningCrop.id}`,
+      kind: 'plan',
+      label: 'Plan',
+      title: 'Finish your growing plan',
+      body: `${cropName(planningCrop)} is waiting for a place in your garden plan.`,
+      cta: 'Open plan',
+      to: '/garden/plan',
+      destination: 'garden',
+      priority: 50,
+    });
+  }
+
+  const localSignal = [...signals]
+    .filter((signal) => signal.cropId && signal.requestCount > signal.listingCount)
+    .sort((left, right) => right.scarcityScore - left.scarcityScore)[0];
+  if (localSignal?.cropId) {
+    candidates.push({
+      id: `local:${localSignal.cropId}`,
+      kind: 'local',
+      label: 'Nearby',
+      title: 'See what neighbors need',
+      body: 'There is more local interest than available produce for a crop near you.',
+      cta: 'View suggestion',
+      to: `/garden/plan/recommendations?crop=${encodeURIComponent(localSignal.cropId)}`,
+      destination: 'garden',
+      priority: 60,
+    });
+  }
+
+  if (candidates.length === 0) {
+    if (cropsLoaded && crops.length === 0) {
+      candidates.push({
+        id: 'start:first-crop',
+        kind: 'start',
+        label: 'Start here',
+        title: 'Add your first crop',
+        body: 'Tell us what you are growing so Today can surface timely next steps.',
+        cta: 'Add a crop',
+        to: '/garden/plants/new',
+        destination: 'garden',
+        priority: 90,
+      });
+    } else {
+      candidates.push({
+        id: 'review:garden',
+        kind: 'review',
+        label: 'Garden',
+        title: 'Your garden is on track',
+        body: 'Nothing is urgent. Take a quick look or keep enjoying the growing season.',
+        cta: 'Open garden',
+        to: '/garden',
+        destination: 'garden',
+        priority: 90,
+      });
+    }
+  }
+
+  return candidates
+    .sort((left, right) => left.priority - right.priority || left.id.localeCompare(right.id))
+    .slice(0, 3);
+}

--- a/apps/grn/src/services/claims.test.ts
+++ b/apps/grn/src/services/claims.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import apiFetch from './api';
+import { listClaims } from './claims';
+
+vi.mock('./api', () => ({ default: vi.fn() }));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+describe('listClaims', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends supported filters and normalizes paginated claim fields', async () => {
+    mockApiFetch.mockResolvedValue({
+      items: [
+        {
+          id: 'claim-1',
+          listing_id: 'listing-1',
+          request_id: null,
+          claimer_id: 'grower-2',
+          listing_owner_id: 'grower-1',
+          quantity_claimed: '2',
+          status: 'pending',
+          notes: null,
+          claimed_at: '2026-07-14T09:00:00Z',
+          confirmed_at: null,
+          completed_at: null,
+          cancelled_at: null,
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      has_more: true,
+      next_offset: 50,
+    });
+
+    const result = await listClaims({ listingId: 'listing-1', status: 'pending', limit: 50 });
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/claims?limit=50&offset=0&listingId=listing-1&status=pending'
+    );
+    expect(result).toMatchObject({ hasMore: true, nextOffset: 50 });
+    expect(result.items[0]).toMatchObject({
+      id: 'claim-1',
+      listingId: 'listing-1',
+      listingOwnerId: 'grower-1',
+      quantityClaimed: '2',
+    });
+  });
+});

--- a/apps/grn/src/services/claims.ts
+++ b/apps/grn/src/services/claims.ts
@@ -1,6 +1,22 @@
 import apiFetch from './api';
 import type { Claim, CreateClaimPayload, TransitionClaimPayload } from '../types/claim';
 
+export interface ListClaimsQuery {
+  listingId?: string;
+  requestId?: string;
+  status?: Claim['status'];
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListClaimsResponse {
+  items: Claim[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset: number | null;
+}
+
 interface RawClaimResponse {
   id: string;
   listingId?: string;
@@ -39,6 +55,38 @@ function mapClaim(raw: RawClaimResponse): Claim {
     confirmedAt: raw.confirmedAt ?? raw.confirmed_at ?? null,
     completedAt: raw.completedAt ?? raw.completed_at ?? null,
     cancelledAt: raw.cancelledAt ?? raw.cancelled_at ?? null,
+  };
+}
+
+interface RawListClaimsResponse {
+  items: RawClaimResponse[];
+  limit: number;
+  offset: number;
+  hasMore?: boolean;
+  has_more?: boolean;
+  nextOffset?: number | null;
+  next_offset?: number | null;
+}
+
+export async function listClaims({
+  listingId,
+  requestId,
+  status,
+  limit = 20,
+  offset = 0,
+}: ListClaimsQuery = {}): Promise<ListClaimsResponse> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (listingId) params.set('listingId', listingId);
+  if (requestId) params.set('requestId', requestId);
+  if (status) params.set('status', status);
+
+  const response = await apiFetch<RawListClaimsResponse>(`/claims?${params.toString()}`);
+  return {
+    items: response.items.map(mapClaim),
+    limit: response.limit,
+    offset: response.offset,
+    hasMore: response.hasMore ?? response.has_more ?? false,
+    nextOffset: response.nextOffset ?? response.next_offset ?? null,
   };
 }
 

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -68,7 +68,7 @@ export function AuthenticatedRoot() {
         ) : (
           <OnboardingGuard user={user} refreshUser={refreshUser}>
             <Routes>
-              <Route path="/" element={<DashboardPage />} />
+              <Route path="/" element={<DashboardPage user={user} />} />
               <Route path="/today/reminders" element={<RemindersPage />} />
               <Route path="/garden" element={<GardenDesignerPage />} />
               <Route path="/garden/plants" element={<CropsPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -5111,6 +5111,99 @@ body {
   gap: 1.25rem;
 }
 
+.grn-today-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(66, 107, 63, 0.28);
+  border-radius: var(--og-radius-base);
+  background: rgba(66, 107, 63, 0.08);
+  color: var(--og-color-soil);
+  font-size: 0.9rem;
+}
+
+.grn-today-notice--warning {
+  border-color: rgba(168, 104, 31, 0.35);
+  background: rgba(244, 197, 112, 0.16);
+}
+
+.grn-today-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grn-today-actions > li,
+.grn-today-action,
+.grn-today-action > .og-card-body {
+  height: 100%;
+}
+
+.grn-today-action > .og-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.65rem;
+}
+
+.grn-today-action__topline {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.grn-today-action__rank {
+  display: inline-grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: var(--og-color-moss);
+  color: white;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.grn-today-action__label {
+  color: var(--og-color-moss);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.grn-today-action h2 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-size: 1.15rem;
+  line-height: 1.25;
+  letter-spacing: normal;
+}
+
+.grn-today-action p {
+  flex: 1;
+  margin: 0;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.grn-today-action button {
+  min-height: 2.75rem;
+}
+
+.grn-dashboard__glance {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .grn-stat-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -5165,9 +5258,11 @@ body {
   margin-bottom: 0.75rem;
 }
 
+.grn-dashboard__panel-head h2,
 .grn-dashboard__panel-head h3 {
   margin: 0;
   font-size: 1.05rem;
+  letter-spacing: normal;
 }
 
 .grn-dashboard__list {
@@ -5260,8 +5355,11 @@ body {
   flex-wrap: wrap;
 }
 
+.grn-dashboard__connect-copy h2,
 .grn-dashboard__connect-copy h3 {
   margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+  letter-spacing: normal;
 }
 
 .grn-dashboard__connect-copy p {
@@ -5271,6 +5369,15 @@ body {
 }
 
 @media (max-width: 720px) {
+  .grn-today-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .grn-today-notice {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .grn-stat-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 0.5rem;

--- a/apps/grn/src/utils/todayActionTracking.test.ts
+++ b/apps/grn/src/utils/todayActionTracking.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { completeTodayAction, recordTodayActionOpen } from './todayActionTracking';
+
+describe('Today action tracking', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('logs a privacy-safe completion only for the matching opened action', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    recordTodayActionOpen('harvest', 1, 'garden');
+    completeTodayAction('claim');
+    expect(info).not.toHaveBeenCalledWith(
+      '[today]',
+      'Today action completed',
+      expect.anything()
+    );
+
+    completeTodayAction('harvest');
+    expect(info).toHaveBeenCalledWith(
+      '[today]',
+      'Today action completed',
+      { actionKind: 'harvest' }
+    );
+    expect(window.sessionStorage.length).toBe(0);
+  });
+});

--- a/apps/grn/src/utils/todayActionTracking.ts
+++ b/apps/grn/src/utils/todayActionTracking.ts
@@ -1,0 +1,45 @@
+import { createLogger } from './logging';
+
+export type TodayActionKind =
+  | 'claim'
+  | 'reminder'
+  | 'harvest'
+  | 'pickup'
+  | 'plan'
+  | 'local'
+  | 'start'
+  | 'review';
+
+const STORAGE_KEY = 'grn-today-action-v1';
+const logger = createLogger('today');
+
+interface PendingTodayAction {
+  kind: TodayActionKind;
+}
+
+export function recordTodayActionOpen(
+  kind: TodayActionKind,
+  rank: number,
+  destination: 'garden' | 'reminders' | 'share'
+): void {
+  logger.info('Today action opened', { actionKind: kind, rank, destination });
+  try {
+    const pending: PendingTodayAction = { kind };
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+  } catch {
+    // Storage is a best-effort measurement handoff; navigation must still work.
+  }
+}
+
+export function completeTodayAction(kind: TodayActionKind): void {
+  try {
+    const serialized = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!serialized) return;
+    const pending = JSON.parse(serialized) as Partial<PendingTodayAction>;
+    if (pending.kind !== kind) return;
+    window.sessionStorage.removeItem(STORAGE_KEY);
+    logger.info('Today action completed', { actionKind: kind });
+  } catch {
+    // Completion tracking must never interrupt the underlying workflow.
+  }
+}

--- a/services/grn-api/functions/ci-auth-seed.mjs
+++ b/services/grn-api/functions/ci-auth-seed.mjs
@@ -182,6 +182,16 @@ async function upsertUser(client, userId, email, { role, tier }) {
 }
 
 /**
+ * CI users are intentionally reused between staging runs. Clear their
+ * rolling AI allowance when fresh credentials are seeded so a previous PR's
+ * contract run cannot make the next run fail with a documented 429 response.
+ * This Lambda is never deployed to production.
+ */
+export async function resetCiUserUsage(client, userId) {
+  await client.query(`DELETE FROM ai_usage_events WHERE user_id = $1`, [userId]);
+}
+
+/**
  * Provision a single named user: create/reuse in Cognito, upsert in Postgres,
  * return tokens keyed by the caller-supplied name.
  */
@@ -190,6 +200,7 @@ async function provisionUser(client, { name, role, tier }) {
   await ensureTierGroup(tokens.email, tier);
   const userId = decodeSubFromJwt(tokens.id_token);
   await upsertUser(client, userId, tokens.email, { role, tier });
+  await resetCiUserUsage(client, userId);
   return { name, ...tokens };
 }
 

--- a/services/grn-api/functions/tests/ci-auth-seed.test.mjs
+++ b/services/grn-api/functions/tests/ci-auth-seed.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resetCiUserUsage } from "../ci-auth-seed.mjs";
+
+test("resetCiUserUsage clears rolling AI allowance for the seeded CI user", async () => {
+  const calls = [];
+  const client = {
+    query: async (...args) => {
+      calls.push(args);
+    },
+  };
+
+  await resetCiUserUsage(client, "11111111-1111-1111-1111-111111111111");
+
+  assert.deepEqual(calls, [
+    [
+      "DELETE FROM ai_usage_events WHERE user_id = $1",
+      ["11111111-1111-1111-1111-111111111111"],
+    ],
+  ]);
+});


### PR DESCRIPTION
## Summary

- replace the signed-in profile dashboard with a deterministic, action-first Today queue capped at three ranked next steps
- keep successful garden, reminder, claim, and local-signal data visible through partial failures and offline states
- deep-link harvests, reminders, listing claims, and pickup claims to the exact existing record or workflow
- reuse the existing claims and derived-feed APIs, including server-backed claim history in the coordination panels
- record privacy-safe Today impressions, openings, and matching workflow completions without record IDs or user content
- reset rolling AI allowance for synthetic CI users when their staging credentials are seeded, preventing one PR's contract run from exhausting the next PR's documented quota

## Verification

- `npm test -w @olivias/grn` — 548 passed
- `npm run lint -w @olivias/grn`
- `npm run typecheck -w @olivias/grn`
- `npm run build -w @olivias/grn`
- `npm run perf:budget -w @olivias/grn`
- `npm test -w @olivias/grn-api` — 49 passed
- `npm run lint -w @olivias/grn-api`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 227 unit tests plus contract/integration suites passed

## Local environment notes

- `cargo fmt --all -- --check` reports CRLF newline differences across all pre-existing Rust sources in this Windows worktree. This PR changes no Rust files; the Linux PR formatting check is the authoritative gate and must pass before merge.
- The authenticated mobile browser preview reached the local login handoff, but that separate login service was not running. Mobile layout, offline behavior, and exact deep links are covered by focused component tests.
- No API endpoint or response contract changed, so no Postman collection update is required. The CI-only auth seeder now resets transient quota state for its synthetic users so the existing 200-response contract remains deterministic.

Closes #372
