### PR TITLE
Unify Garden Map, Plants, and Plan

### DIFF
--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { CropLibraryPanel } from './CropLibraryPanel';
-import { listMyBeds, listMyCrops } from '../../services/api';
+import { listMyBeds, listMyCrops, updateMyCrop } from '../../services/api';
 
 vi.mock('../../services/api', () => ({
   deleteMyCrop: vi.fn(),
   listMyBeds: vi.fn(),
   listMyCrops: vi.fn(),
+  updateMyCrop: vi.fn(),
 }));
 
 vi.mock('../Harvests/HarvestLogModal', () => ({
@@ -55,5 +57,86 @@ describe('CropLibraryPanel deep links', () => {
     );
 
     expect(await screen.findByRole('dialog', { name: 'Harvest Cherry tomatoes' })).toBeInTheDocument();
+  });
+
+  it('changes a crop bed optimistically through the shared crop query', async () => {
+    const tomato = {
+      id: 'crop-1',
+      userId: 'grower-1',
+      canonicalId: null,
+      cropName: 'Tomato',
+      varietyId: null,
+      status: 'growing',
+      visibility: 'private',
+      surplusEnabled: false,
+      nickname: null,
+      defaultUnit: 'lb',
+      notes: null,
+      bedId: null,
+      bedName: null,
+      plantingDate: null,
+      expectedHarvestDate: null,
+      plantCount: null,
+      spacingInches: null,
+      pyramidTier: 2,
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+    };
+    vi.mocked(listMyBeds).mockResolvedValue([
+      {
+        id: 'bed-1',
+        userId: 'grower-1',
+        name: 'Kitchen bed',
+        description: null,
+        sunExposure: null,
+        soilType: null,
+        lengthInches: 96,
+        widthInches: 48,
+        locationNotes: null,
+        sortOrder: 0,
+        bedType: 'raised',
+        shape: 'rect',
+        positionX: 0,
+        positionY: 0,
+        rotationDeg: 0,
+        points: null,
+        color: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    const updatedTomato = {
+      ...tomato,
+      bedId: 'bed-1',
+      bedName: 'Kitchen bed',
+    };
+    vi.mocked(listMyCrops)
+      .mockResolvedValueOnce([tomato])
+      .mockResolvedValue([updatedTomato]);
+    vi.mocked(updateMyCrop).mockResolvedValue(updatedTomato);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/garden/plants']}>
+          <CropLibraryPanel viewerUserId="grower-1" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await userEvent.selectOptions(
+      await screen.findByRole('combobox', { name: 'Bed assignment for Tomato' }),
+      'bed-1'
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Bed assignment for Tomato' })).toHaveValue(
+      'bed-1'
+    );
+    await waitFor(() =>
+      expect(updateMyCrop).toHaveBeenCalledWith(
+        'crop-1',
+        expect.objectContaining({ cropName: 'Tomato', bedId: 'bed-1' })
+      )
+    );
   });
 });

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -1,7 +1,13 @@
 import { useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { listMyCrops, deleteMyCrop, listMyBeds } from '../../services/api';
+import {
+  listMyCrops,
+  deleteMyCrop,
+  listMyBeds,
+  updateMyCrop,
+  type UpsertGrowerCropRequest,
+} from '../../services/api';
 import type { GrowerCropItem } from '../../types/listing';
 import { Button, Card } from '@olivias/ui';
 import { createLogger } from '../../utils/logging';
@@ -31,6 +37,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
   const [filter, setFilter] = useState<'all' | 'growing' | 'planning' | 'interested'>('all');
   const [harvestCrop, setHarvestCrop] = useState<GrowerCropItem | null>(null);
   const [dismissedLinkedHarvestId, setDismissedLinkedHarvestId] = useState<string | null>(null);
+  const [bedUpdateError, setBedUpdateError] = useState<string | null>(null);
 
   const { data: myCrops, isLoading: isLoadingCrops } = useQuery({
     queryKey: ['myCrops'],
@@ -61,6 +68,37 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
     },
     onError: (error) => {
       logger.error('Failed to remove crop', error instanceof Error ? error : undefined);
+    },
+  });
+
+  const bedMutation = useMutation({
+    mutationFn: ({ crop, bedId }: { crop: GrowerCropItem; bedId: string | null }) =>
+      updateMyCrop(crop.id, cropUpdatePayload(crop, bedId)),
+    onMutate: async ({ crop, bedId }) => {
+      setBedUpdateError(null);
+      await queryClient.cancelQueries({ queryKey: ['myCrops'] });
+      const previous = queryClient.getQueryData<GrowerCropItem[]>(['myCrops']);
+      const bedName = beds.find((bed) => bed.id === bedId)?.name ?? null;
+      queryClient.setQueryData<GrowerCropItem[]>(['myCrops'], (current) =>
+        current?.map((item) =>
+          item.id === crop.id ? { ...item, bedId, bedName } : item
+        )
+      );
+      return { previous };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['myCrops'], context.previous);
+      }
+      setBedUpdateError(
+        error instanceof Error ? error.message : 'Could not update that bed assignment.'
+      );
+    },
+    onSuccess: () => {
+      logger.info('Updated crop bed assignment');
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['myCrops'] });
     },
   });
 
@@ -246,6 +284,25 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                       />
                     </div>
                   ) : null}
+
+                  <label className="grn-crop-card__bed-field">
+                    <span>Bed assignment</span>
+                    <select
+                      value={crop.bedId ?? ''}
+                      aria-label={`Bed assignment for ${crop.nickname || crop.cropName}`}
+                      disabled={bedMutation.isPending}
+                      onChange={(event) =>
+                        bedMutation.mutate({ crop, bedId: event.target.value || null })
+                      }
+                    >
+                      <option value="">Not assigned</option>
+                      {beds.map((bed) => (
+                        <option key={bed.id} value={bed.id}>
+                          {bed.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
                 </div>
 
                 <footer className="grn-crop-card__footer">
@@ -256,15 +313,15 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                   >
                     Harvests
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => navigate(`/garden/plants/new?edit=${crop.id}`)}
-                    disabled
-                    title="Editing comes next — for now, remove and re-add"
-                  >
-                    Edit
-                  </Button>
+                  {crop.bedId ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => navigate(`/garden?bed=${crop.bedId}&crop=${crop.id}`)}
+                    >
+                      View on Map
+                    </Button>
+                  ) : null}
                   <Button
                     variant="outline"
                     size="sm"
@@ -281,6 +338,12 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
         </div>
       </Card>
 
+      {bedUpdateError ? (
+        <p className="grn-page-status__error" role="alert">
+          {bedUpdateError}
+        </p>
+      ) : null}
+
       {activeHarvestCrop ? (
         <HarvestLogModal
           cropId={activeHarvestCrop.id}
@@ -296,4 +359,26 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
       ) : null}
     </div>
   );
+}
+
+function cropUpdatePayload(
+  crop: GrowerCropItem,
+  bedId: string | null
+): UpsertGrowerCropRequest {
+  return {
+    canonicalId: crop.canonicalId ?? undefined,
+    cropName: crop.cropName,
+    varietyId: crop.varietyId ?? undefined,
+    status: crop.status,
+    visibility: crop.visibility,
+    surplusEnabled: crop.surplusEnabled,
+    nickname: crop.nickname ?? undefined,
+    defaultUnit: crop.defaultUnit ?? undefined,
+    notes: crop.notes ?? undefined,
+    bedId,
+    plantingDate: crop.plantingDate,
+    expectedHarvestDate: crop.expectedHarvestDate,
+    plantCount: crop.plantCount,
+    spacingInches: crop.spacingInches,
+  };
 }

--- a/apps/grn/src/hooks/useGardenDesigner.ts
+++ b/apps/grn/src/hooks/useGardenDesigner.ts
@@ -58,7 +58,9 @@ import {
 import { createSerialMutationQueue } from './serialMutationQueue';
 
 const CANVAS_QUERY_KEY = ['my-garden-canvas'];
-const BEDS_QUERY_KEY = ['my-garden-beds'];
+// Shared with crop forms and the Plants view so bed assignment changes are
+// visible on the map without a second request or manual refresh.
+const BEDS_QUERY_KEY = ['myBeds'];
 const ANNOTATIONS_QUERY_KEY = ['my-garden-annotations'];
 // Shared with the planner, profile, and listing surfaces so a crop added
 // from any of them — including the inline quick-add here — shows up

--- a/apps/grn/src/pages/CropsPage.tsx
+++ b/apps/grn/src/pages/CropsPage.tsx
@@ -16,7 +16,7 @@ export function CropsPage() {
   if (isLoading) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Grower tools" title="My garden" />
+        <SectionHeading title="Plants" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading…</p>
@@ -32,9 +32,8 @@ export function CropsPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Grower tools"
-        title="My garden"
-        body="Track what you grow, when it goes in the ground, and where it lives."
+        title="Plants"
+        body="Track what is growing, record harvests, and keep every crop connected to its bed."
       />
       <CropLibraryPanel viewerUserId={profile.id} />
     </section>

--- a/apps/grn/src/pages/GardenDesignerPage.test.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGardenDesigner, type UseGardenDesignerResult } from '../hooks/useGardenDesigner';
+import { GardenDesignerPage } from './GardenDesignerPage';
+
+vi.mock('../hooks/useGardenDesigner', () => ({
+  useGardenDesigner: vi.fn(),
+}));
+
+vi.mock('../components/GardenMasterplan/GardenMasterplan', () => ({
+  GardenMasterplan: () => <div data-testid="garden-masterplan">Illustrated map</div>,
+}));
+
+const mockUseGardenDesigner = vi.mocked(useGardenDesigner);
+
+function designerResult(): UseGardenDesignerResult {
+  return {
+    canvas: {
+      id: 'canvas-1',
+      userId: 'grower-1',
+      widthInches: 240,
+      heightInches: 180,
+      backgroundImageKey: null,
+      backgroundImageUrl: null,
+      backgroundOpacity: 1,
+      northOffsetDeg: 0,
+      createdAt: '2026-07-01T00:00:00Z',
+      updatedAt: '2026-07-01T00:00:00Z',
+    },
+    beds: [
+      {
+        id: 'bed-1',
+        userId: 'grower-1',
+        name: 'Kitchen bed',
+        description: null,
+        sunExposure: null,
+        soilType: null,
+        lengthInches: 96,
+        widthInches: 48,
+        locationNotes: null,
+        sortOrder: 0,
+        bedType: 'raised',
+        shape: 'rect',
+        positionX: 12,
+        positionY: 12,
+        rotationDeg: 0,
+        points: null,
+        color: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ],
+    annotations: [],
+    crops: [
+      {
+        id: 'crop-1',
+        userId: 'grower-1',
+        canonicalId: null,
+        cropName: 'Tomato',
+        varietyId: null,
+        status: 'growing',
+        visibility: 'private',
+        surplusEnabled: false,
+        nickname: null,
+        defaultUnit: null,
+        notes: null,
+        bedId: 'bed-1',
+        bedName: 'Kitchen bed',
+        plantingDate: null,
+        expectedHarvestDate: null,
+        plantCount: null,
+        spacingInches: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ],
+    cropsByBedId: new Map(),
+    isLoading: false,
+    loadError: null,
+    selected: null,
+    setSelected: vi.fn(),
+    groupSelection: [],
+    toggleSelected: vi.fn(),
+    marqueeSelect: vi.fn(),
+    moveSelectedGroup: vi.fn(),
+    selectedBed: undefined,
+    selectedAnnotation: undefined,
+    mode: 'idle',
+    setMode: vi.fn(),
+    snap: '12',
+    setSnap: vi.fn(),
+    isMobile: false,
+    isEditable: true,
+    isSaving: false,
+    saveError: null,
+    addBed: vi.fn(),
+    addCrop: vi.fn(),
+    duplicateSelected: vi.fn(),
+    applyTemplate: vi.fn(),
+    moveBed: vi.fn(),
+    resizeBed: vi.fn(),
+    patchBed: vi.fn(),
+    updateBedPoints: vi.fn(),
+    deleteBed: vi.fn(),
+    addAnnotation: vi.fn(),
+    moveAnnotation: vi.fn(),
+    resizeAnnotation: vi.fn(),
+    patchAnnotation: vi.fn(),
+    deleteAnnotation: vi.fn(),
+    patchCanvas: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+  };
+}
+
+describe('GardenDesignerPage garden context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the bed containing a directly linked crop', async () => {
+    const designer = designerResult();
+    mockUseGardenDesigner.mockReturnValue(designer);
+
+    render(
+      <MemoryRouter initialEntries={['/garden?crop=crop-1']}>
+        <GardenDesignerPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Map' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(designer.setSelected).toHaveBeenCalledWith({ kind: 'bed', id: 'bed-1' })
+    );
+  });
+});

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { PlantLoader } from '../components/branding/PlantLoader';
 import { GardenMasterplan } from '../components/GardenMasterplan/GardenMasterplan';
 import { useGardenDesigner } from '../hooks/useGardenDesigner';
 
 /**
- * The garden page is a single delightful editor: the illustrated isometric
- * masterplan. Explore the whole property, then select any element to tend
+ * The Map view is the garden workspace's illustrated isometric masterplan.
+ * Explore the whole property, then select any element to tend
  * it and make tight edits in place — drag to move, grab the handles to
  * resize or rotate, reshape custom outlines, and fine-tune every detail in
  * the inspector. There is no separate precision/layout view; everything
@@ -12,6 +14,25 @@ import { useGardenDesigner } from '../hooks/useGardenDesigner';
  */
 export function GardenDesignerPage() {
   const designer = useGardenDesigner();
+  const [searchParams] = useSearchParams();
+  const appliedContext = useRef<string | null>(null);
+  const requestedBedId = searchParams.get('bed') ?? searchParams.get('bedId');
+  const requestedCropId = searchParams.get('crop');
+
+  useEffect(() => {
+    if (designer.isLoading) return;
+    const contextKey = `${requestedBedId ?? ''}:${requestedCropId ?? ''}`;
+    if (appliedContext.current === contextKey) return;
+
+    const cropBedId = requestedCropId
+      ? designer.crops.find((crop) => crop.id === requestedCropId)?.bedId
+      : null;
+    const bedId = requestedBedId ?? cropBedId;
+    if (bedId && designer.beds.some((bed) => bed.id === bedId)) {
+      designer.setSelected({ kind: 'bed', id: bedId });
+    }
+    appliedContext.current = contextKey;
+  }, [designer, requestedBedId, requestedCropId]);
 
   if (designer.isLoading) {
     return (
@@ -40,10 +61,10 @@ export function GardenDesignerPage() {
     <div className={`grn-designer-page ${designer.isMobile ? 'is-mobile' : ''}`}>
       <header className="grn-designer-page__header">
         <div className="grn-designer-page__title-block">
-          <h1 className="grn-designer-page__title">Garden</h1>
+          <h2 className="grn-designer-page__title">Map</h2>
           <p className="grn-designer-page__subtitle">
-            See the whole garden, place beds and landmarks, then select anything to
-            resize, reshape, and tend it — all on the map.
+            Explore beds, landmarks, and what is growing. Select anything for its
+            details and available actions.
           </p>
         </div>
       </header>

--- a/apps/grn/src/pages/GardenWorkspacePage.test.tsx
+++ b/apps/grn/src/pages/GardenWorkspacePage.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GardenWorkspacePage } from './GardenWorkspacePage';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
+}
+
+function renderWorkspace(initialEntry = '/garden') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/garden" element={<GardenWorkspacePage />}>
+          <Route index element={<h2>Map view</h2>} />
+          <Route path="plants" element={<h2>Plants view</h2>} />
+          <Route path="plan" element={<h2>Plan view</h2>} />
+        </Route>
+      </Routes>
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+});
+
+describe('GardenWorkspacePage', () => {
+  it('opens the illustrated map as the useful default view', () => {
+    renderWorkspace();
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Garden' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Map view' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /map/i })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('switches views without dropping selected garden context', async () => {
+    renderWorkspace('/garden?crop=crop-7&bed=bed-2&season=fall');
+
+    await userEvent.click(screen.getByRole('link', { name: /plants/i }));
+
+    expect(screen.getByRole('heading', { name: 'Plants view' })).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plants?crop=crop-7&bed=bed-2&season=fall'
+    );
+  });
+
+  it('lets keyboard users enter each view with native links', async () => {
+    renderWorkspace('/garden');
+    const plantsLink = screen.getByRole('link', { name: /plants/i });
+
+    plantsLink.focus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(screen.getByRole('heading', { name: 'Plants view' })).toBeInTheDocument();
+    expect(plantsLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('announces offline garden behavior and clears it after reconnecting', () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    renderWorkspace('/garden/plan');
+
+    expect(screen.getByText(/you are offline/i)).toBeInTheDocument();
+    fireEvent(window, new Event('online'));
+    expect(screen.queryByText(/you are offline/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/pages/GardenWorkspacePage.tsx
+++ b/apps/grn/src/pages/GardenWorkspacePage.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
+
+const GARDEN_VIEWS = [
+  {
+    id: 'map',
+    label: 'Map',
+    path: '/garden',
+    description: 'Explore beds and what is planted.',
+    end: true,
+  },
+  {
+    id: 'plants',
+    label: 'Plants',
+    path: '/garden/plants',
+    description: 'Manage crops, harvests, and bed assignments.',
+    end: false,
+  },
+  {
+    id: 'plan',
+    label: 'Plan',
+    path: '/garden/plan',
+    description: 'Balance the garden pyramid and planting ideas.',
+    end: false,
+  },
+] as const;
+
+function readOnlineStatus(): boolean {
+  return typeof navigator === 'undefined' || navigator.onLine;
+}
+
+/**
+ * Stable shell for every view of one garden. Query state is carried between
+ * views so a crop, bed, tier, or season selected in one view remains useful
+ * in the next instead of becoming a fresh navigation journey.
+ */
+export function GardenWorkspacePage() {
+  const location = useLocation();
+  const [isOnline, setIsOnline] = useState(readOnlineStatus);
+
+  useEffect(() => {
+    const goOnline = () => setIsOnline(true);
+    const goOffline = () => setIsOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return (
+    <section className="grn-garden-workspace" aria-labelledby="garden-workspace-title">
+      <header className="grn-garden-workspace__header">
+        <div>
+          <h1 id="garden-workspace-title">Garden</h1>
+          <p>
+            See the whole garden, tend what is growing, and shape the season in one place.
+          </p>
+        </div>
+      </header>
+
+      <nav className="grn-garden-views" aria-label="Garden views">
+        {GARDEN_VIEWS.map((view) => (
+          <NavLink
+            key={view.id}
+            to={{ pathname: view.path, search: location.search }}
+            end={view.end}
+            className={({ isActive }) =>
+              `grn-garden-views__link ${isActive ? 'is-active' : ''}`.trim()
+            }
+          >
+            <span className="grn-garden-views__label">{view.label}</span>
+            <span className="grn-garden-views__description">{view.description}</span>
+          </NavLink>
+        ))}
+      </nav>
+
+      {!isOnline ? (
+        <p className="grn-garden-workspace__offline" role="status">
+          You are offline. Showing garden information saved on this device; changes will
+          need a connection.
+        </p>
+      ) : null}
+
+      <div className="grn-garden-workspace__view">
+        <Outlet />
+      </div>
+    </section>
+  );
+}
+
+export default GardenWorkspacePage;

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -54,9 +54,8 @@ export function NewCropPage() {
   return (
     <section className="grn-section grn-new-crop">
       <SectionHeading
-        eyebrow="Plan your garden"
         title="Add a crop"
-        body="Tell us what's going in the ground — we'll tuck it into your garden plan."
+        body="Tell us what's going in the ground and where it belongs."
       />
 
       <CropForm

--- a/apps/grn/src/pages/PlannerPage.test.tsx
+++ b/apps/grn/src/pages/PlannerPage.test.tsx
@@ -46,13 +46,13 @@ function crop(id: string, cropName: string, pyramidTier?: number | null): Grower
   };
 }
 
-function renderPage() {
+function renderPage(initialEntry = '/') {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <PlannerPage />
         <LocationDisplay />
       </MemoryRouter>
@@ -62,7 +62,7 @@ function renderPage() {
 
 function LocationDisplay() {
   const location = useLocation();
-  return <output data-testid="location">{location.pathname}</output>;
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
 }
 
 describe('PlannerPage', () => {
@@ -137,8 +137,24 @@ describe('PlannerPage', () => {
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(await screen.findByRole('button', { name: 'Open garden map' }));
+    await user.click(await screen.findByRole('button', { name: 'Open Map' }));
     expect(screen.getByTestId('location')).toHaveTextContent('/garden');
+  });
+
+  it('opens a directly linked layer and preserves it in the URL while switching', async () => {
+    renderPage('/garden/plan?tier=4&season=fall');
+
+    expect(await screen.findByRole('heading', { name: 'Flavor' })).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('pyramid-band-joy'));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/garden/plan?tier=5&season=fall');
+  });
+
+  it('explains that local recommendations are optional context', async () => {
+    renderPage('/garden/plan');
+
+    expect(await screen.findByRole('heading', { name: 'Local planting context' })).toBeInTheDocument();
+    expect(screen.getByText(/optional community signals, not instructions/i)).toBeInTheDocument();
   });
 
   it('guides the grower to their next unfilled layer', async () => {

--- a/apps/grn/src/pages/PlannerPage.tsx
+++ b/apps/grn/src/pages/PlannerPage.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Button, Card, Panel, SectionHeading } from '@olivias/ui';
 import { getMe, listMyCrops } from '../services/api';
@@ -20,9 +20,27 @@ import type { GrowerCropItem } from '../types/listing';
 
 const ALL_TIERS: PyramidTier[] = [1, 2, 3, 4, 5];
 
+function parseTier(value: string | null): PyramidTier {
+  const tier = Number(value);
+  return ALL_TIERS.includes(tier as PyramidTier) ? (tier as PyramidTier) : 1;
+}
+
 export function PlannerPage() {
   const navigate = useNavigate();
-  const [activeTier, setActiveTier] = useState<PyramidTier>(1);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedTier = parseTier(searchParams.get('tier'));
+  const [activeTier, setActiveTier] = useState<PyramidTier>(requestedTier);
+
+  useEffect(() => {
+    setActiveTier(requestedTier);
+  }, [requestedTier]);
+
+  const selectTier = (tier: PyramidTier) => {
+    setActiveTier(tier);
+    const next = new URLSearchParams(searchParams);
+    next.set('tier', String(tier));
+    setSearchParams(next, { replace: true });
+  };
 
   const { data: profile, isLoading: isLoadingProfile } = useQuery({
     queryKey: ['userProfile'],
@@ -77,7 +95,7 @@ export function PlannerPage() {
   if (isLoadingProfile) {
     return (
       <section className="grn-section">
-        <SectionHeading title="Garden pyramid" />
+        <SectionHeading title="Plan" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading your plan…</p>
@@ -95,8 +113,8 @@ export function PlannerPage() {
   return (
     <section className="grn-section grn-planner">
       <SectionHeading
-        title="Garden planner"
-        body="Choose a layer, see what is growing there, and keep your plan moving one simple step at a time."
+        title="Plan"
+        body="Use the garden pyramid to see what is covered and choose a practical next layer."
       />
 
       <Card padding="6" className="grn-planner__workspace">
@@ -119,15 +137,19 @@ export function PlannerPage() {
             <p className="grn-planner__guidance">{planGuidance(evaluation)}</p>
             <div className="grn-planner__map-link">
               <span>Ready to give your plan a place?</span>
-              <Button variant="outline" size="sm" onClick={() => navigate('/garden')}>
-                Open garden map
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate({ pathname: '/garden', search: searchParams.toString() })}
+              >
+                Open Map
               </Button>
             </div>
           </div>
           <Button
             variant="secondary"
             size="sm"
-            onClick={() => setActiveTier(nextTier)}
+            onClick={() => selectTier(nextTier)}
           >
             {counts[nextTier] > 0
               ? `Review ${tierMeta(nextTier).name}`
@@ -147,7 +169,7 @@ export function PlannerPage() {
               cropsByTier={cropsByTier}
               activeTier={activeTier}
               nextTier={evaluation.nextFocusTier}
-              onSelectTier={setActiveTier}
+              onSelectTier={selectTier}
             />
           </section>
 
@@ -162,6 +184,28 @@ export function PlannerPage() {
             />
           </section>
         </div>
+      </Card>
+
+      <Card padding="6" className="grn-planner__local-context">
+        <div>
+          <h3>Local planting context</h3>
+          <p>
+            If it helps, compare this plan with aggregated activity near you. These are
+            optional community signals, not instructions or a commitment to grow more.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            navigate({
+              pathname: '/garden/plan/recommendations',
+              search: searchParams.toString(),
+            })
+          }
+        >
+          View local context
+        </Button>
       </Card>
 
       {unsorted.length > 0 ? (

--- a/apps/grn/src/pages/RecommendationsPage.tsx
+++ b/apps/grn/src/pages/RecommendationsPage.tsx
@@ -16,7 +16,7 @@ export function RecommendationsPage() {
   if (isLoading) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Grower tools" title="Recommendations" />
+        <SectionHeading title="Local planting context" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading…</p>
@@ -32,9 +32,8 @@ export function RecommendationsPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Grower tools"
-        title="Recommendations"
-        body="See what's scarce, what's already covered, and what to plant next based on neighbors near you."
+        title="Local planting context"
+        body="Optional ideas based on aggregated activity near you. Use what fits your garden and ignore the rest."
       />
       <RecommendationsPanel
         viewerUserId={profile.id}

--- a/apps/grn/src/shell/AuthenticatedRoot.test.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.test.tsx
@@ -38,6 +38,10 @@ vi.mock('../pages/RecommendationsPage', () => ({
 vi.mock('../pages/GardenDesignerPage', () => ({
   GardenDesignerPage: () => <h1>Garden map page</h1>,
 }));
+vi.mock('../pages/GardenWorkspacePage', async () => {
+  const { Outlet } = await import('react-router-dom');
+  return { GardenWorkspacePage: () => <><span>Garden workspace</span><Outlet /></> };
+});
 vi.mock('../pages/ConnectPage', () => ({ ConnectPage: () => <h1>Share page</h1> }));
 vi.mock('../pages/ListingsPage', () => ({ ListingsPage: () => <h1>Listings page</h1> }));
 vi.mock('../pages/RequestsPage', () => ({ RequestsPage: () => <h1>Find food page</h1> }));
@@ -88,6 +92,13 @@ describe('AuthenticatedRoot routes', () => {
     expect(screen.getByTestId('location')).toHaveTextContent(
       '/garden/plan?season=fall#workhorses'
     );
+  });
+
+  it('keeps every garden view inside the shared workspace shell', async () => {
+    renderRoot(['/garden/plan']);
+
+    expect(await screen.findByText('Garden workspace')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Plan page' })).toBeInTheDocument();
   });
 
   it('replaces a legacy history entry so Back returns to the previous page', async () => {

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -25,6 +25,9 @@ const PlannerPage = lazy(() =>
 const GardenDesignerPage = lazy(() =>
   import('../pages/GardenDesignerPage').then((m) => ({ default: m.GardenDesignerPage }))
 );
+const GardenWorkspacePage = lazy(() =>
+  import('../pages/GardenWorkspacePage').then((m) => ({ default: m.GardenWorkspacePage }))
+);
 const ListingsPage = lazy(() =>
   import('../pages/ListingsPage').then((m) => ({ default: m.ListingsPage }))
 );
@@ -70,11 +73,13 @@ export function AuthenticatedRoot() {
             <Routes>
               <Route path="/" element={<DashboardPage user={user} />} />
               <Route path="/today/reminders" element={<RemindersPage />} />
-              <Route path="/garden" element={<GardenDesignerPage />} />
-              <Route path="/garden/plants" element={<CropsPage />} />
-              <Route path="/garden/plants/new" element={<NewCropPage />} />
-              <Route path="/garden/plan" element={<PlannerPage />} />
-              <Route path="/garden/plan/recommendations" element={<RecommendationsPage />} />
+              <Route path="/garden" element={<GardenWorkspacePage />}>
+                <Route index element={<GardenDesignerPage />} />
+                <Route path="plants" element={<CropsPage />} />
+                <Route path="plants/new" element={<NewCropPage />} />
+                <Route path="plan" element={<PlannerPage />} />
+                <Route path="plan/recommendations" element={<RecommendationsPage />} />
+              </Route>
               <Route path="/share" element={<ConnectPage />} />
               <Route path="/share/listings" element={<ListingsPage />} />
               <Route path="/share/find" element={<RequestsPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -336,6 +336,119 @@ body {
   gap: 1.25rem;
 }
 
+/* One garden, three related views. The shell stays deliberately compact so
+   the illustrated map remains the visual home instead of competing with a
+   second page hero. */
+.grn-garden-workspace {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.grn-garden-workspace__header h1 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: normal;
+}
+
+.grn-garden-workspace__header p {
+  max-width: 46rem;
+  margin: 0.35rem 0 0;
+  color: rgba(79, 56, 37, 0.75);
+}
+
+.grn-garden-views {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border: 1px solid rgba(79, 56, 37, 0.12);
+  border-radius: var(--og-radius-lg);
+  background: rgba(255, 253, 248, 0.78);
+}
+
+.grn-garden-views__link {
+  display: grid;
+  gap: 0.15rem;
+  min-height: 3.5rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: calc(var(--og-radius-lg) - 0.25rem);
+  color: rgba(79, 56, 37, 0.72);
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.grn-garden-views__link:hover {
+  background: rgba(66, 107, 63, 0.08);
+  color: var(--og-color-soil);
+}
+
+.grn-garden-views__link:focus-visible {
+  outline: 3px solid rgba(66, 107, 63, 0.35);
+  outline-offset: 2px;
+}
+
+.grn-garden-views__link.is-active {
+  color: var(--og-color-moss);
+  background: var(--og-color-paper);
+  box-shadow: 0 1px 4px rgba(79, 56, 37, 0.14);
+}
+
+.grn-garden-views__label {
+  font-family: var(--og-font-display);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.grn-garden-views__description {
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
+.grn-garden-workspace__offline {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(176, 106, 60, 0.35);
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 244, 224, 0.82);
+  color: var(--og-color-soil);
+  font-size: 0.9rem;
+}
+
+.grn-garden-workspace__view {
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .grn-garden-workspace {
+    gap: 0.75rem;
+  }
+
+  .grn-garden-workspace__header p {
+    font-size: 0.9rem;
+  }
+
+  .grn-garden-views {
+    gap: 0.25rem;
+    padding: 0.3rem;
+  }
+
+  .grn-garden-views__link {
+    place-items: center;
+    min-height: 2.75rem;
+    padding: 0.55rem 0.35rem;
+    text-align: center;
+  }
+
+  .grn-garden-views__description {
+    display: none;
+  }
+}
+
 .grn-section__header {
   display: flex;
   justify-content: space-between;
@@ -1514,9 +1627,35 @@ body {
   border-radius: 999px;
 }
 
+.grn-crop-card__bed-field {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 0.15rem;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.grn-crop-card__bed-field select {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid rgba(79, 56, 37, 0.22);
+  border-radius: var(--og-radius-sm);
+  background: var(--og-color-paper);
+  color: var(--og-color-soil);
+  font: inherit;
+}
+
+.grn-crop-card__bed-field select:focus-visible {
+  outline: 3px solid rgba(66, 107, 63, 0.3);
+  outline-offset: 1px;
+}
+
 .grn-crop-card__footer {
   margin-top: auto;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0 1rem 0.85rem;
 }
@@ -1579,6 +1718,28 @@ body {
 .grn-planner__workspace {
   display: grid;
   gap: 1.5rem;
+}
+
+.grn-planner__local-context {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-left: 4px solid rgba(66, 107, 63, 0.55);
+}
+
+.grn-planner__local-context h3 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  font-size: 1.05rem;
+}
+
+.grn-planner__local-context p {
+  max-width: 48rem;
+  margin: 0.25rem 0 0;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.9rem;
 }
 
 .grn-planner__health {
@@ -2014,6 +2175,11 @@ body {
 }
 
 @media (max-width: 480px) {
+  .grn-planner__local-context {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .grn-planner__health {
     align-items: flex-start;
     gap: 1rem;


### PR DESCRIPTION
## Summary

- introduce one stable Garden workspace with accessible Map, Plants, and Plan views
- keep Map as the default illustrated home while preserving every canonical and legacy deep link
- carry crop, bed, tier, season, and other query context between Garden views
- open the exact mapped bed when a crop or bed deep link reaches the Map
- let growers reassign a crop to a bed from Plants with an optimistic shared-cache update reflected by Map and Plan
- preserve the selected pyramid tier in direct links and frame nearby planting signals as optional local context
- add explicit offline messaging plus compact one-handed mobile view navigation
- remove redundant grower-tool eyebrow labels and repeated Garden page headings inside the workspace

## Verification

- `npm test -w @olivias/grn` — 68 files, 557 tests passed
- `npm run lint -w @olivias/grn`
- `npm run typecheck -w @olivias/grn`
- `npm run build -w @olivias/grn`
- `npm run perf:budget -w @olivias/grn` — 797,893 bytes total
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` — 227 unit tests plus contract/integration suites passed

## Local environment notes

- `cargo fmt --all -- --check` reports checkout-wide CRLF newline differences across pre-existing Rust files in this Windows worktree. This PR changes no Rust files; the Linux PR formatting check is the authoritative gate and must pass before merge.
- No API endpoint or response contract changed, so no Postman collection update is required. Existing staging Postman suites remain required before merge.

Closes #373
