### PR TITLE
[GRN] Separate everyday tending from structural layout editing

### DIFF
--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.test.tsx
@@ -9,7 +9,11 @@ import type {
   GrowerCropItem,
 } from '../../types/listing';
 import { GARDEN_TEMPLATES } from '../GardenDesigner/gardenTemplates';
-import { GardenMasterplan, type MasterplanEditing } from './GardenMasterplan';
+import {
+  GardenMasterplan,
+  type MasterplanEditing,
+  type MasterplanTending,
+} from './GardenMasterplan';
 import { screenDeltaToWorld } from './iso';
 
 beforeAll(() => {
@@ -135,6 +139,7 @@ function renderMasterplan(args?: {
     patch: Partial<GardenAnnotation>
   ) => void | Promise<boolean>;
   onApplyTemplate?: (templateId: string) => Promise<void>;
+  tending?: Partial<MasterplanTending> | false;
   editing?: Partial<MasterplanEditing>;
 }) {
   const beds = args?.beds ?? [makeBed({})];
@@ -161,7 +166,6 @@ function renderMasterplan(args?: {
         onAddAnnotation: () => {},
         onDeleteBed: () => {},
         onDeleteAnnotation: () => {},
-        onAddCrop: async () => {},
         onDuplicate: () => {},
         onPatchCanvas: () => {},
         canUndo: false,
@@ -173,6 +177,17 @@ function renderMasterplan(args?: {
         ...args.editing,
       }
     : undefined;
+  const tending: MasterplanTending | undefined =
+    args?.tending === false
+      ? undefined
+      : {
+          onAddCrop: async () => {},
+          onOpenCrop: () => {},
+          onLogHarvest: () => {},
+          onAddReminder: () => {},
+          onShareCrop: () => {},
+          ...args?.tending,
+        };
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -196,6 +211,7 @@ function renderMasterplan(args?: {
         onPatchBed={args?.onPatchBed ?? (() => {})}
         onPatchAnnotation={args?.onPatchAnnotation ?? (() => {})}
         onApplyTemplate={args?.onApplyTemplate ?? (async () => {})}
+        tending={tending}
         editing={editing}
       />
     </QueryClientProvider>
@@ -239,6 +255,45 @@ describe('GardenMasterplan', () => {
     expect(panel).toHaveTextContent('Compost-amended');
     expect(panel).toHaveTextContent('Tomato');
     expect(panel).toHaveTextContent('×4');
+  });
+
+  it('offers everyday crop actions without structural layout controls in Tend', async () => {
+    const onOpenCrop = vi.fn();
+    const onLogHarvest = vi.fn();
+    const onAddReminder = vi.fn();
+    const onShareCrop = vi.fn();
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      tending: { onOpenCrop, onLogHarvest, onAddReminder, onShareCrop },
+    });
+
+    expect(screen.getByRole('heading', { name: /tend this bed/i })).toBeInTheDocument();
+    expect(screen.getByText('Tomato')).toBeInTheDocument();
+    expect(screen.queryByText(/fine-tune/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /duplicate/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: /stacking order/i })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Update' }));
+    await userEvent.click(screen.getByRole('button', { name: /log harvest/i }));
+    await userEvent.click(screen.getByRole('button', { name: /share food/i }));
+    await userEvent.click(screen.getByRole('button', { name: /add reminder/i }));
+
+    expect(onOpenCrop).toHaveBeenCalledWith('crop-1');
+    expect(onLogHarvest).toHaveBeenCalledWith('crop-1');
+    expect(onShareCrop).toHaveBeenCalledWith('crop-1');
+    expect(onAddReminder).toHaveBeenCalledWith(expect.objectContaining({ id: 'bed-1' }));
+  });
+
+  it('keeps a read-only plan free of tending and layout mutations', () => {
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      tending: false,
+    });
+
+    expect(screen.queryByRole('heading', { name: /tend this bed/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/fine-tune/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add reminder/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /duplicate/i })).not.toBeInTheDocument();
   });
 
   it('shows a capacity line in the detail panel when crops have spacing data', () => {
@@ -411,8 +466,12 @@ describe('GardenMasterplan', () => {
     expect(screen.getByText(/your property, beautifully mapped/i)).toBeInTheDocument();
   });
 
-  it('offers starter template cards in the empty state', () => {
+  it('keeps structural empty-state actions behind Edit layout', () => {
     renderMasterplan({ beds: [], annotations: [], crops: [] });
+    expect(screen.queryByText(/start from a template/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/choose edit layout/i)).toBeInTheDocument();
+
+    renderMasterplan({ beds: [], annotations: [], crops: [], editing: {} });
     expect(screen.getByText(/start from a template/i)).toBeInTheDocument();
     for (const template of GARDEN_TEMPLATES) {
       expect(screen.getByText(template.name)).toBeInTheDocument();
@@ -437,7 +496,13 @@ describe('GardenMasterplan', () => {
 
   it('applies the clicked template by id', async () => {
     const onApplyTemplate = vi.fn(async () => {});
-    renderMasterplan({ beds: [], annotations: [], crops: [], onApplyTemplate });
+    renderMasterplan({
+      beds: [],
+      annotations: [],
+      crops: [],
+      onApplyTemplate,
+      editing: {},
+    });
     const buttons = screen.getAllByRole('button', { name: /use this layout/i });
     await userEvent.click(buttons[1]);
     expect(onApplyTemplate).toHaveBeenCalledTimes(1);
@@ -452,7 +517,13 @@ describe('GardenMasterplan', () => {
           resolveApply = resolve;
         })
     );
-    renderMasterplan({ beds: [], annotations: [], crops: [], onApplyTemplate });
+    renderMasterplan({
+      beds: [],
+      annotations: [],
+      crops: [],
+      onApplyTemplate,
+      editing: {},
+    });
     const buttons = screen.getAllByRole('button', { name: /use this layout/i });
     await userEvent.click(buttons[0]);
 
@@ -530,7 +601,11 @@ describe('GardenMasterplan', () => {
 
   it('changes stacking order from the detail panel', async () => {
     const onPatchBed = vi.fn();
-    renderMasterplan({ selected: { kind: 'bed', id: 'bed-1' }, onPatchBed });
+    renderMasterplan({
+      selected: { kind: 'bed', id: 'bed-1' },
+      onPatchBed,
+      editing: {},
+    });
     await userEvent.click(screen.getByRole('button', { name: /bring forward/i }));
     expect(onPatchBed).toHaveBeenCalledWith('bed-1', { sortOrder: 1 });
     await userEvent.click(screen.getByRole('button', { name: /send backward/i }));
@@ -542,6 +617,7 @@ describe('GardenMasterplan', () => {
     renderMasterplan({
       selected: { kind: 'annotation', id: 'ann-1' },
       onPatchAnnotation,
+      editing: {},
     });
     await userEvent.click(screen.getByRole('button', { name: /send backward/i }));
     expect(onPatchAnnotation).toHaveBeenCalledWith('ann-1', { sortOrder: -1 });

--- a/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
+++ b/apps/grn/src/components/GardenMasterplan/GardenMasterplan.tsx
@@ -8,7 +8,6 @@ import type {
   GrowerCropItem,
 } from '../../types/listing';
 import type { SelectedItem } from '../../hooks/useGardenDesigner';
-import type { QuickAddCropInput } from '../GardenDesigner/QuickAddCrop';
 import { GARDEN_TEMPLATES } from '../GardenDesigner/gardenTemplates';
 import type { DesignerMode, GridSnap } from '../GardenDesigner/designerTypes';
 import type { ElementGeometry } from './isoTransform';
@@ -18,7 +17,10 @@ import { sceneMetrics } from './footprints';
 import { GardenReviewPanel } from './GardenReviewPanel';
 import { IsoScene } from './IsoScene';
 import { MasterplanDesignBar } from './MasterplanDesignBar';
-import { MasterplanDetailPanel } from './MasterplanDetailPanel';
+import {
+  MasterplanDetailPanel,
+  type MasterplanPanelTending,
+} from './MasterplanDetailPanel';
 import {
   MONTH_LABELS_FULL,
   MONTH_LABELS_SHORT,
@@ -58,8 +60,6 @@ export interface MasterplanEditing {
   onAddAnnotation: (presetId: string) => void;
   onDeleteBed: (bedId: string) => void;
   onDeleteAnnotation: (annotationId: string) => void;
-  /** Attach a crop to the currently-selected bed from the detail panel. */
-  onAddCrop: (input: QuickAddCropInput) => Promise<void>;
   onDuplicate: () => void;
   /** Edit garden-level scale from the masterplan design bar. */
   onPatchCanvas: (patch: {
@@ -73,6 +73,9 @@ export interface MasterplanEditing {
   isSaving: boolean;
   saveError: string | null;
 }
+
+/** Everyday crop work stays available while structural editing is disabled. */
+export type MasterplanTending = MasterplanPanelTending;
 
 interface GardenMasterplanProps {
   canvas: GardenCanvas;
@@ -92,8 +95,11 @@ interface GardenMasterplanProps {
     patch: Partial<GardenAnnotation>
   ) => void | Promise<boolean>;
   onApplyTemplate: (templateId: string) => Promise<void>;
+  /** Present for the grower's everyday bed and crop actions. */
+  tending?: MasterplanTending;
   /** Present when the plan is an editable design surface. */
   editing?: MasterplanEditing;
+  onLayoutDraftChange?: (hasDraft: boolean) => void;
 }
 
 const SNAP_INCHES: Record<GridSnap, number> = { off: 0, '6': 6, '12': 12 };
@@ -117,7 +123,9 @@ export function GardenMasterplan({
   onPatchBed,
   onPatchAnnotation,
   onApplyTemplate,
+  tending,
   editing,
+  onLayoutDraftChange,
 }: GardenMasterplanProps) {
   const metrics = useMemo(() => sceneMetrics(canvas), [canvas]);
 
@@ -424,44 +432,50 @@ export function GardenMasterplan({
         {isEmpty && (
           <div className="mp-explorer__empty">
             <h2>Your property, beautifully mapped</h2>
-            <p>
-              Add beds, trees, paths, and structures and they’ll appear here
-              as an illustrated masterplan.
-            </p>
-            <h3 className="mp-templates__heading">Start from a template</h3>
-            <div className="mp-templates" role="list" aria-label="Starter garden templates">
-              {GARDEN_TEMPLATES.map((template) => (
-                <div key={template.id} className="mp-template-card" role="listitem">
-                  <h4 className="mp-template-card__name">{template.name}</h4>
-                  <p className="mp-template-card__desc">{template.description}</p>
-                  <p className="mp-template-card__stats">
-                    {template.stats.bedCount}{' '}
-                    {template.stats.bedCount === 1 ? 'bed' : 'beds'} ·{' '}
-                    {template.stats.annotationCount}{' '}
-                    {template.stats.annotationCount === 1 ? 'landmark' : 'landmarks'}
-                  </p>
-                  <button
-                    type="button"
-                    className="mp-template-card__use"
-                    disabled={applyingTemplateId !== null}
-                    onClick={() => {
-                      void handleApplyTemplate(template.id);
-                    }}
-                  >
-                    {applyingTemplateId === template.id
-                      ? 'Planting…'
-                      : 'Use this layout'}
-                  </button>
-                </div>
-              ))}
-            </div>
-            {applyingTemplateId !== null && (
-              <p className="mp-templates__progress" role="status">
-                Planting your starter garden…
-              </p>
-            )}
-            {editing && (
+            {editing ? (
               <>
+                <p>
+                  Add beds, trees, paths, and structures and they’ll appear here
+                  as an illustrated masterplan.
+                </p>
+                <h3 className="mp-templates__heading">Start from a template</h3>
+                <div
+                  className="mp-templates"
+                  role="list"
+                  aria-label="Starter garden templates"
+                >
+                  {GARDEN_TEMPLATES.map((template) => (
+                    <div key={template.id} className="mp-template-card" role="listitem">
+                      <h4 className="mp-template-card__name">{template.name}</h4>
+                      <p className="mp-template-card__desc">{template.description}</p>
+                      <p className="mp-template-card__stats">
+                        {template.stats.bedCount}{' '}
+                        {template.stats.bedCount === 1 ? 'bed' : 'beds'} ·{' '}
+                        {template.stats.annotationCount}{' '}
+                        {template.stats.annotationCount === 1
+                          ? 'landmark'
+                          : 'landmarks'}
+                      </p>
+                      <button
+                        type="button"
+                        className="mp-template-card__use"
+                        disabled={applyingTemplateId !== null}
+                        onClick={() => {
+                          void handleApplyTemplate(template.id);
+                        }}
+                      >
+                        {applyingTemplateId === template.id
+                          ? 'Planting…'
+                          : 'Use this layout'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+                {applyingTemplateId !== null && (
+                  <p className="mp-templates__progress" role="status">
+                    Planting your starter garden…
+                  </p>
+                )}
                 <p className="mp-templates__or">or start from scratch</p>
                 <button
                   type="button"
@@ -472,6 +486,11 @@ export function GardenMasterplan({
                   Add a raised bed
                 </button>
               </>
+            ) : (
+              <p>
+                There is no layout yet. Choose Edit layout to start with a template
+                or add your first bed.
+              </p>
             )}
           </div>
         )}
@@ -507,6 +526,8 @@ export function GardenMasterplan({
             }
           }}
           onClose={() => onSelect(null)}
+          tending={selectedBed ? tending : undefined}
+          onDraftChange={editing ? onLayoutDraftChange : undefined}
           editing={
             editing
               ? {
@@ -531,7 +552,6 @@ export function GardenMasterplan({
                     else if (selectedAnnotation)
                       editing.onDeleteAnnotation(selectedAnnotation.id);
                   },
-                  onAddCrop: editing.onAddCrop,
                 }
               : undefined
           }

--- a/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
+++ b/apps/grn/src/components/GardenMasterplan/MasterplanDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type {
   BedType,
   GardenAnnotation,
@@ -62,7 +62,15 @@ export interface MasterplanPanelEditing {
   onPatchAnnotation: (patch: Partial<GardenAnnotation>) => void | Promise<boolean>;
   onDuplicate: () => void;
   onDelete: () => void;
+}
+
+/** Everyday garden actions stay available without enabling layout editing. */
+export interface MasterplanPanelTending {
   onAddCrop: (input: QuickAddCropInput) => Promise<void>;
+  onOpenCrop: (cropId: string) => void;
+  onLogHarvest: (cropId: string) => void;
+  onAddReminder: (bed: GardenBed) => void;
+  onShareCrop: (cropId: string) => void;
 }
 
 interface DimensionDraft {
@@ -83,7 +91,9 @@ interface MasterplanDetailPanelProps {
   noonShadeConflict?: boolean;
   onArrange: (direction: 'forward' | 'backward') => void;
   onClose: () => void;
+  tending?: MasterplanPanelTending;
   editing?: MasterplanPanelEditing;
+  onDraftChange?: (hasDraft: boolean) => void;
 }
 
 /**
@@ -103,7 +113,9 @@ export function MasterplanDetailPanel({
   noonShadeConflict = false,
   onArrange,
   onClose,
+  tending,
   editing,
+  onDraftChange,
 }: MasterplanDetailPanelProps) {
   // The parent re-keys this panel on the selected element's id, so initial
   // state is the right snapshot without a syncing effect. Length, width, and
@@ -116,6 +128,25 @@ export function MasterplanDetailPanel({
   const [dimensionError, setDimensionError] = useState<string | null>(null);
   const [isApplyingDimensions, setIsApplyingDimensions] = useState(false);
   const [soils, setSoils] = useState<string[]>(parseSoilField(bed?.soilType));
+
+  const hasDraft = Boolean(
+    editing &&
+      (dimensionDraft !== null ||
+        name !== (bed?.name ?? annotation?.label ?? '') ||
+        icon !== (annotation?.icon ?? '') ||
+        notes !== (bed?.locationNotes ?? ''))
+  );
+
+  useEffect(() => {
+    onDraftChange?.(hasDraft);
+  }, [hasDraft, onDraftChange]);
+
+  useEffect(
+    () => () => {
+      onDraftChange?.(false);
+    },
+    [onDraftChange]
+  );
 
   if (!bed && !annotation) return null;
 
@@ -292,6 +323,90 @@ export function MasterplanDetailPanel({
             Labeled full sun, but sits mostly in shade at midday.
           </p>
         )}
+
+        {bed && tending ? (
+          <section className="mp-panel__tend" aria-label="Tend this bed">
+            <header className="mp-panel__tend-header">
+              <div>
+                <h3 className="mp-panel__section-title">Tend this bed</h3>
+                <p>Keep the crop work here; layout tools stay out of the way.</p>
+              </div>
+              <button
+                type="button"
+                className="mp-panel__tend-reminder"
+                onClick={() => tending.onAddReminder(bed)}
+              >
+                Add reminder
+              </button>
+            </header>
+
+            {capacity?.utilization != null ? (
+              <p
+                className={`mp-panel__capacity ${
+                  capacity.utilization > 1 ? 'is-over' : ''
+                }`}
+              >
+                Using ~{Math.round(capacity.utilization * 100)}% of this bed ·{' '}
+                {capacityLabel(capacity)}
+              </p>
+            ) : null}
+
+            {seasonMonth != null && harvestCount > 0 ? (
+              <p className="mp-panel__harvest">
+                {harvestCount} crop{harvestCount === 1 ? '' : 's'} ready to harvest in{' '}
+                {MONTH_LABELS_FULL[seasonMonth]}
+              </p>
+            ) : null}
+
+            {crops.length > 0 ? (
+              <ul className="mp-panel__crop-list">
+                {crops.map((crop) => {
+                  const visual = visualForCrop(crop.cropName);
+                  return (
+                    <li key={crop.id} className="mp-panel__crop mp-panel__crop--tend">
+                      <div className="mp-panel__crop-summary">
+                        <svg
+                          className="mp-panel__crop-icon"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d={CROP_ICON_PATHS[visual.iconKey]}
+                            fill={mute(visual.accent, 0.15)}
+                          />
+                        </svg>
+                        <span className="mp-panel__crop-name">
+                          {crop.nickname || crop.cropName}
+                        </span>
+                        {crop.plantCount != null && crop.plantCount > 0 ? (
+                          <span className="mp-panel__crop-count">×{crop.plantCount}</span>
+                        ) : null}
+                      </div>
+                      <div
+                        className="mp-panel__crop-actions"
+                        aria-label={`${crop.nickname || crop.cropName} actions`}
+                      >
+                        <button type="button" onClick={() => tending.onOpenCrop(crop.id)}>
+                          Update
+                        </button>
+                        <button type="button" onClick={() => tending.onLogHarvest(crop.id)}>
+                          Log harvest
+                        </button>
+                        <button type="button" onClick={() => tending.onShareCrop(crop.id)}>
+                          Share food
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="mp-panel__tend-empty">Nothing planted here yet.</p>
+            )}
+
+            <QuickAddCrop onAdd={tending.onAddCrop} />
+          </section>
+        ) : null}
 
         {editing ? (
           <fieldset className="grn-designer-inspector__fieldset mp-panel__edit">
@@ -602,85 +717,31 @@ export function MasterplanDetailPanel({
           </dl>
         )}
 
-        {bed && (
-          <section className="mp-panel__crops" aria-label="Crops in this bed">
-            <h3 className="mp-panel__section-title">
-              {crops.length > 0
-                ? `Growing here (${crops.length})`
-                : 'Nothing planted yet'}
-            </h3>
-            {capacity?.utilization != null && (
-              <p
-                className={`mp-panel__capacity ${
-                  capacity.utilization > 1 ? 'is-over' : ''
-                }`}
-              >
-                Using ~{Math.round(capacity.utilization * 100)}% of this bed ·{' '}
-                {capacityLabel(capacity)}
-              </p>
-            )}
-            {seasonMonth != null && harvestCount > 0 && (
-              <p className="mp-panel__harvest">
-                {harvestCount} crop{harvestCount === 1 ? '' : 's'} ready to harvest in{' '}
-                {MONTH_LABELS_FULL[seasonMonth]}
-              </p>
-            )}
-            {crops.length > 0 && (
-              <ul className="mp-panel__crop-list">
-                {crops.map((crop) => {
-                  const visual = visualForCrop(crop.cropName);
-                  return (
-                    <li key={crop.id} className="mp-panel__crop">
-                      <svg
-                        className="mp-panel__crop-icon"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                      >
-                        <path
-                          d={CROP_ICON_PATHS[visual.iconKey]}
-                          fill={mute(visual.accent, 0.15)}
-                        />
-                      </svg>
-                      <span className="mp-panel__crop-name">
-                        {crop.nickname || crop.cropName}
-                      </span>
-                      {crop.plantCount != null && crop.plantCount > 0 && (
-                        <span className="mp-panel__crop-count">×{crop.plantCount}</span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {editing && <QuickAddCrop onAdd={editing.onAddCrop} />}
-          </section>
-        )}
-
         {bed?.locationNotes && !editing && (
           <p className="mp-panel__notes">{bed.locationNotes}</p>
         )}
       </div>
 
-      <footer className="mp-panel__footer">
-        <div className="mp-panel__arrange" role="group" aria-label="Stacking order">
-          <button
-            type="button"
-            className="mp-panel__arrange-btn"
-            onClick={() => onArrange('backward')}
-            title="Draw this element behind overlapping neighbors"
-          >
-            ↓ Send backward
-          </button>
-          <button
-            type="button"
-            className="mp-panel__arrange-btn"
-            onClick={() => onArrange('forward')}
-            title="Draw this element in front of overlapping neighbors"
-          >
-            ↑ Bring forward
-          </button>
-        </div>
-        {editing && (
+      {editing && (
+        <footer className="mp-panel__footer">
+          <div className="mp-panel__arrange" role="group" aria-label="Stacking order">
+            <button
+              type="button"
+              className="mp-panel__arrange-btn"
+              onClick={() => onArrange('backward')}
+              title="Draw this element behind overlapping neighbors"
+            >
+              ↓ Send backward
+            </button>
+            <button
+              type="button"
+              className="mp-panel__arrange-btn"
+              onClick={() => onArrange('forward')}
+              title="Draw this element in front of overlapping neighbors"
+            >
+              ↑ Bring forward
+            </button>
+          </div>
           <>
             <div className="mp-panel__quick" role="group" aria-label="Quick actions">
               <button
@@ -713,8 +774,8 @@ export function MasterplanDetailPanel({
                   : 'Saved'}
             </span>
           </>
-        )}
-      </footer>
+        </footer>
+      )}
     </aside>
   );
 }

--- a/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
@@ -12,6 +12,30 @@ vi.mock('../../services/api', () => ({
 }));
 
 describe('ReminderPanel deep links', () => {
+  it('prefills and focuses a new reminder from garden context', async () => {
+    vi.mocked(listReminders).mockResolvedValue({ items: [] });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter
+          initialEntries={[
+            '/today/reminders?new=true&type=harvest&title=Harvest+Kitchen+bed',
+          ]}
+        >
+          <ReminderPanel />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const title = screen.getByLabelText(/reminder title/i);
+    await waitFor(() => expect(title).toHaveValue('Harvest Kitchen bed'));
+    expect(screen.getByLabelText(/^type$/i)).toHaveValue('harvest');
+    expect(title).toHaveFocus();
+  });
+
   it('focuses the linked reminder record', async () => {
     vi.mocked(listReminders).mockResolvedValue({
       items: [

--- a/apps/grn/src/components/Reminders/ReminderPanel.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -22,11 +22,25 @@ function todayIsoDate(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function reminderTypeFromQuery(value: string | null): ReminderType {
+  return REMINDER_TYPES.some((option) => option.value === value)
+    ? (value as ReminderType)
+    : 'watering';
+}
+
 export function ReminderPanel() {
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
-  const [title, setTitle] = useState('');
-  const [reminderType, setReminderType] = useState<ReminderType>('watering');
+  const requestedNewReminder = searchParams.get('new') === 'true';
+  const requestedTitle = searchParams.get('title')?.trim() ?? '';
+  const requestedType = reminderTypeFromQuery(searchParams.get('type'));
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const [title, setTitle] = useState(() =>
+    requestedNewReminder ? requestedTitle : ''
+  );
+  const [reminderType, setReminderType] = useState<ReminderType>(() =>
+    requestedNewReminder ? requestedType : 'watering'
+  );
   const [cadenceDays, setCadenceDays] = useState(7);
   const [startDate, setStartDate] = useState(todayIsoDate());
   const [formError, setFormError] = useState<string | null>(null);
@@ -68,6 +82,12 @@ export function ReminderPanel() {
   const linkedReminderId = searchParams.get('reminder');
 
   useEffect(() => {
+    if (!requestedNewReminder) return;
+    titleInputRef.current?.focus();
+    titleInputRef.current?.scrollIntoView?.({ block: 'center' });
+  }, [requestedNewReminder]);
+
+  useEffect(() => {
     if (!linkedReminderId || sortedReminders.length === 0) return;
     const element = document.getElementById(`reminder-${linkedReminderId}`);
     element?.focus();
@@ -92,7 +112,7 @@ export function ReminderPanel() {
   return (
     <div className="bg-white rounded-lg shadow-md p-6 space-y-4">
       <div>
-        <h3 className="text-lg font-semibold text-gray-900">Deterministic reminders</h3>
+        <h3 className="text-lg font-semibold text-gray-900">Garden reminders</h3>
         <p className="text-sm text-gray-600 mt-1">
           Set recurring reminders for watering, harvest, fertilizer, and check-ins.
         </p>
@@ -102,6 +122,7 @@ export function ReminderPanel() {
         <label className="text-sm">
           <span className="block text-gray-600 mb-1">Reminder title</span>
           <input
+            ref={titleInputRef}
             className="w-full rounded-md border border-gray-300 px-3 py-2"
             value={title}
             onChange={(event) => setTitle(event.target.value)}

--- a/apps/grn/src/pages/GardenDesignerPage.test.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGardenDesigner, type UseGardenDesignerResult } from '../hooks/useGardenDesigner';
 import { GardenDesignerPage } from './GardenDesignerPage';
@@ -9,12 +10,43 @@ vi.mock('../hooks/useGardenDesigner', () => ({
 }));
 
 vi.mock('../components/GardenMasterplan/GardenMasterplan', () => ({
-  GardenMasterplan: () => <div data-testid="garden-masterplan">Illustrated map</div>,
+  GardenMasterplan: (props: {
+    editing?: unknown;
+    tending?: {
+      onAddReminder: (bed: { name: string }) => void;
+      onShareCrop: (cropId: string) => void;
+    };
+    onLayoutDraftChange?: (hasDraft: boolean) => void;
+  }) => (
+    <div
+      data-testid="garden-masterplan"
+      data-editing={props.editing ? 'true' : 'false'}
+      data-tending={props.tending ? 'true' : 'false'}
+    >
+      Illustrated map
+      <button type="button" onClick={() => props.onLayoutDraftChange?.(true)}>
+        Create layout draft
+      </button>
+      {props.tending && (
+        <>
+          <button
+            type="button"
+            onClick={() => props.tending?.onAddReminder({ name: 'Kitchen bed' })}
+          >
+            Reminder link
+          </button>
+          <button type="button" onClick={() => props.tending?.onShareCrop('crop-1')}>
+            Share link
+          </button>
+        </>
+      )}
+    </div>
+  ),
 }));
 
 const mockUseGardenDesigner = vi.mocked(useGardenDesigner);
 
-function designerResult(): UseGardenDesignerResult {
+function designerResult(overrides: Partial<UseGardenDesignerResult> = {}): UseGardenDesignerResult {
   return {
     canvas: {
       id: 'canvas-1',
@@ -113,27 +145,133 @@ function designerResult(): UseGardenDesignerResult {
     redo: vi.fn(),
     canUndo: false,
     canRedo: false,
+    ...overrides,
   };
 }
 
-describe('GardenDesignerPage garden context', () => {
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{`${location.pathname}${location.search}`}</output>;
+}
+
+function renderPage(path = '/garden') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <GardenDesignerPage />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+}
+
+describe('GardenDesignerPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
   });
 
   it('opens the bed containing a directly linked crop', async () => {
     const designer = designerResult();
     mockUseGardenDesigner.mockReturnValue(designer);
 
-    render(
-      <MemoryRouter initialEntries={['/garden?crop=crop-1']}>
-        <GardenDesignerPage />
-      </MemoryRouter>
-    );
+    renderPage('/garden?crop=crop-1');
 
     expect(screen.getByRole('heading', { level: 2, name: 'Map' })).toBeInTheDocument();
     await waitFor(() =>
       expect(designer.setSelected).toHaveBeenCalledWith({ kind: 'bed', id: 'bed-1' })
+    );
+  });
+
+  it('starts in Tend and enables structural controls only after an explicit action', async () => {
+    const user = userEvent.setup();
+    mockUseGardenDesigner.mockReturnValue(designerResult());
+    renderPage();
+
+    const map = screen.getByTestId('garden-masterplan');
+    expect(map).toHaveAttribute('data-tending', 'true');
+    expect(map).toHaveAttribute('data-editing', 'false');
+    expect(screen.getByText(/need to move beds/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Edit layout' }));
+
+    expect(map).toHaveAttribute('data-tending', 'false');
+    expect(map).toHaveAttribute('data-editing', 'true');
+    expect(window.sessionStorage.getItem('og-grn-layout-editing')).toBe('true');
+    expect(screen.queryByText(/need to move beds/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps Edit layout active while navigating during the same session', () => {
+    window.sessionStorage.setItem('og-grn-layout-editing', 'true');
+    mockUseGardenDesigner.mockReturnValue(designerResult());
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'Done editing layout' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'true');
+  });
+
+  it('lets a mobile keyboard user enter and exit Edit layout', async () => {
+    const user = userEvent.setup();
+    mockUseGardenDesigner.mockReturnValue(designerResult({ isMobile: true }));
+    renderPage();
+
+    const page = screen.getByRole('heading', { name: 'Map' }).closest('.grn-designer-page');
+    expect(page).toHaveClass('is-mobile');
+
+    const enterButton = screen.getByRole('button', { name: 'Edit layout' });
+    enterButton.focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'true');
+
+    const exitButton = screen.getByRole('button', { name: 'Done editing layout' });
+    exitButton.focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'false');
+  });
+
+  it('does not leave Edit layout while a save is active', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem('og-grn-layout-editing', 'true');
+    const designer = designerResult({ isSaving: true });
+    mockUseGardenDesigner.mockReturnValue(designer);
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Done editing layout' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/finish saving/i);
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'true');
+    expect(designer.setMode).not.toHaveBeenCalled();
+  });
+
+  it('confirms before discarding an unapplied layout draft', async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem('og-grn-layout-editing', 'true');
+    const designer = designerResult();
+    mockUseGardenDesigner.mockReturnValue(designer);
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /create layout draft/i }));
+    await user.click(screen.getByRole('button', { name: 'Done editing layout' }));
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'true');
+
+    confirm.mockReturnValue(true);
+    await user.click(screen.getByRole('button', { name: 'Done editing layout' }));
+    expect(screen.getByTestId('garden-masterplan')).toHaveAttribute('data-editing', 'false');
+    expect(designer.setMode).toHaveBeenCalledWith('idle');
+    expect(window.sessionStorage.getItem('og-grn-layout-editing')).toBe('false');
+  });
+
+  it('creates contextual reminder and sharing links from Tend', async () => {
+    const user = userEvent.setup();
+    mockUseGardenDesigner.mockReturnValue(designerResult());
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /reminder link/i }));
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/today/reminders?new=true&type=watering&title=Water+Kitchen+bed'
     );
   });
 });

--- a/apps/grn/src/pages/GardenDesignerPage.tsx
+++ b/apps/grn/src/pages/GardenDesignerPage.tsx
@@ -1,21 +1,46 @@
-import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PlantLoader } from '../components/branding/PlantLoader';
 import { GardenMasterplan } from '../components/GardenMasterplan/GardenMasterplan';
 import { useGardenDesigner } from '../hooks/useGardenDesigner';
 
+const LAYOUT_EDITING_STORAGE_KEY = 'og-grn-layout-editing';
+const LAYOUT_HELP_STORAGE_KEY = 'og-grn-layout-help-seen';
+
+function readSessionFlag(key: string): boolean {
+  try {
+    return window.sessionStorage.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeSessionFlag(key: string, value: boolean) {
+  try {
+    window.sessionStorage.setItem(key, String(value));
+  } catch {
+    // The mode still works when storage is unavailable.
+  }
+}
+
 /**
- * The Map view is the garden workspace's illustrated isometric masterplan.
- * Explore the whole property, then select any element to tend
- * it and make tight edits in place — drag to move, grab the handles to
- * resize or rotate, reshape custom outlines, and fine-tune every detail in
- * the inspector. There is no separate precision/layout view; everything
- * happens on the map.
+ * The Map view separates everyday crop care from less-frequent structural
+ * design. Tend is the calm default; Edit layout explicitly enables direct
+ * manipulation, precise dimensions, landmarks, and history controls.
  */
 export function GardenDesignerPage() {
   const designer = useGardenDesigner();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const appliedContext = useRef<string | null>(null);
+  const [layoutEditing, setLayoutEditing] = useState(() =>
+    readSessionFlag(LAYOUT_EDITING_STORAGE_KEY)
+  );
+  const [showLayoutHelp, setShowLayoutHelp] = useState(
+    () => !readSessionFlag(LAYOUT_HELP_STORAGE_KEY)
+  );
+  const [layoutMessage, setLayoutMessage] = useState<string | null>(null);
+  const [hasLayoutDraft, setHasLayoutDraft] = useState(false);
   const requestedBedId = searchParams.get('bed') ?? searchParams.get('bedId');
   const requestedCropId = searchParams.get('crop');
 
@@ -33,6 +58,45 @@ export function GardenDesignerPage() {
     }
     appliedContext.current = contextKey;
   }, [designer, requestedBedId, requestedCropId]);
+
+  useEffect(() => {
+    if (!layoutEditing || !hasLayoutDraft) return;
+
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload);
+  }, [hasLayoutDraft, layoutEditing]);
+
+  function enterLayoutEditing() {
+    setLayoutEditing(true);
+    setShowLayoutHelp(false);
+    setLayoutMessage(null);
+    writeSessionFlag(LAYOUT_EDITING_STORAGE_KEY, true);
+    writeSessionFlag(LAYOUT_HELP_STORAGE_KEY, true);
+  }
+
+  function exitLayoutEditing() {
+    if (designer.isSaving) {
+      setLayoutMessage(
+        'Wait for your current changes to finish saving before leaving Edit layout.'
+      );
+      return;
+    }
+    if (
+      hasLayoutDraft &&
+      !window.confirm('You have unapplied layout changes. Leave Edit layout anyway?')
+    ) {
+      return;
+    }
+
+    designer.setMode('idle');
+    setLayoutEditing(false);
+    setHasLayoutDraft(false);
+    setLayoutMessage(null);
+    writeSessionFlag(LAYOUT_EDITING_STORAGE_KEY, false);
+  }
 
   if (designer.isLoading) {
     return (
@@ -63,11 +127,42 @@ export function GardenDesignerPage() {
         <div className="grn-designer-page__title-block">
           <h2 className="grn-designer-page__title">Map</h2>
           <p className="grn-designer-page__subtitle">
-            Explore beds, landmarks, and what is growing. Select anything for its
-            details and available actions.
+            {layoutEditing
+              ? 'Move, resize, and shape the permanent parts of your garden.'
+              : 'Select a bed to update crops, log a harvest, set a reminder, or share food.'}
           </p>
         </div>
+        {designer.isEditable && (
+          <div className="grn-designer-page__mode">
+            <button
+              type="button"
+              className={`grn-designer-page__mode-button${
+                layoutEditing ? ' is-editing' : ''
+              }`}
+              aria-pressed={layoutEditing}
+              onClick={layoutEditing ? exitLayoutEditing : enterLayoutEditing}
+            >
+              {layoutEditing ? 'Done editing layout' : 'Edit layout'}
+            </button>
+            {showLayoutHelp && !layoutEditing && (
+              <p className="grn-designer-page__mode-help">
+                Need to move beds or change dimensions? Start here.
+              </p>
+            )}
+          </div>
+        )}
       </header>
+
+      {layoutEditing && (
+        <p className="grn-designer-page__mode-status" role="status">
+          Edit layout is on. Crop tending stays available when you finish.
+        </p>
+      )}
+      {layoutMessage && (
+        <p className="grn-designer-page__mode-message" role="alert">
+          {layoutMessage}
+        </p>
+      )}
 
       <GardenMasterplan
         canvas={designer.canvas}
@@ -81,8 +176,32 @@ export function GardenDesignerPage() {
         onPatchBed={designer.patchBed}
         onPatchAnnotation={designer.patchAnnotation}
         onApplyTemplate={designer.applyTemplate}
+        tending={
+          designer.isEditable && !layoutEditing
+            ? {
+                onAddCrop: async (input) => {
+                  const bedId = designer.selectedBed?.id;
+                  if (!bedId) return;
+                  await designer.addCrop({ ...input, bedId });
+                },
+                onOpenCrop: (cropId) => navigate(`/garden/plants?crop=${cropId}`),
+                onLogHarvest: (cropId) =>
+                  navigate(`/garden/plants?crop=${cropId}&action=harvest`),
+                onAddReminder: (bed) => {
+                  const params = new URLSearchParams({
+                    new: 'true',
+                    type: 'watering',
+                    title: `Water ${bed.name}`,
+                  });
+                  navigate(`/today/reminders?${params.toString()}`);
+                },
+                onShareCrop: (cropId) => navigate(`/share/listings?crop=${cropId}`),
+              }
+            : undefined
+        }
+        onLayoutDraftChange={setHasLayoutDraft}
         editing={
-          designer.isEditable
+          designer.isEditable && layoutEditing
             ? {
                 snap: designer.snap,
                 onSnapChange: designer.setSnap,
@@ -105,11 +224,6 @@ export function GardenDesignerPage() {
                 onDeleteAnnotation: (annotationId) => {
                   void designer.deleteAnnotation(annotationId);
                 },
-                onAddCrop: (input) =>
-                  designer.addCrop({
-                    ...input,
-                    bedId: designer.selectedBed!.id,
-                  }),
                 onDuplicate: () => {
                   void designer.duplicateSelected();
                 },

--- a/apps/grn/src/pages/RemindersPage.tsx
+++ b/apps/grn/src/pages/RemindersPage.tsx
@@ -5,9 +5,8 @@ export function RemindersPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Planning"
         title="Reminders"
-        body="Stay on top of upcoming actions for your listings and requests."
+        body="Stay on top of watering, harvests, feeding, and garden check-ins."
       />
       <ReminderPanel />
     </section>

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -2268,6 +2268,81 @@ body {
   font-size: 0.95rem;
 }
 
+.grn-designer-page__mode {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.65rem;
+}
+
+.grn-designer-page__mode-button {
+  min-height: 44px;
+  padding: 0.55rem 1rem;
+  border: 1px solid rgba(91, 140, 74, 0.5);
+  border-radius: var(--og-radius-pill);
+  background: var(--og-color-paper);
+  color: var(--og-color-moss);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.grn-designer-page__mode-button:hover,
+.grn-designer-page__mode-button:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  outline: 3px solid rgba(91, 140, 74, 0.2);
+  outline-offset: 2px;
+}
+
+.grn-designer-page__mode-button.is-editing {
+  border-color: var(--og-color-moss);
+  background: var(--og-color-moss);
+  color: var(--og-color-paper);
+}
+
+.grn-designer-page__mode-help,
+.grn-designer-page__mode-status,
+.grn-designer-page__mode-message {
+  margin: 0;
+  font-size: 0.84rem;
+}
+
+.grn-designer-page__mode-help {
+  max-width: 18rem;
+  color: rgba(79, 56, 37, 0.72);
+}
+
+.grn-designer-page__mode-status,
+.grn-designer-page__mode-message {
+  padding: 0.55rem 0.8rem;
+  border-radius: var(--og-radius-sm);
+}
+
+.grn-designer-page__mode-status {
+  background: rgba(91, 140, 74, 0.12);
+  color: var(--og-color-moss);
+}
+
+.grn-designer-page__mode-message {
+  background: rgba(173, 32, 27, 0.1);
+  color: #8b1f1a;
+}
+
+@media (max-width: 768px) {
+  .grn-designer-page__header,
+  .grn-designer-page__mode {
+    align-items: center;
+  }
+
+  .grn-designer-page__mode {
+    flex: 1 1 auto;
+  }
+
+  .grn-designer-page__mode-help {
+    display: none;
+  }
+}
+
 .grn-designer-page__hint {
   margin: 0;
   padding: 0.5rem 0.85rem;
@@ -4815,6 +4890,80 @@ body {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: rgba(79, 56, 37, 0.55);
+}
+
+.mp-panel__tend {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(91, 140, 74, 0.22);
+  border-radius: var(--og-radius-md);
+  background: rgba(250, 248, 239, 0.72);
+}
+
+.mp-panel__tend-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.mp-panel__tend-header p,
+.mp-panel__tend-empty {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.82rem;
+}
+
+.mp-panel__tend-reminder,
+.mp-panel__crop-actions button {
+  min-height: 44px;
+  border: 1px solid rgba(91, 140, 74, 0.4);
+  border-radius: var(--og-radius-pill);
+  background: var(--og-color-paper);
+  color: var(--og-color-moss);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.mp-panel__tend-reminder {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.75rem;
+}
+
+.mp-panel__crop--tend {
+  align-items: stretch;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-block: 0.35rem;
+  border-top: 1px solid rgba(91, 58, 28, 0.08);
+}
+
+.mp-panel__crop-summary,
+.mp-panel__crop-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.mp-panel__crop-actions {
+  flex-wrap: wrap;
+}
+
+.mp-panel__crop-actions button {
+  flex: 1 1 5.5rem;
+  padding: 0.4rem 0.55rem;
+}
+
+.mp-panel__tend-reminder:hover,
+.mp-panel__tend-reminder:focus-visible,
+.mp-panel__crop-actions button:hover,
+.mp-panel__crop-actions button:focus-visible {
+  background: rgba(91, 140, 74, 0.1);
+  outline: 2px solid rgba(91, 140, 74, 0.18);
+  outline-offset: 1px;
 }
 
 .mp-panel__capacity {


### PR DESCRIPTION
Closes #374

## Summary

- make Tend the calm default Garden Map mode, with crop update, harvest, reminder, sharing, and quick-add actions
- move every structural affordance behind an explicit, session-persistent Edit layout mode
- block mode exit while saves are active and confirm before discarding unapplied panel drafts
- keep empty-garden templates, direct manipulation, dimensions, vertices, arrange, duplicate, snap, and history scoped to Edit layout
- prefill contextual reminders from the selected bed and preserve public/read-only behavior
- add responsive controls plus focused mode, keyboard, draft, deep-link, and read-only coverage

## Validation

- `npm test -w @olivias/grn` (565 tests passed before the final test-only keyboard addition)
- focused Garden Designer test after the final addition (7 tests passed)
- `npm run lint -w @olivias/grn`
- `npm run typecheck -w @olivias/grn`
- `npm run build -w @olivias/grn`
- `npm run perf:budget -w @olivias/grn`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (227 API unit tests plus integration contract suites passed)

## Environment note

`cargo fmt --all -- --check` is blocked locally by the existing Windows worktree CRLF checkout artifact across unchanged Rust files. This PR changes only frontend files; the Linux CI formatting gate remains authoritative before merge.
