### PR TITLE
feat(grn): build the food sharing journey

### DIFF
--- a/apps/grn/src/components/Harvests/HarvestLogModal.test.tsx
+++ b/apps/grn/src/components/Harvests/HarvestLogModal.test.tsx
@@ -14,11 +14,17 @@ vi.mock('../../services/api', async (importOriginal) => {
   return { ...actual, listHarvests, recordHarvest, updateHarvest, deleteHarvest };
 });
 
-function renderModal() {
+function renderModal(onShareHarvest?: Parameters<typeof HarvestLogModal>[0]['onShareHarvest']) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <HarvestLogModal cropId="crop-1" cropName="Tomato" defaultUnit="lb" onClose={() => {}} />
+      <HarvestLogModal
+        cropId="crop-1"
+        cropName="Tomato"
+        defaultUnit="lb"
+        onClose={() => {}}
+        onShareHarvest={onShareHarvest}
+      />
     </QueryClientProvider>
   );
 }
@@ -74,6 +80,42 @@ describe('HarvestLogModal', () => {
     await waitFor(() => expect(recordHarvest).toHaveBeenCalledTimes(1));
     expect(recordHarvest.mock.calls[0][0]).toBe('crop-1');
     expect(recordHarvest.mock.calls[0][1]).toMatchObject({ amount: 2, unit: 'lb' });
+  });
+
+  it('starts a food share from the harvest that was just saved', async () => {
+    const onShareHarvest = vi.fn();
+    const savedHarvest = {
+      id: 'h2',
+      growerCropId: 'crop-1',
+      amount: '2',
+      unit: 'lb',
+      harvestedOn: '2026-06-22',
+      notes: null,
+      createdAt: '2026-06-22T00:00:00Z',
+    };
+    recordHarvest.mockResolvedValue({
+      harvest: savedHarvest,
+      totalHarvested: '5.5',
+      harvestCount: 2,
+    });
+
+    renderModal(onShareHarvest);
+    await screen.findByTestId('harvest-total');
+    await userEvent.type(screen.getByPlaceholderText('3.5'), '2');
+    await userEvent.click(screen.getByRole('button', { name: /log harvest/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /share some food/i }));
+
+    expect(onShareHarvest).toHaveBeenCalledWith(savedHarvest);
+  });
+
+  it('starts a food share from an existing harvest', async () => {
+    const onShareHarvest = vi.fn();
+    renderModal(onShareHarvest);
+    const row = (await screen.findByText(/first picking/i)).closest('li') as HTMLElement;
+
+    await userEvent.click(within(row).getByRole('button', { name: /share food/i }));
+
+    expect(onShareHarvest).toHaveBeenCalledWith(expect.objectContaining({ id: 'h1' }));
   });
 
   it('rejects a non-positive amount before calling the API', async () => {

--- a/apps/grn/src/components/Harvests/HarvestLogModal.tsx
+++ b/apps/grn/src/components/Harvests/HarvestLogModal.tsx
@@ -15,6 +15,7 @@ interface HarvestLogModalProps {
   cropName: string;
   defaultUnit?: string | null;
   onClose: () => void;
+  onShareHarvest?: (harvest: HarvestItem) => void;
 }
 
 function todayIsoDate(): string {
@@ -35,7 +36,13 @@ interface EditState {
   notes: string;
 }
 
-export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: HarvestLogModalProps) {
+export function HarvestLogModal({
+  cropId,
+  cropName,
+  defaultUnit,
+  onClose,
+  onShareHarvest,
+}: HarvestLogModalProps) {
   const queryClient = useQueryClient();
   const [amount, setAmount] = useState('');
   const [unit, setUnit] = useState(defaultUnit ?? '');
@@ -44,6 +51,7 @@ export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: Harv
   const [formError, setFormError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editState, setEditState] = useState<EditState | null>(null);
+  const [savedHarvest, setSavedHarvest] = useState<HarvestItem | null>(null);
 
   // Close on Escape, matching the app's other dialogs.
   useEffect(() => {
@@ -68,9 +76,10 @@ export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: Harv
   const recordMutation = useMutation({
     mutationFn: (input: { amount: number; unit?: string; harvestedOn?: string; notes?: string }) =>
       recordHarvest(cropId, input),
-    onSuccess: () => {
+    onSuccess: (response) => {
       invalidate();
       completeTodayAction('harvest');
+      setSavedHarvest(response.harvest);
       setAmount('');
       setNotes('');
       setHarvestedOn(todayIsoDate());
@@ -227,6 +236,22 @@ export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: Harv
           {recordMutation.isPending ? 'Logging...' : 'Log harvest'}
         </Button>
 
+        {savedHarvest && onShareHarvest ? (
+          <div className="rounded-base border border-primary-200 bg-primary-50 px-4 py-3" role="status">
+            <p className="font-medium text-primary-900">Harvest saved.</p>
+            <p className="mt-1 text-sm text-primary-800">
+              Have extra? You decide whether and how much to make available.
+            </p>
+            <Button
+              className="mt-3"
+              variant="secondary"
+              onClick={() => onShareHarvest(savedHarvest)}
+            >
+              Share some food
+            </Button>
+          </div>
+        ) : null}
+
         <div className="border-t pt-4">
           {logQuery.isLoading ? <p className="text-sm text-gray-600">Loading harvests...</p> : null}
           {logQuery.isError ? (
@@ -297,7 +322,12 @@ export function HarvestLogModal({ cropId, cropName, defaultUnit, onClose }: Harv
                         <p className="text-xs text-gray-600 truncate">{harvest.notes}</p>
                       ) : null}
                     </div>
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex flex-wrap items-center justify-end gap-2 shrink-0">
+                      {onShareHarvest ? (
+                        <Button variant="secondary" onClick={() => onShareHarvest(harvest)}>
+                          Share food
+                        </Button>
+                      ) : null}
                       <Button variant="secondary" onClick={() => startEditing(harvest)}>
                         Edit
                       </Button>

--- a/apps/grn/src/components/Listings/ClaimStatusList.tsx
+++ b/apps/grn/src/components/Listings/ClaimStatusList.tsx
@@ -16,15 +16,31 @@ interface ClaimStatusListProps {
 }
 
 const actionLabels: Record<ClaimStatus, string> = {
-  pending: 'Set Pending',
-  confirmed: 'Confirm',
-  completed: 'Complete',
-  cancelled: 'Cancel',
-  no_show: 'No Show',
+  pending: 'Return to waiting',
+  confirmed: 'Confirm pickup',
+  completed: 'Mark picked up',
+  cancelled: 'Cancel pickup',
+  no_show: 'Mark pickup missed',
+};
+
+const statusLabels: Record<ClaimStatus, string> = {
+  pending: 'Waiting for confirmation',
+  confirmed: 'Pickup scheduled',
+  completed: 'Food picked up',
+  cancelled: 'Pickup cancelled',
+  no_show: 'Pickup missed',
 };
 
 function formatStatus(status: ClaimStatus): string {
-  return status.replace('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+  return statusLabels[status];
+}
+
+function nextAction(status: ClaimStatus): string {
+  if (status === 'pending') return 'The grower needs to confirm the pickup.';
+  if (status === 'confirmed') return 'Coordinate the pickup, then mark the food picked up.';
+  if (status === 'completed') return 'Pickup is complete. No further action is needed.';
+  if (status === 'cancelled') return 'This pickup will not happen.';
+  return 'This pickup was not completed.';
 }
 
 export function ClaimStatusList({
@@ -83,15 +99,14 @@ export function ClaimStatusList({
             }`}
           >
             <div className="space-y-2">
-              <p className="text-sm text-neutral-800">
-                Claim <span className="font-medium">{claim.id}</span>
-              </p>
+              <p className="text-sm font-medium text-neutral-900">Pickup request</p>
               <p className="text-sm text-neutral-700">
                 Status: <span className="font-medium">{formatStatus(claim.status)}</span>
               </p>
               <p className="text-sm text-neutral-700">
                 Quantity: {claim.quantityClaimed}
               </p>
+              <p className="text-sm text-neutral-700">{nextAction(claim.status)}</p>
             </div>
 
             <div className="mt-3 flex flex-wrap gap-2">

--- a/apps/grn/src/components/Listings/FindFoodPanel.test.tsx
+++ b/apps/grn/src/components/Listings/FindFoodPanel.test.tsx
@@ -319,7 +319,7 @@ describe('FindFoodPanel', () => {
 
     renderPanel();
 
-    expect(await screen.findByText(/no listings found in this area yet/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no food is available in this area yet/i)).toBeInTheDocument();
   });
 
   it('shows an error state when discovery fails', async () => {
@@ -372,21 +372,21 @@ describe('FindFoodPanel', () => {
 
     expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
     window.dispatchEvent(new Event('online'));
-    await user.click(screen.getByRole('button', { name: /claim this listing/i }));
+    await user.click(screen.getByRole('button', { name: /request pickup/i }));
 
     await waitFor(() => {
       expect(mockCreateClaim).toHaveBeenCalledTimes(1);
     });
 
-    expect(await screen.findByText(/claim submitted/i)).toBeInTheDocument();
-    const claimSectionHeading = await screen.findByRole('heading', { name: /my claim coordination/i });
+    expect(await screen.findByText(/pickup requested/i)).toBeInTheDocument();
+    const claimSectionHeading = await screen.findByRole('heading', { name: /my pickups/i });
     const claimSection = claimSectionHeading.closest('.rounded-base');
     expect(claimSection).not.toBeNull();
 
-    await user.click(within(claimSection as HTMLElement).getByRole('button', { name: /^cancel$/i }));
+    await user.click(within(claimSection as HTMLElement).getByRole('button', { name: /cancel pickup/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /my claim coordination/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /my pickups/i })).toBeInTheDocument();
     });
   });
 
@@ -398,21 +398,21 @@ describe('FindFoodPanel', () => {
 
     expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
     window.dispatchEvent(new Event('online'));
-    await user.click(screen.getByRole('button', { name: /claim this listing/i }));
+    await user.click(screen.getByRole('button', { name: /request pickup/i }));
 
     await waitFor(() => {
       expect(mockCreateClaim).toHaveBeenCalledTimes(1);
     });
 
-    const claimSectionHeading = await screen.findByRole('heading', { name: /my claim coordination/i });
+    const claimSectionHeading = await screen.findByRole('heading', { name: /my pickups/i });
     const claimSection = claimSectionHeading.closest('.rounded-base');
     expect(claimSection).not.toBeNull();
-    expect(within(claimSection as HTMLElement).getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+    expect(within(claimSection as HTMLElement).getByRole('button', { name: /cancel pickup/i })).toBeInTheDocument();
 
-    await user.click(within(claimSection as HTMLElement).getByRole('button', { name: /^cancel$/i }));
+    await user.click(within(claimSection as HTMLElement).getByRole('button', { name: /cancel pickup/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /my claim coordination/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /my pickups/i })).toBeInTheDocument();
     });
   });
 
@@ -426,10 +426,10 @@ describe('FindFoodPanel', () => {
     setOnlineStatus(false);
     window.dispatchEvent(new Event('offline'));
 
-    await user.click(screen.getByRole('button', { name: /claim this listing/i }));
+    await user.click(screen.getByRole('button', { name: /request pickup/i }));
 
     expect(mockCreateClaim).not.toHaveBeenCalled();
-    expect(await screen.findByText(/claim was queued/i)).toBeInTheDocument();
+    expect(await screen.findByText(/pickup request is saved/i)).toBeInTheDocument();
 
     setOnlineStatus(true);
     window.dispatchEvent(new Event('online'));
@@ -487,7 +487,7 @@ describe('FindFoodPanel', () => {
       expect(mockCreateRequest).toHaveBeenCalledTimes(2);
     });
 
-    await user.click(screen.getByRole('button', { name: /claim this listing/i }));
+    await user.click(screen.getByRole('button', { name: /request pickup/i }));
 
     await waitFor(() => {
       expect(mockCreateClaim).toHaveBeenCalledTimes(1);
@@ -581,8 +581,8 @@ describe('FindFoodPanel', () => {
 
     renderPanel('/share/find?claim=claim-server');
 
-    const claimId = await screen.findByText('claim-server');
-    expect(claimId.closest('[aria-current="true"]')).not.toBeNull();
-    expect(screen.getByRole('button', { name: /^complete$/i })).toBeInTheDocument();
+    await screen.findByText(/pickup scheduled/i);
+    expect(document.querySelector('[aria-current="true"]')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /mark picked up/i })).toBeInTheDocument();
   });
 });

--- a/apps/grn/src/components/Listings/FindFoodPanel.tsx
+++ b/apps/grn/src/components/Listings/FindFoodPanel.tsx
@@ -287,12 +287,12 @@ export function FindFoodPanel({
       if (result.processed.length > 0) {
         setSessionClaims((current) => applyProcessedQueuedClaims(current, result.processed));
         setClaimSuccessMessage(
-          `Synced ${result.processed.length} queued claim action${result.processed.length === 1 ? '' : 's'}.`
+          `Synced ${result.processed.length} saved pickup update${result.processed.length === 1 ? '' : 's'}.`
         );
       }
 
       if (result.failed.length > 0) {
-        setClaimError('Some offline claim actions are still queued. They will retry when you reconnect.');
+        setClaimError('Some offline pickup updates are still saved. They will retry when you reconnect.');
       }
     } finally {
       setIsReplayingClaimQueue(false);
@@ -577,7 +577,7 @@ export function FindFoodPanel({
 
     const cropId = selectedListing?.cropId ?? draft.cropId;
     if (!cropId) {
-      setSubmitError('Choose a listing or crop before submitting your request.');
+      setSubmitError('Choose available food or a crop before submitting your request.');
       return;
     }
 
@@ -624,7 +624,7 @@ export function FindFoodPanel({
 
     const requestMatch = resolveMatchingRequestId(listing, sessionRequests);
     if (requestMatch.ambiguous) {
-      setClaimError('Multiple open requests match this listing. Claim will be created without linking to a request.');
+      setClaimError('Multiple open food requests match. This pickup will not be linked to one automatically.');
     }
 
     const payload = {
@@ -652,7 +652,7 @@ export function FindFoodPanel({
 
       setSessionClaims((previous) => upsertSessionClaim(previous, localClaim));
       enqueueCreateClaimAction(payload, localClaimId, viewerUserId);
-      setClaimSuccessMessage('You are offline. Claim was queued and will sync when you reconnect.');
+      setClaimSuccessMessage('You are offline. Your pickup request is saved and will sync when you reconnect.');
       return;
     }
 
@@ -661,10 +661,10 @@ export function FindFoodPanel({
 
       setSessionClaims((previous) => upsertSessionClaim(previous, createdClaim));
       void queryClient.invalidateQueries({ queryKey: ['claims'] });
-      setClaimSuccessMessage('Claim submitted.');
+      setClaimSuccessMessage('Pickup requested.');
       logger.info('Claim created', { claimId: createdClaim.id, listingId: createdClaim.listingId });
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to create claim';
+      const message = error instanceof Error ? error.message : 'Failed to request this pickup';
       setClaimError(message);
       logger.error('Claim creation failed', error as Error);
     }
@@ -696,27 +696,27 @@ export function FindFoodPanel({
     try {
       if (isOffline) {
         enqueueTransitionClaimAction(claimId, { status }, viewerUserId);
-        setClaimSuccessMessage('You are offline. Claim transition was queued and will sync when you reconnect.');
+        setClaimSuccessMessage('You are offline. This pickup update is saved and will sync when you reconnect.');
         return;
       }
 
       const resolvedClaimId = isLocalClaimId(claimId) ? previousClaim?.id : claimId;
       if (!resolvedClaimId || isLocalClaimId(resolvedClaimId)) {
-        throw new Error('Claim is not synced yet. Reconnect to sync queued actions first.');
+        throw new Error('This pickup is not synced yet. Reconnect before updating it.');
       }
 
       const updated = await transitionClaimMutation.mutateAsync({ claimId: resolvedClaimId, status });
       setSessionClaims((current) => upsertSessionClaim(current, updated));
       void queryClient.invalidateQueries({ queryKey: ['claims'] });
       completeTodayAction('pickup');
-      setClaimSuccessMessage('Claim updated.');
+      setClaimSuccessMessage('Pickup updated.');
       logger.info('Claim updated', { claimId: updated.id, status: updated.status });
     } catch (error) {
       if (previousClaim) {
         setSessionClaims((current) => upsertSessionClaim(current, previousClaim));
       }
 
-      const message = error instanceof Error ? error.message : 'Failed to update claim';
+      const message = error instanceof Error ? error.message : 'Failed to update pickup';
       setClaimError(message);
       logger.error('Claim transition failed', error as Error);
     } finally {
@@ -729,7 +729,7 @@ export function FindFoodPanel({
       <Card className="space-y-3" padding="6">
         <h3 className="text-lg font-semibold text-neutral-900">Find food nearby</h3>
         <p className="text-sm text-neutral-700">
-          Add your garden location in Settings to start discovering nearby listings.
+          Add your garden location in Settings to find food shared nearby.
         </p>
       </Card>
     );
@@ -790,7 +790,7 @@ export function FindFoodPanel({
               onClick={() => discoveryQuery.refetch()}
               disabled={isOffline || discoveryQuery.isFetching}
             >
-              Refresh Listings
+              Refresh food
             </Button>
           </div>
         </div>
@@ -827,7 +827,7 @@ export function FindFoodPanel({
           </div>
 
           <p className="text-xs text-neutral-500">
-            We only show AI-generated summary text for Pro accounts when enabled. Core listing and request flows always remain available.
+            We only show AI-generated summary text for Pro accounts when enabled. Finding food and requesting pickups always remain available.
           </p>
         </div>
 
@@ -849,7 +849,7 @@ export function FindFoodPanel({
 
         {hasProAiInsights && !aiInsightsOptOut && derivedFeedQuery.isError && (
           <p className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800" role="status">
-            AI insights are temporarily unavailable. You can still discover listings and submit requests.
+            AI insights are temporarily unavailable. You can still find food and request a pickup.
           </p>
         )}
 
@@ -921,24 +921,24 @@ export function FindFoodPanel({
 
       <Card className="space-y-4" padding="6">
         <div className="space-y-1">
-          <h4 className="text-base font-semibold text-neutral-900">Available listings</h4>
+          <h4 className="text-base font-semibold text-neutral-900">Food available nearby</h4>
           <p className="text-sm text-neutral-600">
-            Select a listing to prefill your request form.
+            Select food to prefill your request form.
           </p>
         </div>
 
         {discoveryQuery.isLoading && (
-          <p className="text-sm text-neutral-600" role="status">Loading listings...</p>
+          <p className="text-sm text-neutral-600" role="status">Loading food...</p>
         )}
 
         {discoveryQuery.isError && (
           <p className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error" role="alert">
-            {discoveryQuery.error instanceof Error ? discoveryQuery.error.message : 'Failed to load listings'}
+            {discoveryQuery.error instanceof Error ? discoveryQuery.error.message : 'Failed to load food nearby'}
           </p>
         )}
 
         {!discoveryQuery.isLoading && !discoveryQuery.isError && sortedListings.length === 0 && (
-          <p className="text-sm text-neutral-600">No listings found in this area yet. Try a wider radius.</p>
+          <p className="text-sm text-neutral-600">No food is available in this area yet. Try a wider radius.</p>
         )}
 
         {sortedListings.map((listing) => {
@@ -963,7 +963,7 @@ export function FindFoodPanel({
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="space-y-1">
-                  <p className="font-medium text-neutral-900">{listing.title || 'Untitled listing'}</p>
+                  <p className="font-medium text-neutral-900">{listing.title || 'Shared food'}</p>
                   <p className="text-sm text-neutral-700">
                     {listing.quantityRemaining} {listing.unit} available
                   </p>
@@ -982,7 +982,7 @@ export function FindFoodPanel({
                     loading={createClaimMutation.isPending}
                     onClick={() => handleCreateClaim(listing)}
                   >
-                    Claim this listing
+                    Request pickup
                   </Button>
                 </div>
               </div>
@@ -1003,7 +1003,7 @@ export function FindFoodPanel({
 
         {selectedListing && (
           <p className="rounded-base border border-primary-200 bg-primary-50 px-3 py-2 text-sm text-primary-800" role="status">
-            Requesting from: {selectedListing.title || 'Untitled listing'}
+            Requesting from: {selectedListing.title || 'Shared food'}
           </p>
         )}
 
@@ -1104,13 +1104,13 @@ export function FindFoodPanel({
       </Card>
 
       <ClaimStatusList
-        title="My claim coordination"
-        description="Track your claim states and apply only valid transitions."
+        title="My pickups"
+        description="Follow each pickup and take the next available action."
         claims={visibleClaims}
         pendingClaimIds={pendingClaimIds}
         successMessage={claimSuccessMessage}
         errorMessage={claimError}
-        emptyMessage={claimsQuery.isLoading ? 'Loading your claims...' : 'No claims yet.'}
+        emptyMessage={claimsQuery.isLoading ? 'Loading your pickups...' : 'No pickup requests yet.'}
         getActions={(claim) => getClaimActions(claim.status)}
         onTransition={handleClaimTransition}
         highlightedClaimId={linkedClaimId}

--- a/apps/grn/src/components/Listings/GrowerListingPanel.test.tsx
+++ b/apps/grn/src/components/Listings/GrowerListingPanel.test.tsx
@@ -136,7 +136,7 @@ describe('GrowerListingPanel', () => {
     });
   });
 
-  it('renders my listings, applies status filters, and opens listing details', async () => {
+  it('renders food offers, applies human status filters, and opens pickup details', async () => {
     const user = userEvent.setup();
 
     const activeListing = makeListing({ id: 'listing-1', title: 'Tomatoes Basket', status: 'active' });
@@ -149,44 +149,12 @@ describe('GrowerListingPanel', () => {
       pickupLocationText: 'Driveway table',
     });
 
-    mockListMyListings.mockImplementation(async (_limit, _offset, status) => {
-      if (status === 'active') {
-        return {
-          items: [activeListing],
-          limit: 50,
-          offset: 0,
-          hasMore: false,
-          nextOffset: null,
-        };
-      }
-
-      if (status === 'expired') {
-        return {
-          items: [expiredListing],
-          limit: 50,
-          offset: 0,
-          hasMore: false,
-          nextOffset: null,
-        };
-      }
-
-      if (status === 'completed') {
-        return {
-          items: [],
-          limit: 50,
-          offset: 0,
-          hasMore: false,
-          nextOffset: null,
-        };
-      }
-
-      return {
-        items: [activeListing, expiredListing],
-        limit: 50,
-        offset: 0,
-        hasMore: false,
-        nextOffset: null,
-      };
+    mockListMyListings.mockResolvedValue({
+      items: [activeListing, expiredListing],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
     });
 
     mockGetMyListing.mockImplementation(async (listingId: string) => {
@@ -195,22 +163,21 @@ describe('GrowerListingPanel', () => {
 
     renderPanel();
 
-    await user.click(screen.getByRole('tab', { name: /my listings/i }));
-
     expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Current' })).toBeInTheDocument();
+    expect(screen.queryByText('Late Kale')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Expired' }));
+    await user.click(screen.getByRole('button', { name: 'Ended' }));
 
     expect(await screen.findByText('Late Kale')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /view details/i }));
+    await user.click(screen.getByRole('button', { name: /pickup details/i }));
 
-    expect(await screen.findByText(/listing details/i)).toBeInTheDocument();
+    expect(await screen.findByText(/food to share details/i)).toBeInTheDocument();
     expect(screen.getByText(/driveway table/i)).toBeInTheDocument();
   });
 
-  it('shows empty states for my listings and local discovery', async () => {
+  it('shows an empty hub and keeps sharing one action away', async () => {
     const user = userEvent.setup();
 
     mockListMyListings.mockResolvedValue({
@@ -224,21 +191,16 @@ describe('GrowerListingPanel', () => {
 
     renderPanel();
 
-    await user.click(screen.getByRole('tab', { name: /my listings/i }));
-    expect(await screen.findByText(/no listings match this filter/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no food offers match this view/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('tab', { name: /local discovery/i }));
-    expect(await screen.findByText(/no active listings available for local discovery yet/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^share food$/i }));
+    expect(await screen.findByRole('heading', { name: /^share food$/i })).toBeInTheDocument();
   });
 
   it('shows error state when listing queries fail', async () => {
-    const user = userEvent.setup();
-
     mockListMyListings.mockRejectedValue(new Error('Listings request failed'));
 
     renderPanel();
-
-    await user.click(screen.getByRole('tab', { name: /my listings/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/listings request failed/i)).toBeInTheDocument();
@@ -271,13 +233,12 @@ describe('GrowerListingPanel', () => {
 
     renderPanel();
 
-    await user.click(screen.getByRole('tab', { name: /my listings/i }));
     expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Edit offer' }));
 
-    expect(await screen.findByRole('heading', { name: /edit listing/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/listing title/i)).toHaveValue('Tomatoes Basket');
+    expect(await screen.findByRole('heading', { name: /edit food offer/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/share title/i)).toHaveValue('Tomatoes Basket');
 
     resolveDetail?.(activeListing);
   });
@@ -316,16 +277,15 @@ describe('GrowerListingPanel', () => {
 
     renderPanel();
 
-    await user.click(screen.getByRole('tab', { name: /my listings/i }));
     expect(await screen.findByText('Tomatoes Basket')).toBeInTheDocument();
     window.dispatchEvent(new Event('online'));
-    await user.click(screen.getByRole('button', { name: /view details/i }));
+    await user.click(screen.getByRole('button', { name: /pickup details/i }));
 
-    const claimSectionHeading = await screen.findByRole('heading', { name: /claim coordination/i });
+    const claimSectionHeading = await screen.findByRole('heading', { name: /pickup coordination/i });
     const claimSection = claimSectionHeading.closest('.rounded-base');
     expect(claimSection).not.toBeNull();
-    expect(within(claimSection as HTMLElement).getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
-    expect(within(claimSection as HTMLElement).queryByRole('button', { name: /^complete$/i })).not.toBeInTheDocument();
+    expect(within(claimSection as HTMLElement).getByRole('button', { name: /confirm pickup/i })).toBeInTheDocument();
+    expect(within(claimSection as HTMLElement).queryByRole('button', { name: /mark picked up/i })).not.toBeInTheDocument();
   });
 
   it('opens and highlights the exact listing claim from a Today deep link', async () => {
@@ -363,9 +323,140 @@ describe('GrowerListingPanel', () => {
 
     renderPanel('/share/listings?listing=listing-1&claim=claim-server');
 
-    expect(await screen.findByRole('heading', { name: 'My Listings' })).toBeInTheDocument();
-    const claimId = await screen.findByText('claim-server');
-    expect(claimId.closest('[aria-current="true"]')).not.toBeNull();
-    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Food to share & pickups' })).toBeInTheDocument();
+    await screen.findByText(/waiting for confirmation/i);
+    expect(document.querySelector('[aria-current="true"]')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /confirm pickup/i })).toBeInTheDocument();
+  });
+
+  it('prefills an editable share draft from a saved harvest deep link', async () => {
+    const user = userEvent.setup();
+    mockListMyCrops.mockResolvedValue([
+      {
+        id: 'grower-crop-1',
+        userId: 'user-1',
+        canonicalId: 'crop-1',
+        cropName: 'Tomato',
+        varietyId: null,
+        status: 'growing',
+        visibility: 'private',
+        surplusEnabled: true,
+        nickname: 'Patio tomatoes',
+        defaultUnit: 'lb',
+        notes: null,
+        bedId: null,
+        bedName: null,
+        plantingDate: null,
+        expectedHarvestDate: null,
+        plantCount: null,
+        spacingInches: null,
+        pyramidTier: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    mockListMyListings.mockResolvedValue({
+      items: [],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    renderPanel('/share/listings?crop=grower-crop-1&harvest=h1&quantity=3.5&unit=lb');
+
+    expect(await screen.findByLabelText(/share title/i)).toHaveValue('Patio tomatoes');
+    expect(screen.getByLabelText(/quantity/i)).toHaveValue(3.5);
+    expect(screen.getByLabelText(/unit/i)).toHaveValue('lb');
+    expect(screen.getByText(/prefilled from your saved harvest/i)).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/quantity/i));
+    await user.type(screen.getByLabelText(/quantity/i), '4');
+    expect(screen.getByLabelText(/quantity/i)).toHaveValue(4);
+  });
+
+  it('requires confirmation and reuses the idempotency key when a share is retried', async () => {
+    const user = userEvent.setup();
+    mockListMyCrops.mockResolvedValue([
+      {
+        id: 'grower-crop-1',
+        userId: 'user-1',
+        canonicalId: 'crop-1',
+        cropName: 'Tomato',
+        varietyId: null,
+        status: 'growing',
+        visibility: 'private',
+        surplusEnabled: true,
+        nickname: null,
+        defaultUnit: 'lb',
+        notes: null,
+        bedId: null,
+        bedName: null,
+        plantingDate: null,
+        expectedHarvestDate: null,
+        plantCount: null,
+        spacingInches: null,
+        pyramidTier: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    mockListMyListings.mockResolvedValue({
+      items: [], limit: 50, offset: 0, hasMore: false, nextOffset: null,
+    });
+    mockCreateListing
+      .mockRejectedValueOnce(new Error('Connection interrupted'))
+      .mockResolvedValueOnce(makeListing({ id: 'new-listing' }));
+
+    renderPanel('/share/listings?crop=grower-crop-1&quantity=2&unit=lb');
+
+    await screen.findByLabelText(/share title/i);
+    await user.click(screen.getByRole('button', { name: /review share/i }));
+    expect(mockCreateListing).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /confirm and share/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/connection interrupted/i);
+    await user.click(screen.getByRole('button', { name: /confirm and share/i }));
+
+    await waitFor(() => expect(mockCreateListing).toHaveBeenCalledTimes(2));
+    expect(mockCreateListing.mock.calls[0][1]).toBe(mockCreateListing.mock.calls[1][1]);
+    expect(mockCreateListing.mock.calls[0][1]).toMatch(/^share-/);
+    expect(await screen.findByText(/now available to nearby neighbors/i)).toBeInTheDocument();
+  });
+
+  it('shows completed pickups only in the grower private impact summary', async () => {
+    mockListMyListings.mockResolvedValue({
+      items: [makeListing({ id: 'listing-1' })],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+    mockListClaims.mockResolvedValue({
+      items: [
+        {
+          id: 'claim-1',
+          listingId: 'listing-1',
+          requestId: null,
+          claimerId: 'neighbor-1',
+          listingOwnerId: 'user-1',
+          quantityClaimed: '2',
+          status: 'completed',
+          notes: null,
+          claimedAt: '2026-07-14T09:00:00Z',
+          confirmedAt: '2026-07-14T10:00:00Z',
+          completedAt: '2026-07-14T11:00:00Z',
+          cancelledAt: null,
+        },
+      ],
+      limit: 50,
+      offset: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText(/1 neighbor pickup completed/i)).toBeInTheDocument();
   });
 });

--- a/apps/grn/src/components/Listings/GrowerListingPanel.tsx
+++ b/apps/grn/src/components/Listings/GrowerListingPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import {
@@ -32,8 +32,8 @@ import {
 
 const logger = createLogger('grower-listings');
 
-type ListingsView = 'create' | 'my-listings' | 'discovery';
-type MyListingsFilter = 'all' | 'active' | 'expired' | 'completed';
+type ShareView = 'create' | 'hub';
+type ShareFilter = 'current' | 'completed' | 'ended' | 'all';
 
 interface GrowerListingPanelProps {
   viewerUserId?: string;
@@ -52,23 +52,29 @@ const statusStyles: Record<string, string> = {
   active: 'border-success bg-primary-50 text-primary-800',
   pending: 'border-warning bg-accent-50 text-neutral-800',
   claimed: 'border-neutral-300 bg-neutral-100 text-neutral-800',
+  scheduled: 'border-success bg-primary-50 text-primary-800',
   expired: 'border-neutral-300 bg-neutral-100 text-neutral-700',
   completed: 'border-neutral-300 bg-neutral-100 text-neutral-700',
 };
 
-const filterOptions: Array<{ value: MyListingsFilter; label: string }> = [
-  { value: 'all', label: 'All' },
-  { value: 'active', label: 'Active' },
-  { value: 'expired', label: 'Expired' },
+const filterOptions: Array<{ value: ShareFilter; label: string }> = [
+  { value: 'current', label: 'Current' },
   { value: 'completed', label: 'Completed' },
+  { value: 'ended', label: 'Ended' },
+  { value: 'all', label: 'All' },
 ];
 
-function formatStatus(status: string): string {
-  if (!status) {
-    return 'Unknown';
-  }
+const listingStatusLabels: Record<string, string> = {
+  pending: 'Not shared yet',
+  active: 'Available now',
+  claimed: 'Fully claimed',
+  scheduled: 'Pickup scheduled',
+  completed: 'Share completed',
+  expired: 'Availability ended',
+};
 
-  return status.charAt(0).toUpperCase() + status.slice(1);
+function formatStatus(status: string): string {
+  return listingStatusLabels[status] ?? 'Status unavailable';
 }
 
 function formatDateTime(value: string): string {
@@ -78,27 +84,6 @@ function formatDateTime(value: string): string {
   }
 
   return parsed.toLocaleString();
-}
-
-function toRadians(value: number): number {
-  return (value * Math.PI) / 180;
-}
-
-function distanceInKm(fromLat: number, fromLng: number, toLat: number, toLng: number): number {
-  const earthRadiusKm = 6371;
-  const dLat = toRadians(toLat - fromLat);
-  const dLng = toRadians(toLng - fromLng);
-
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos(toRadians(fromLat)) * Math.cos(toRadians(toLat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return earthRadiusKm * c;
-}
-
-function isFiniteCoordinate(value: number | undefined): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
 }
 
 function getGrowerActions(status: ClaimStatus): ClaimStatus[] {
@@ -111,6 +96,46 @@ function getGrowerActions(status: ClaimStatus): ClaimStatus[] {
   }
 
   return [];
+}
+
+function newShareIdempotencyKey(): string {
+  return `share-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function displayListingStatus(listing: Listing, claims: Claim[]): string {
+  if (listing.status === 'expired' || listing.status === 'completed') {
+    return listing.status;
+  }
+  if (claims.some((claim) => claim.status === 'confirmed')) {
+    return 'scheduled';
+  }
+  if (
+    claims.length > 0 &&
+    claims.every((claim) => claim.status === 'completed' || claim.status === 'cancelled') &&
+    claims.some((claim) => claim.status === 'completed')
+  ) {
+    return 'completed';
+  }
+  return listing.status;
+}
+
+function listingNextAction(status: string, claims: Claim[]): string {
+  if (claims.some((claim) => claim.status === 'pending')) {
+    return 'Next: review the pickup request.';
+  }
+  if (claims.some((claim) => claim.status === 'confirmed')) {
+    return 'Next: coordinate pickup, then mark the food picked up.';
+  }
+  if (status === 'active') {
+    return 'Neighbors can see this now. No action is needed until someone requests pickup.';
+  }
+  if (status === 'expired') {
+    return 'This is no longer visible as available food.';
+  }
+  if (status === 'completed') {
+    return 'Pickup is complete. This result is visible only in your impact summary.';
+  }
+  return 'Open the offer to review its pickup status.';
 }
 
 function applyProcessedQueuedClaims(
@@ -140,17 +165,18 @@ function ListingStatusChip({ status }: { status: string }) {
   );
 }
 
-function ListingDetails({ listing }: { listing: Listing }) {
+function ListingDetails({ listing, claims }: { listing: Listing; claims: Claim[] }) {
+  const displayStatus = displayListingStatus(listing, claims);
   return (
     <div className="rounded-base border border-neutral-200 bg-white px-4 py-4">
       <div className="flex items-center justify-between gap-2">
-        <h4 className="text-base font-semibold text-neutral-900">Listing details</h4>
-        <ListingStatusChip status={listing.status} />
+        <h4 className="text-base font-semibold text-neutral-900">Food to share details</h4>
+        <ListingStatusChip status={displayStatus} />
       </div>
 
       <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-neutral-700">
         <div>
-          <dt className="font-medium text-neutral-900">Title</dt>
+          <dt className="font-medium text-neutral-900">Food</dt>
           <dd>{listing.title}</dd>
         </div>
         <div>
@@ -166,6 +192,9 @@ function ListingDetails({ listing }: { listing: Listing }) {
           <dd>{listing.pickupLocationText ?? 'Not provided'}</dd>
         </div>
       </dl>
+      <p className="mt-3 rounded-base bg-neutral-50 px-3 py-2 text-sm font-medium text-neutral-800">
+        {listingNextAction(displayStatus, claims)}
+      </p>
     </div>
   );
 }
@@ -175,15 +204,20 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
   const [searchParams] = useSearchParams();
   const linkedListingId = searchParams.get('listing');
   const linkedClaimId = searchParams.get('claim');
+  const linkedCropId = searchParams.get('crop');
+  const linkedHarvestId = searchParams.get('harvest');
+  const linkedQuantity = searchParams.get('quantity');
+  const linkedUnit = searchParams.get('unit');
+  const createIdempotencyKey = useRef(newShareIdempotencyKey());
   const [isOffline, setIsOffline] = useState<boolean>(() => !navigator.onLine);
   const [selectedCropId, setSelectedCropId] = useState<string>('');
   const [editingListingId, setEditingListingId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [activeView, setActiveView] = useState<ListingsView>(() =>
-    linkedListingId ? 'my-listings' : 'create'
+  const [activeView, setActiveView] = useState<ShareView>(() =>
+    linkedCropId ? 'create' : 'hub'
   );
-  const [myListingsFilter, setMyListingsFilter] = useState<MyListingsFilter>('all');
+  const [shareFilter, setShareFilter] = useState<ShareFilter>('current');
   const [selectedListingId, setSelectedListingId] = useState<string | null>(linkedListingId);
   const [sessionClaims, setSessionClaims] = useState<Claim[]>(() => loadSessionClaims(viewerUserId));
   const [claimSuccessMessage, setClaimSuccessMessage] = useState<string | null>(null);
@@ -212,12 +246,12 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       if (result.processed.length > 0) {
         setSessionClaims((current) => applyProcessedQueuedClaims(current, result.processed));
         setClaimSuccessMessage(
-          `Synced ${result.processed.length} queued claim action${result.processed.length === 1 ? '' : 's'}.`
+          `Synced ${result.processed.length} saved pickup update${result.processed.length === 1 ? '' : 's'}.`
         );
       }
 
       if (result.failed.length > 0) {
-        setClaimError('Some offline claim actions are still queued. They will retry when you reconnect.');
+        setClaimError('Some offline pickup updates are still saved. They will retry when you reconnect.');
       }
     } finally {
       setIsReplayingClaimQueue(false);
@@ -236,22 +270,10 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
     staleTime: 5 * 60 * 1000,
   });
 
-  const myListingsStatus = myListingsFilter === 'all' ? undefined : myListingsFilter;
-  const isMyListingsViewActive = activeView === 'my-listings';
-  const isDiscoveryViewActive = activeView === 'discovery';
-
   const myListingsQuery = useQuery({
-    queryKey: ['myListings', myListingsStatus],
-    queryFn: () => listMyListings(50, 0, myListingsStatus),
+    queryKey: ['myListings'],
+    queryFn: () => listMyListings(50, 0),
     staleTime: 30 * 1000,
-    enabled: isMyListingsViewActive,
-  });
-
-  const discoveryQuery = useQuery({
-    queryKey: ['myListingsDiscovery'],
-    queryFn: () => listMyListings(50, 0, 'active'),
-    staleTime: 30 * 1000,
-    enabled: isDiscoveryViewActive,
   });
 
   const editListingQuery = useQuery({
@@ -266,15 +288,20 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
     enabled: !!selectedListingId,
   });
 
-  const listingClaimsQuery = useQuery({
-    queryKey: ['claims', 'listing', selectedListingId],
-    queryFn: () => listClaims({ listingId: selectedListingId ?? '', limit: 50 }),
-    enabled: !!selectedListingId,
+  const allClaimsQuery = useQuery({
+    queryKey: ['claims', 'share-hub'],
+    queryFn: () => listClaims({ limit: 50 }),
     staleTime: 30 * 1000,
   });
 
   const createMutation = useMutation({
-    mutationFn: (request: UpsertListingRequest) => createListing(request),
+    mutationFn: ({
+      request,
+      idempotencyKey,
+    }: {
+      request: UpsertListingRequest;
+      idempotencyKey: string;
+    }) => createListing(request, idempotencyKey),
   });
 
   const updateMutation = useMutation({
@@ -309,7 +336,7 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
 
   useEffect(() => {
     if (!linkedListingId) return;
-    setActiveView('my-listings');
+    setActiveView('hub');
     setSelectedListingId(linkedListingId);
   }, [linkedListingId]);
 
@@ -332,7 +359,11 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
   const isEditingListingLoading =
     editingListingId !== null && editListingQuery.isLoading && activeEditListing === null;
 
-  const varietiesCropId = selectedCropId || activeEditListing?.cropId || '';
+  const linkedGrowerCrop = growerCropsQuery.data?.find(
+    (crop) => crop.id === linkedCropId
+  );
+  const varietiesCropId =
+    selectedCropId || linkedGrowerCrop?.canonicalId || activeEditListing?.cropId || '';
 
   const varietiesQuery = useQuery({
     queryKey: ['catalogVarieties', varietiesCropId],
@@ -342,7 +373,15 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
 
   const listingFormKey = useMemo(() => {
     if (!activeEditListing) {
-      return `create:${defaultLat ?? ''}:${defaultLng ?? ''}`;
+      return [
+        'create',
+        linkedCropId ?? '',
+        linkedHarvestId ?? '',
+        linkedQuantity ?? '',
+        linkedUnit ?? '',
+        defaultLat ?? '',
+        defaultLng ?? '',
+      ].join(':');
     }
 
     return [
@@ -360,7 +399,15 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       activeEditListing.pickupLocationText ?? '',
       activeEditListing.pickupNotes ?? '',
     ].join(':');
-  }, [activeEditListing, defaultLat, defaultLng]);
+  }, [
+    activeEditListing,
+    defaultLat,
+    defaultLng,
+    linkedCropId,
+    linkedHarvestId,
+    linkedQuantity,
+    linkedUnit,
+  ]);
 
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
   const pendingClaimIds = useMemo(() => new Set(transitioningClaimIds), [transitioningClaimIds]);
@@ -400,20 +447,6 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       });
   }, [growerCropsQuery.data, cropNameById]);
 
-  const discoveryListings = useMemo(() => {
-    const items = discoveryQuery.data?.items ?? [];
-
-    if (!isFiniteCoordinate(defaultLat) || !isFiniteCoordinate(defaultLng)) {
-      return items;
-    }
-
-    return [...items].sort((left, right) => {
-      const leftDistance = distanceInKm(defaultLat, defaultLng, left.lat, left.lng);
-      const rightDistance = distanceInKm(defaultLat, defaultLng, right.lat, right.lng);
-      return leftDistance - rightDistance;
-    });
-  }, [defaultLat, defaultLng, discoveryQuery.data?.items]);
-
   const handleCreateMode = () => {
     setEditingListingId(null);
     setSelectedCropId('');
@@ -432,7 +465,7 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
     setActiveView('create');
   };
 
-  const handleViewChange = (view: ListingsView) => {
+  const handleViewChange = (view: ShareView) => {
     setActiveView(view);
     setSelectedListingId(null);
 
@@ -449,53 +482,81 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
 
     try {
       if (editingListingId) {
-        await updateMutation.mutateAsync({ listingId: editingListingId, request });
-        setSuccessMessage('Listing updated.');
-        logger.info('Listing updated', { listingId: editingListingId });
+        const updated = await updateMutation.mutateAsync({
+          listingId: editingListingId,
+          request,
+        });
+        setSuccessMessage('Food offer updated.');
+        setSelectedListingId(updated.id);
+        logger.info('Food offer updated', { listingId: editingListingId });
       } else {
-        await createMutation.mutateAsync(request);
-        setSuccessMessage('Listing posted.');
-        logger.info('Listing created', { cropId: request.cropId });
+        const created = await createMutation.mutateAsync({
+          request,
+          idempotencyKey: createIdempotencyKey.current,
+        });
+        createIdempotencyKey.current = newShareIdempotencyKey();
+        setSuccessMessage('Your food is now available to nearby neighbors.');
+        setSelectedListingId(created.id);
+        completeTodayAction('share');
+        logger.info('Food offer created', { cropId: request.cropId });
       }
 
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['myListings'] }),
-        queryClient.invalidateQueries({ queryKey: ['myListingsDiscovery'] }),
-      ]);
+      await queryClient.invalidateQueries({ queryKey: ['myListings'] });
+      setActiveView('hub');
+      setEditingListingId(null);
 
       if (!editingListingId) {
         setSelectedCropId('');
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to submit listing';
+      const message = error instanceof Error ? error.message : 'Failed to share this food';
       setSubmitError(message);
-      logger.error('Listing submission failed', error as Error);
+      logger.error('Food sharing failed', error as Error);
       throw error;
     }
   };
 
   const selectedListing = detailListingQuery.data ?? null;
 
-  const claimsForSelectedListing = useMemo(() => {
-    if (!selectedListing) {
-      return [];
-    }
-
+  const visibleClaims = useMemo(() => {
     const combinedClaims = new Map(
-      (listingClaimsQuery.data?.items ?? []).map((claim) => [claim.id, claim])
+      (allClaimsQuery.data?.items ?? []).map((claim) => [claim.id, claim])
     );
     for (const claim of sessionClaims) {
       combinedClaims.set(claim.id, claim);
     }
+    return [...combinedClaims.values()].filter((claim) =>
+      viewerUserId ? claim.listingOwnerId === viewerUserId : true
+    );
+  }, [allClaimsQuery.data?.items, sessionClaims, viewerUserId]);
 
-    return [...combinedClaims.values()].filter((claim) => {
-      if (claim.listingId !== selectedListing.id) {
-        return false;
-      }
+  const claimsByListingId = useMemo(() => {
+    const claims = new Map<string, Claim[]>();
+    for (const claim of visibleClaims) {
+      claims.set(claim.listingId, [...(claims.get(claim.listingId) ?? []), claim]);
+    }
+    return claims;
+  }, [visibleClaims]);
 
-      return viewerUserId ? claim.listingOwnerId === viewerUserId : true;
+  const claimsForSelectedListing = selectedListing
+    ? claimsByListingId.get(selectedListing.id) ?? []
+    : [];
+
+  const hubListings = useMemo(() => {
+    const listings = myListingsQuery.data?.items ?? [];
+    if (shareFilter === 'all') return listings;
+    return listings.filter((listing) => {
+      const status = displayListingStatus(
+        listing,
+        claimsByListingId.get(listing.id) ?? []
+      );
+      if (shareFilter === 'completed') return status === 'completed';
+      if (shareFilter === 'ended') return status === 'expired';
+      return status !== 'completed' && status !== 'expired';
     });
-  }, [listingClaimsQuery.data?.items, selectedListing, sessionClaims, viewerUserId]);
+  }, [claimsByListingId, myListingsQuery.data?.items, shareFilter]);
+
+  const completedClaims = visibleClaims.filter((claim) => claim.status === 'completed');
 
   const handleClaimTransition = async (claimId: string, status: ClaimStatus) => {
     setClaimError(null);
@@ -523,7 +584,7 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
     try {
       if (isOffline) {
         enqueueTransitionClaimAction(claimId, { status }, viewerUserId);
-        setClaimSuccessMessage('You are offline. Claim transition was queued and will sync when you reconnect.');
+        setClaimSuccessMessage('You are offline. This pickup update is saved and will sync when you reconnect.');
         return;
       }
 
@@ -531,14 +592,14 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
       setSessionClaims((current) => upsertSessionClaim(current, updated));
       void queryClient.invalidateQueries({ queryKey: ['claims'] });
       completeTodayAction('claim');
-      setClaimSuccessMessage('Claim updated.');
+      setClaimSuccessMessage('Pickup updated.');
       logger.info('Claim updated', { claimId: updated.id, status: updated.status });
     } catch (error) {
       if (previousClaim) {
         setSessionClaims((current) => upsertSessionClaim(current, previousClaim));
       }
 
-      const message = error instanceof Error ? error.message : 'Failed to update claim';
+      const message = error instanceof Error ? error.message : 'Failed to update pickup';
       setClaimError(message);
       logger.error('Claim transition failed', error as Error);
     } finally {
@@ -549,7 +610,16 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
   return (
     <div className="space-y-4">
       <Card className="space-y-3" padding="4">
-        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Listings workspace views">
+        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Share workspace views">
+          <Button
+            size="sm"
+            variant={activeView === 'hub' ? 'primary' : 'ghost'}
+            role="tab"
+            aria-selected={activeView === 'hub'}
+            onClick={() => handleViewChange('hub')}
+          >
+            Food to share & pickups
+          </Button>
           <Button
             size="sm"
             variant={activeView === 'create' ? 'primary' : 'ghost'}
@@ -557,25 +627,7 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
             aria-selected={activeView === 'create'}
             onClick={() => handleViewChange('create')}
           >
-            Create Listing
-          </Button>
-          <Button
-            size="sm"
-            variant={activeView === 'my-listings' ? 'primary' : 'ghost'}
-            role="tab"
-            aria-selected={activeView === 'my-listings'}
-            onClick={() => handleViewChange('my-listings')}
-          >
-            My Listings
-          </Button>
-          <Button
-            size="sm"
-            variant={activeView === 'discovery' ? 'primary' : 'ghost'}
-            role="tab"
-            aria-selected={activeView === 'discovery'}
-            onClick={() => handleViewChange('discovery')}
-          >
-            Local Discovery
+            Share food
           </Button>
         </div>
       </Card>
@@ -584,10 +636,10 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
         <Card className="space-y-4" padding="6">
           <div className="space-y-1">
             <h2 className="text-xl font-semibold text-neutral-900">
-              {editingListingId ? 'Edit listing' : 'Create listing'}
+              {editingListingId ? 'Edit food offer' : 'Share food'}
             </h2>
             <p className="text-sm text-neutral-600">
-              Start from something you already grow, then post in seconds.
+              Choose what is available, review the pickup details, then confirm when you are ready.
             </p>
           </div>
 
@@ -603,7 +655,7 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
 
           {growerCropsQuery.isError && (
             <p className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800" role="status">
-              Could not load your crop library. You can still post manually.
+              Could not load your crop library. You can still fill the draft manually.
             </p>
           )}
 
@@ -614,10 +666,22 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
           )}
 
           {isEditingListingLoading && (
-            <p className="text-sm text-neutral-600" role="status">Loading listing...</p>
+            <p className="text-sm text-neutral-600" role="status">Loading food offer...</p>
           )}
 
-          {!cropsQuery.isLoading && !cropsQuery.isError && !isEditingListingLoading && (
+          {linkedCropId &&
+          !growerCropsQuery.isLoading &&
+          !growerCropsQuery.isError &&
+          !quickPickOptions.some((option) => option.id === linkedCropId) ? (
+            <p className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800" role="alert">
+              We could not find that garden crop. Choose another crop before sharing.
+            </p>
+          ) : null}
+
+          {!cropsQuery.isLoading &&
+            !cropsQuery.isError &&
+            !isEditingListingLoading &&
+            (!linkedCropId || !growerCropsQuery.isLoading) && (
             <ListingForm
               key={listingFormKey}
               mode={editingListingId ? 'edit' : 'create'}
@@ -626,6 +690,20 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
               quickPickOptions={quickPickOptions}
               isLoadingVarieties={varietiesQuery.isLoading}
               isLoadingQuickPicks={growerCropsQuery.isLoading}
+              prefill={
+                editingListingId
+                  ? undefined
+                  : {
+                      quickPickId: linkedCropId,
+                      quantity: linkedQuantity,
+                      unit: linkedUnit,
+                      sourceLabel: linkedHarvestId
+                        ? 'your saved harvest'
+                        : linkedCropId
+                          ? 'your garden crop'
+                          : null,
+                    }
+              }
               initialListing={activeEditListing}
               defaultLat={defaultLat}
               defaultLng={defaultLng}
@@ -640,22 +718,44 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
         </Card>
       )}
 
-      {activeView === 'my-listings' && (
+      {activeView === 'hub' && (
         <Card className="space-y-4" padding="6">
-          <div className="space-y-1">
-            <h3 className="text-lg font-semibold text-neutral-900">My Listings</h3>
-            <p className="text-sm text-neutral-600">Review your posted listings and open details for each entry.</p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold text-neutral-900">Food to share & pickups</h3>
+              <p className="text-sm text-neutral-600">
+                See what neighbors can find, review pickup requests, and finish each share in one place.
+              </p>
+            </div>
+            <Button variant="primary" onClick={handleCreateMode}>
+              Share food
+            </Button>
           </div>
 
-          <div className="flex flex-wrap gap-2" aria-label="Listing status filters">
+          {successMessage ? (
+            <p className="rounded-base border border-success bg-primary-50 px-3 py-2 text-sm text-primary-800" role="status">
+              {successMessage}
+            </p>
+          ) : null}
+
+          <div className="rounded-base border border-primary-200 bg-primary-50 px-4 py-3">
+            <p className="text-sm font-semibold text-primary-900">Your private impact</p>
+            <p className="mt-1 text-sm text-primary-800">
+              {completedClaims.length === 0
+                ? 'Completed pickups will appear here for you only.'
+                : `${completedClaims.length} neighbor pickup${completedClaims.length === 1 ? '' : 's'} completed. Thank you for helping food reach someone nearby.`}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2" aria-label="Food sharing status filters">
             {filterOptions.map((option) => (
               <Button
                 key={option.value}
                 size="sm"
-                variant={myListingsFilter === option.value ? 'outline' : 'ghost'}
-                aria-pressed={myListingsFilter === option.value}
+                variant={shareFilter === option.value ? 'outline' : 'ghost'}
+                aria-pressed={shareFilter === option.value}
                 onClick={() => {
-                  setMyListingsFilter(option.value);
+                  setShareFilter(option.value);
                   setSelectedListingId(null);
                 }}
               >
@@ -665,170 +765,89 @@ export function GrowerListingPanel({ viewerUserId, defaultLat, defaultLng }: Gro
           </div>
 
           {myListingsQuery.isLoading && (
-            <p className="text-sm text-neutral-600" role="status">Loading your listings...</p>
+            <p className="text-sm text-neutral-600" role="status">Loading food to share...</p>
           )}
 
           {myListingsQuery.isError && (
             <p className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error" role="alert">
               {myListingsQuery.error instanceof Error
                 ? myListingsQuery.error.message
-                : 'Failed to load your listings'}
+                : 'Failed to load food to share'}
             </p>
           )}
 
-          {!myListingsQuery.isLoading && !myListingsQuery.isError && (myListingsQuery.data?.items.length ?? 0) === 0 && (
-            <p className="text-sm text-neutral-600">No listings match this filter.</p>
-          )}
-
-          {(myListingsQuery.data?.items ?? []).map((listing) => (
-            <div
-              key={listing.id}
-              className="rounded-base border border-neutral-200 bg-white px-3 py-3"
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="space-y-1">
-                  <p className="font-medium text-neutral-900">{listing.title}</p>
-                  <p className="text-sm text-neutral-600">
-                    {listing.quantityRemaining} {listing.unit} remaining
-                  </p>
-                  <ListingStatusChip status={listing.status} />
-                </div>
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setSelectedListingId(listing.id)}
-                  >
-                    View details
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEditMode(listing.id, listing.cropId)}
-                  >
-                    Edit
-                  </Button>
-                </div>
-              </div>
-            </div>
-          ))}
-
-          {selectedListingId && detailListingQuery.isLoading && (
-            <p className="text-sm text-neutral-600" role="status">Loading listing details...</p>
-          )}
-
-          {selectedListingId && detailListingQuery.isError && (
-            <p className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error" role="alert">
-              {detailListingQuery.error instanceof Error
-                ? detailListingQuery.error.message
-                : 'Failed to load listing details'}
-            </p>
-          )}
-
-          {selectedListing && (
-            <>
-              <ListingDetails listing={selectedListing} />
-              <ClaimStatusList
-                title="Claim coordination"
-                description="Review claim status and apply valid transitions."
-                claims={claimsForSelectedListing}
-                pendingClaimIds={pendingClaimIds}
-                successMessage={claimSuccessMessage}
-                errorMessage={claimError}
-                emptyMessage={
-                  listingClaimsQuery.isLoading
-                    ? 'Loading claims for this listing...'
-                    : 'No claims for this listing yet.'
-                }
-                getActions={(claim) => getGrowerActions(claim.status)}
-                onTransition={handleClaimTransition}
-                highlightedClaimId={linkedClaimId}
-              />
-            </>
-          )}
-        </Card>
-      )}
-
-      {activeView === 'discovery' && (
-        <Card className="space-y-4" padding="6">
-          <div className="space-y-1">
-            <h3 className="text-lg font-semibold text-neutral-900">Local Discovery</h3>
+          {!myListingsQuery.isLoading && !myListingsQuery.isError && hubListings.length === 0 && (
             <p className="text-sm text-neutral-600">
-              Showing your active listings in local-context order so you can verify what nearby neighbors can discover.
-            </p>
-          </div>
-
-          {discoveryQuery.isLoading && (
-            <p className="text-sm text-neutral-600" role="status">Loading local discovery listings...</p>
-          )}
-
-          {discoveryQuery.isError && (
-            <p className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error" role="alert">
-              {discoveryQuery.error instanceof Error
-                ? discoveryQuery.error.message
-                : 'Failed to load local discovery listings'}
+              No food offers match this view. Share food when you have something extra.
             </p>
           )}
 
-          {!discoveryQuery.isLoading && !discoveryQuery.isError && discoveryListings.length === 0 && (
-            <p className="text-sm text-neutral-600">No active listings available for local discovery yet.</p>
-          )}
-
-          {discoveryListings.map((listing) => {
-            const canShowDistance = isFiniteCoordinate(defaultLat) && isFiniteCoordinate(defaultLng);
-            const distanceLabel = canShowDistance
-              ? `${distanceInKm(defaultLat, defaultLng, listing.lat, listing.lng).toFixed(1)} km away`
-              : null;
-
+          {hubListings.map((listing) => {
+            const listingClaims = claimsByListingId.get(listing.id) ?? [];
+            const displayStatus = displayListingStatus(listing, listingClaims);
             return (
-              <div key={listing.id} className="rounded-base border border-neutral-200 bg-white px-3 py-3">
-                <div className="flex items-start justify-between gap-2">
+              <div
+                key={listing.id}
+                className="rounded-base border border-neutral-200 bg-white px-3 py-3"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-1">
                     <p className="font-medium text-neutral-900">{listing.title}</p>
                     <p className="text-sm text-neutral-600">
-                      {listing.quantityRemaining} {listing.unit} remaining
+                      {listing.quantityRemaining} {listing.unit} available
                     </p>
-                    {distanceLabel && <p className="text-xs text-neutral-500">{distanceLabel}</p>}
-                    <ListingStatusChip status={listing.status} />
+                    <ListingStatusChip status={displayStatus} />
+                    <p className="text-sm text-neutral-700">
+                      {listingNextAction(displayStatus, listingClaims)}
+                    </p>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setSelectedListingId(listing.id)}
-                  >
-                    View details
-                  </Button>
+                  <div className="flex flex-wrap gap-2 sm:justify-end">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setSelectedListingId(listing.id)}
+                    >
+                      Pickup details
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleEditMode(listing.id, listing.cropId)}
+                    >
+                      Edit offer
+                    </Button>
+                  </div>
                 </div>
               </div>
             );
           })}
 
           {selectedListingId && detailListingQuery.isLoading && (
-            <p className="text-sm text-neutral-600" role="status">Loading listing details...</p>
+            <p className="text-sm text-neutral-600" role="status">Loading pickup details...</p>
           )}
 
           {selectedListingId && detailListingQuery.isError && (
             <p className="rounded-base border border-error bg-red-50 px-3 py-2 text-sm text-error" role="alert">
               {detailListingQuery.error instanceof Error
                 ? detailListingQuery.error.message
-                : 'Failed to load listing details'}
+                : 'Failed to load pickup details'}
             </p>
           )}
 
           {selectedListing && (
             <>
-              <ListingDetails listing={selectedListing} />
+              <ListingDetails listing={selectedListing} claims={claimsForSelectedListing} />
               <ClaimStatusList
-                title="Claim coordination"
-                description="Review claim status and apply valid transitions."
+                title="Pickup coordination"
+                description="The next available action matches the pickup's current state."
                 claims={claimsForSelectedListing}
                 pendingClaimIds={pendingClaimIds}
                 successMessage={claimSuccessMessage}
                 errorMessage={claimError}
                 emptyMessage={
-                  listingClaimsQuery.isLoading
-                    ? 'Loading claims for this listing...'
-                    : 'No claims for this listing yet.'
+                  allClaimsQuery.isLoading
+                    ? 'Loading pickup requests...'
+                    : 'No pickup requests for this food yet.'
                 }
                 getActions={(claim) => getGrowerActions(claim.status)}
                 onTransition={handleClaimTransition}

--- a/apps/grn/src/components/Listings/ListingForm.test.tsx
+++ b/apps/grn/src/components/Listings/ListingForm.test.tsx
@@ -34,7 +34,7 @@ describe('ListingForm', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /post listing/i }));
+    await user.click(screen.getByRole('button', { name: /review share/i }));
 
     expect(await screen.findByText(/title is required/i)).toBeInTheDocument();
     expect(screen.getByText(/crop is required/i)).toBeInTheDocument();
@@ -73,10 +73,52 @@ describe('ListingForm', () => {
 
     await user.selectOptions(screen.getByLabelText(/share something you already grow/i), 'grower-crop-1');
 
-    expect(screen.getByLabelText(/listing title/i)).toHaveValue('Patio Tomatoes');
+    expect(screen.getByLabelText(/share title/i)).toHaveValue('Patio Tomatoes');
     expect(screen.getByLabelText(/crop/i)).toHaveValue('crop-1');
     expect(screen.getByLabelText(/unit/i)).toHaveValue('kg');
     expect(onCropChange).toHaveBeenCalledWith('crop-1');
+  });
+
+  it('prefills an editable draft from a saved harvest', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ListingForm
+        mode="create"
+        crops={crops}
+        varieties={[]}
+        quickPickOptions={[
+          {
+            id: 'grower-crop-1',
+            label: 'Patio Tomatoes',
+            cropId: 'crop-1',
+            defaultUnit: 'lb',
+            suggestedTitle: 'Patio Tomatoes',
+          },
+        ]}
+        prefill={{
+          quickPickId: 'grower-crop-1',
+          quantity: '3.5',
+          unit: 'lb',
+          sourceLabel: 'your saved harvest',
+        }}
+        isLoadingVarieties={false}
+        isSubmitting={false}
+        isOffline={false}
+        submitError={null}
+        onCropChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText(/share something you already grow/i)).toHaveValue('grower-crop-1');
+    expect(screen.getByLabelText(/share title/i)).toHaveValue('Patio Tomatoes');
+    expect(screen.getByLabelText(/quantity/i)).toHaveValue(3.5);
+    expect(screen.getByText(/prefilled from your saved harvest/i)).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText(/quantity/i));
+    await user.type(screen.getByLabelText(/quantity/i), '4');
+    expect(screen.getByLabelText(/quantity/i)).toHaveValue(4);
   });
 
   it('submits valid payload when required fields are complete', async () => {
@@ -97,13 +139,18 @@ describe('ListingForm', () => {
       />
     );
 
-    await user.type(screen.getByLabelText(/listing title/i), 'Fresh Tomatoes');
+    await user.type(screen.getByLabelText(/share title/i), 'Fresh Tomatoes');
     await user.selectOptions(screen.getByLabelText(/crop/i), 'crop-1');
     await user.type(screen.getByLabelText(/quantity/i), '4.5');
     await user.type(screen.getByLabelText(/latitude/i), '37.7');
     await user.type(screen.getByLabelText(/longitude/i), '-122.4');
 
-    await user.click(screen.getByRole('button', { name: /post listing/i }));
+    await user.click(screen.getByRole('button', { name: /review share/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: /ready to share/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /confirm and share/i }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -141,13 +188,13 @@ describe('ListingForm', () => {
 
     expect(screen.getByText(/you are offline/i)).toBeInTheDocument();
 
-    await user.type(screen.getByLabelText(/listing title/i), 'Fresh Tomatoes');
+    await user.type(screen.getByLabelText(/share title/i), 'Fresh Tomatoes');
     await user.selectOptions(screen.getByLabelText(/crop/i), 'crop-1');
     await user.type(screen.getByLabelText(/quantity/i), '4.5');
     await user.type(screen.getByLabelText(/latitude/i), '37.7');
     await user.type(screen.getByLabelText(/longitude/i), '-122.4');
 
-    await user.click(screen.getByRole('button', { name: /post listing/i }));
+    expect(screen.getByRole('button', { name: /review share/i })).toBeDisabled();
 
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/apps/grn/src/components/Listings/ListingForm.tsx
+++ b/apps/grn/src/components/Listings/ListingForm.tsx
@@ -17,6 +17,13 @@ export interface ListingQuickPickOption {
   suggestedTitle: string;
 }
 
+export interface ListingFormPrefill {
+  quickPickId?: string | null;
+  quantity?: string | null;
+  unit?: string | null;
+  sourceLabel?: string | null;
+}
+
 interface ListingFormProps {
   mode: 'create' | 'edit';
   crops: CatalogCrop[];
@@ -24,6 +31,7 @@ interface ListingFormProps {
   quickPickOptions?: ListingQuickPickOption[];
   isLoadingVarieties: boolean;
   isLoadingQuickPicks?: boolean;
+  prefill?: ListingFormPrefill;
   initialListing?: Listing | null;
   defaultLat?: number;
   defaultLng?: number;
@@ -88,19 +96,24 @@ function parseIsoToLocal(isoValue: string): string {
   return toLocalDateTimeInput(parsed);
 }
 
-function buildDefaultForm(defaultLat?: number, defaultLng?: number): ListingFormState {
+function buildDefaultForm(
+  defaultLat?: number,
+  defaultLng?: number,
+  quickPick?: ListingQuickPickOption,
+  prefill?: ListingFormPrefill
+): ListingFormState {
   const now = new Date();
-  const oneHourLater = new Date(now.getTime() + 60 * 60 * 1000);
+  const oneDayLater = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
   return {
-    title: '',
-    cropId: '',
-    growerCropId: '',
-    varietyId: '',
-    quantityTotal: '',
-    unit: 'lb',
+    title: quickPick?.suggestedTitle ?? '',
+    cropId: quickPick?.cropId ?? '',
+    growerCropId: quickPick?.growerCropId ?? quickPick?.id ?? '',
+    varietyId: quickPick?.varietyId ?? '',
+    quantityTotal: prefill?.quantity ?? '',
+    unit: prefill?.unit ?? quickPick?.defaultUnit ?? 'lb',
     availableStart: toLocalDateTimeInput(now),
-    availableEnd: toLocalDateTimeInput(oneHourLater),
+    availableEnd: toLocalDateTimeInput(oneDayLater),
     lat: defaultLat !== undefined ? String(defaultLat) : '',
     lng: defaultLng !== undefined ? String(defaultLng) : '',
     pickupLocationText: '',
@@ -132,6 +145,7 @@ export function ListingForm({
   quickPickOptions = [],
   isLoadingVarieties,
   isLoadingQuickPicks = false,
+  prefill,
   initialListing,
   defaultLat,
   defaultLng,
@@ -143,14 +157,20 @@ export function ListingForm({
   onCancelEdit,
 }: ListingFormProps) {
   const [errors, setErrors] = useState<ListingFormErrors>({});
-  const [selectedQuickPickId, setSelectedQuickPickId] = useState<string>('');
+  const prefilledQuickPick = prefill?.quickPickId
+    ? quickPickOptions.find((option) => option.id === prefill.quickPickId)
+    : undefined;
+  const [selectedQuickPickId, setSelectedQuickPickId] = useState<string>(
+    prefilledQuickPick?.id ?? ''
+  );
+  const [isReviewing, setIsReviewing] = useState(false);
 
   const initialState = useMemo(() => {
     if (mode === 'edit' && initialListing) {
       return buildEditForm(initialListing);
     }
-    return buildDefaultForm(defaultLat, defaultLng);
-  }, [mode, initialListing, defaultLat, defaultLng]);
+    return buildDefaultForm(defaultLat, defaultLng, prefilledQuickPick, prefill);
+  }, [mode, initialListing, defaultLat, defaultLng, prefilledQuickPick, prefill]);
 
   const [formState, setFormState] = useState<ListingFormState>(initialState);
 
@@ -246,6 +266,11 @@ export function ListingForm({
       return;
     }
 
+    if (mode === 'create' && !isReviewing) {
+      setIsReviewing(true);
+      return;
+    }
+
     const status: UpsertListingRequest['status'] =
       mode === 'edit' && initialListing && isListingStatus(initialListing.status)
         ? initialListing.status
@@ -269,7 +294,12 @@ export function ListingForm({
       contactPref: 'app_message',
     };
 
-    await onSubmit(request);
+    try {
+      await onSubmit(request);
+    } catch {
+      // The parent renders the actionable error and keeps this confirmed draft
+      // intact so retrying reuses the same idempotency key.
+    }
   };
 
   return (
@@ -298,11 +328,16 @@ export function ListingForm({
           {!isLoadingQuickPicks && quickPickOptions.length === 0 && (
             <p className="text-sm text-neutral-600">No saved grower crops yet. Fill the form manually below.</p>
           )}
+          {prefill?.sourceLabel ? (
+            <p className="rounded-base border border-primary-200 bg-primary-50 px-3 py-2 text-sm text-primary-800" role="status">
+              Prefilled from {prefill.sourceLabel}. Review every field before sharing.
+            </p>
+          ) : null}
         </div>
       )}
 
       <Input
-        label="Listing title"
+        label="Share title"
         value={formState.title}
         onChange={(event) => {
           setFormState((current) => ({ ...current, title: event.target.value }));
@@ -310,7 +345,7 @@ export function ListingForm({
             setErrors((current) => ({ ...current, title: undefined }));
           }
         }}
-        placeholder="Fresh tomatoes ready this afternoon"
+        placeholder="Fresh tomatoes ready to share"
         required
         error={errors.title}
       />
@@ -529,9 +564,33 @@ export function ListingForm({
         placeholder="Please text before pickup"
       />
 
+      {mode === 'create' && !isReviewing ? (
+        <p className="rounded-base border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-700">
+          Draft — only you can see this. Nothing becomes available to neighbors until you review and confirm.
+        </p>
+      ) : null}
+
+      {mode === 'create' && isReviewing ? (
+        <section
+          className="space-y-2 rounded-base border-2 border-primary-300 bg-primary-50 px-4 py-4"
+          aria-label="Review food to share"
+        >
+          <h3 className="font-semibold text-neutral-900">Ready to share?</h3>
+          <p className="text-sm text-neutral-700">
+            {formState.quantityTotal} {formState.unit} · {formState.title}
+          </p>
+          <p className="text-sm text-neutral-700">
+            Confirming makes this visible to nearby neighbors. You can still edit any field above.
+          </p>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setIsReviewing(false)}>
+            Keep editing
+          </Button>
+        </section>
+      ) : null}
+
       {isOffline && (
         <p className="rounded-base border border-warning bg-accent-50 px-3 py-2 text-sm text-neutral-800" role="status">
-          You are offline. Reconnect to submit this listing.
+          You are offline. This draft stays private; reconnect before sharing.
         </p>
       )}
 
@@ -554,7 +613,11 @@ export function ListingForm({
           loading={isSubmitting}
           disabled={isSubmitting || isOffline}
         >
-          {mode === 'create' ? 'Post listing' : 'Save changes'}
+          {mode === 'create'
+            ? isReviewing
+              ? 'Confirm and share'
+              : 'Review share'
+            : 'Save changes'}
         </Button>
       </div>
     </form>

--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { CropLibraryPanel } from './CropLibraryPanel';
 import { listMyBeds, listMyCrops, updateMyCrop } from '../../services/api';
 
@@ -18,6 +18,11 @@ vi.mock('../Harvests/HarvestLogModal', () => ({
     <div role="dialog" aria-label={`Harvest ${cropName}`}>Harvest {cropName}</div>
   ),
 }));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+}
 
 describe('CropLibraryPanel deep links', () => {
   it('opens the harvest workflow for the linked crop', async () => {
@@ -138,5 +143,47 @@ describe('CropLibraryPanel deep links', () => {
         expect.objectContaining({ cropName: 'Tomato', bedId: 'bed-1' })
       )
     );
+  });
+
+  it('starts an editable food share from a crop', async () => {
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(listMyCrops).mockResolvedValue([
+      {
+        id: 'crop-1',
+        userId: 'grower-1',
+        canonicalId: 'catalog-tomato',
+        cropName: 'Tomato',
+        varietyId: null,
+        status: 'growing',
+        visibility: 'private',
+        surplusEnabled: true,
+        nickname: null,
+        defaultUnit: 'lb',
+        notes: null,
+        bedId: null,
+        bedName: null,
+        plantingDate: null,
+        expectedHarvestDate: null,
+        plantCount: null,
+        spacingInches: null,
+        pyramidTier: null,
+        createdAt: '2026-07-01T00:00:00Z',
+        updatedAt: '2026-07-01T00:00:00Z',
+      },
+    ]);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/garden/plants']}>
+          <CropLibraryPanel viewerUserId="grower-1" />
+          <LocationDisplay />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /share food/i }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/share/listings?crop=crop-1');
   });
 });

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -6,6 +6,7 @@ import {
   deleteMyCrop,
   listMyBeds,
   updateMyCrop,
+  type HarvestItem,
   type UpsertGrowerCropRequest,
 } from '../../services/api';
 import type { GrowerCropItem } from '../../types/listing';
@@ -111,11 +112,22 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
   const handleDelete = (crop: GrowerCropItem) => {
     if (
       confirm(
-        `Remove "${crop.nickname || crop.cropName}" from your garden? This won't delete any listings already created.`
+        `Remove "${crop.nickname || crop.cropName}" from your garden? This won't delete any food offers already shared.`
       )
     ) {
       deleteMutation.mutate(crop.id);
     }
+  };
+
+  const openShareDraft = (crop: GrowerCropItem, harvest?: HarvestItem) => {
+    const params = new URLSearchParams({ crop: crop.id });
+    if (harvest) {
+      params.set('harvest', harvest.id);
+      params.set('quantity', harvest.amount);
+      params.set('unit', harvest.unit ?? crop.defaultUnit ?? 'lb');
+      params.set('harvestedOn', harvest.harvestedOn);
+    }
+    navigate(`/share/listings?${params.toString()}`);
   };
 
   if (isLoadingCrops) {
@@ -264,7 +276,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                     {crop.surplusEnabled ? (
                       <li>
                         <span aria-hidden="true">🤝</span>
-                        <span>Surplus sharing on</span>
+                        <span>Food sharing enabled</span>
                       </li>
                     ) : null}
                   </ul>
@@ -306,6 +318,13 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                 </div>
 
                 <footer className="grn-crop-card__footer">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => openShareDraft(crop)}
+                  >
+                    Share food
+                  </Button>
                   <Button
                     variant="ghost"
                     size="sm"
@@ -349,6 +368,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
           cropId={activeHarvestCrop.id}
           cropName={activeHarvestCrop.nickname || activeHarvestCrop.cropName}
           defaultUnit={activeHarvestCrop.defaultUnit}
+          onShareHarvest={(harvest) => openShareDraft(activeHarvestCrop, harvest)}
           onClose={() => {
             setHarvestCrop(null);
             if (activeHarvestCrop.id === linkedCropId) {

--- a/apps/grn/src/pages/ConnectPage.test.tsx
+++ b/apps/grn/src/pages/ConnectPage.test.tsx
@@ -21,7 +21,7 @@ function renderPage() {
 describe('ConnectPage', () => {
   it('renders the four connect options', () => {
     renderPage();
-    expect(screen.getByText('Share your surplus')).toBeInTheDocument();
+    expect(screen.getByText('Food to share')).toBeInTheDocument();
     expect(screen.getByText('Find food nearby')).toBeInTheDocument();
     expect(screen.getByText('What neighbors need')).toBeInTheDocument();
     expect(screen.getByText('Share your garden')).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('ConnectPage', () => {
 
   it('navigates to the listings flow from the share card', async () => {
     renderPage();
-    await userEvent.click(screen.getByRole('button', { name: /post a listing/i }));
+    await userEvent.click(screen.getByRole('button', { name: /share food/i }));
     await waitFor(() => {
       expect(screen.getByTestId('location')).toHaveTextContent('/share/listings');
     });

--- a/apps/grn/src/pages/ConnectPage.tsx
+++ b/apps/grn/src/pages/ConnectPage.tsx
@@ -18,9 +18,9 @@ const options: ConnectOption[] = [
   {
     id: 'share',
     emoji: '🧺',
-    title: 'Share your surplus',
-    body: 'Post what’s ready to give away so nearby neighbors can pick it up before it goes to waste.',
-    cta: 'Post a listing',
+    title: 'Food to share',
+    body: 'Share what is ready so a nearby neighbor can request a pickup before it goes to waste.',
+    cta: 'Share food',
     to: '/share/listings',
   },
   {
@@ -69,7 +69,7 @@ export function ConnectPage() {
     <section className="grn-section">
       <SectionHeading
         title="Share with people nearby"
-        body="Growing is better together. Share what you have, find what you need, and stay in touch with your local food community — all optional."
+        body="Share what you have, find what you need, and stay in touch with your local food community. It is always optional."
       />
       <div className="grn-connect-grid">
         {options.map((option) => (

--- a/apps/grn/src/pages/ListingsPage.tsx
+++ b/apps/grn/src/pages/ListingsPage.tsx
@@ -16,7 +16,7 @@ export function ListingsPage() {
   if (isLoading) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Market activity" title="Listings" />
+        <SectionHeading title="Food to share" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading…</p>
@@ -32,9 +32,8 @@ export function ListingsPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Market activity"
-        title="Listings"
-        body="Post what's ready to share and review listings you've already created."
+        title="Food to share"
+        body="Share extra food, respond to pickup requests, and see your completed neighbor pickups."
       />
       <GrowerListingPanel
         viewerUserId={profile.id}

--- a/apps/grn/src/pages/RequestsPage.tsx
+++ b/apps/grn/src/pages/RequestsPage.tsx
@@ -19,7 +19,7 @@ export function RequestsPage() {
   if (isLoading) {
     return (
       <section className="grn-section">
-        <SectionHeading eyebrow="Connect" title="Find food nearby" />
+        <SectionHeading title="Find food nearby" />
         <Panel className="grn-page-status">
           <PlantLoader size="md" />
           <p>Loading…</p>
@@ -42,9 +42,8 @@ export function RequestsPage() {
   return (
     <section className="grn-section">
       <SectionHeading
-        eyebrow="Connect"
         title="Find food nearby"
-        body="Search growers near you and coordinate pickup details."
+        body="See food available from nearby growers, request a pickup, and follow its status."
       />
       <FindFoodPanel
         viewerUserId={profile.id}

--- a/apps/grn/src/pages/todayActions.test.ts
+++ b/apps/grn/src/pages/todayActions.test.ts
@@ -106,6 +106,32 @@ describe('buildTodayActions', () => {
     expect(action.to).toBe('/share/find?claim=claim-1');
   });
 
+  it('offers an optional share action for a surplus-enabled crop', () => {
+    const [action] = buildTodayActions({
+      userId: 'grower-1',
+      now: new Date('2026-07-14T12:00:00Z'),
+      crops: [
+        crop({
+          id: 'crop-share',
+          cropName: 'Zucchini',
+          status: 'growing',
+          surplusEnabled: true,
+        }),
+      ],
+      cropsLoaded: true,
+      reminders: [],
+      claims: [],
+      signals: [],
+    });
+
+    expect(action).toMatchObject({
+      kind: 'share',
+      cta: 'Share food',
+      to: '/share/listings?crop=crop-share',
+    });
+    expect(action.body).toMatch(/you choose the amount and timing/i);
+  });
+
   it('returns one clear start action for an empty, loaded garden', () => {
     const actions = buildTodayActions({
       crops: [],

--- a/apps/grn/src/pages/todayActions.ts
+++ b/apps/grn/src/pages/todayActions.ts
@@ -130,6 +130,23 @@ export function buildTodayActions({
     }
   }
 
+  const surplusCrop = crops.find(
+    (crop) => crop.status === 'growing' && crop.surplusEnabled
+  );
+  if (surplusCrop) {
+    candidates.push({
+      id: `share:${surplusCrop.id}`,
+      kind: 'share',
+      label: 'Share',
+      title: `Share extra ${cropName(surplusCrop)}`,
+      body: 'You marked this crop for surplus sharing. You choose the amount and timing before anything is public.',
+      cta: 'Share food',
+      to: `/share/listings?crop=${encodeURIComponent(surplusCrop.id)}`,
+      destination: 'share',
+      priority: 45,
+    });
+  }
+
   const planningCrop = crops.find((crop) => crop.status === 'planning' || crop.status === 'interested');
   if (planningCrop) {
     candidates.push({

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -1093,9 +1093,13 @@ export async function getMyListing(listingId: string): Promise<Listing> {
   return mapListingItem(response);
 }
 
-export async function createListing(data: UpsertListingRequest): Promise<Listing> {
+export async function createListing(
+  data: UpsertListingRequest,
+  idempotencyKey = uuidv4()
+): Promise<Listing> {
   const response = await apiFetch<RawListingWriteResponse>('/listings', {
     method: 'POST',
+    headers: { 'Idempotency-Key': idempotencyKey },
     body: JSON.stringify(data),
   });
 

--- a/apps/grn/src/utils/todayActionTracking.ts
+++ b/apps/grn/src/utils/todayActionTracking.ts
@@ -4,6 +4,7 @@ export type TodayActionKind =
   | 'claim'
   | 'reminder'
   | 'harvest'
+  | 'share'
   | 'pickup'
   | 'plan'
   | 'local'


### PR DESCRIPTION
## Summary
- start an editable food-share draft from crops, saved harvests, Today, the garden map, or the Share destination
- require an explicit review and confirmation before publishing, with a stable idempotency key across retries
- combine grower offers, pickup requests, human-readable states, next actions, and private completion feedback in one Share hub
- align gatherer-facing discovery and pickup language without changing the existing listing/claim API contracts

## Validation
- `npm run lint -w @olivias/grn`
- `npm run test -w @olivias/grn` (574 tests)
- `npm run build -w @olivias/grn`
- `npm run perf:budget -w @olivias/grn`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (GRN API)
- `git diff --check`

`cargo fmt --all -- --check` reports the existing Windows newline-style mismatch across untouched Rust files. This PR does not modify Rust source or any API request/response contract; the existing Postman suites remain the deployed compatibility gate.

Closes #375