### PR TITLE
feat(grn): add private seasonal garden journal

### DIFF
--- a/apps/grn/src/components/Harvests/HarvestLogModal.test.tsx
+++ b/apps/grn/src/components/Harvests/HarvestLogModal.test.tsx
@@ -14,7 +14,10 @@ vi.mock('../../services/api', async (importOriginal) => {
   return { ...actual, listHarvests, recordHarvest, updateHarvest, deleteHarvest };
 });
 
-function renderModal(onShareHarvest?: Parameters<typeof HarvestLogModal>[0]['onShareHarvest']) {
+function renderModal(
+  onShareHarvest?: Parameters<typeof HarvestLogModal>[0]['onShareHarvest'],
+  highlightedHarvestId?: string
+) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
@@ -24,6 +27,7 @@ function renderModal(onShareHarvest?: Parameters<typeof HarvestLogModal>[0]['onS
         defaultUnit="lb"
         onClose={() => {}}
         onShareHarvest={onShareHarvest}
+        highlightedHarvestId={highlightedHarvestId}
       />
     </QueryClientProvider>
   );
@@ -54,6 +58,13 @@ describe('HarvestLogModal', () => {
     renderModal();
     expect(await screen.findByText(/3.5 lb brought in across 1 harvest/i)).toBeInTheDocument();
     expect(screen.getByText(/first picking/i)).toBeInTheDocument();
+  });
+
+  it('focuses the exact harvest linked from the journal', async () => {
+    renderModal(undefined, 'h1');
+    const row = (await screen.findByText(/first picking/i)).closest('li');
+    expect(row).toHaveAttribute('aria-current', 'true');
+    await waitFor(() => expect(row).toHaveFocus());
   });
 
   it('logs a new harvest', async () => {

--- a/apps/grn/src/components/Harvests/HarvestLogModal.tsx
+++ b/apps/grn/src/components/Harvests/HarvestLogModal.tsx
@@ -16,6 +16,7 @@ interface HarvestLogModalProps {
   defaultUnit?: string | null;
   onClose: () => void;
   onShareHarvest?: (harvest: HarvestItem) => void;
+  highlightedHarvestId?: string | null;
 }
 
 function todayIsoDate(): string {
@@ -42,6 +43,7 @@ export function HarvestLogModal({
   defaultUnit,
   onClose,
   onShareHarvest,
+  highlightedHarvestId,
 }: HarvestLogModalProps) {
   const queryClient = useQueryClient();
   const [amount, setAmount] = useState('');
@@ -154,6 +156,13 @@ export function HarvestLogModal({
   const log = logQuery.data;
   const harvests = log?.harvests ?? [];
 
+  useEffect(() => {
+    if (!highlightedHarvestId || harvests.length === 0) return;
+    const row = document.getElementById(`harvest-${highlightedHarvestId}`);
+    row?.focus();
+    row?.scrollIntoView?.({ block: 'center' });
+  }, [highlightedHarvestId, harvests.length]);
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -263,7 +272,17 @@ export function HarvestLogModal({
 
           <ul className="space-y-2">
             {harvests.map((harvest) => (
-              <li key={harvest.id} className="rounded-md border border-gray-200 px-3 py-2">
+              <li
+                key={harvest.id}
+                id={`harvest-${harvest.id}`}
+                tabIndex={-1}
+                aria-current={highlightedHarvestId === harvest.id ? 'true' : undefined}
+                className={`rounded-md border px-3 py-2 ${
+                  highlightedHarvestId === harvest.id
+                    ? 'border-primary-500 bg-primary-50'
+                    : 'border-gray-200'
+                }`}
+              >
                 {editingId === harvest.id && editState ? (
                   <div className="grid gap-2 sm:grid-cols-2">
                     <input

--- a/apps/grn/src/components/Journal/GardenJournalPanel.test.tsx
+++ b/apps/grn/src/components/Journal/GardenJournalPanel.test.tsx
@@ -1,0 +1,128 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GardenJournalPanel } from './GardenJournalPanel';
+
+const getGardenJournal = vi.hoisted(() => vi.fn());
+const createJournalNote = vi.hoisted(() => vi.fn());
+const deleteJournalNote = vi.hoisted(() => vi.fn());
+const requestJournalPhotoUpload = vi.hoisted(() => vi.fn());
+const uploadJournalPhoto = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/api')>();
+  return {
+    ...actual,
+    getGardenJournal,
+    createJournalNote,
+    deleteJournalNote,
+    requestJournalPhotoUpload,
+    uploadJournalPhoto,
+  };
+});
+
+const summary = {
+  season: 2026,
+  plantedCount: 2,
+  harvestCount: 1,
+  reminderCompletionCount: 3,
+  completedShareCount: 1,
+  foodSharedBeforeExpiryCount: 1,
+  activeMonthCount: 4,
+  explanation: 'Built from the garden activity you recorded.',
+  explanationSource: 'recorded_facts' as const,
+  isAiGenerated: false as const,
+};
+
+function renderPanel(path = '/garden/journal?season=2026') {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <GardenJournalPanel />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('GardenJournalPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+  });
+
+  it('shows a private factual summary and source-linked timeline', async () => {
+    getGardenJournal.mockResolvedValue({
+      season: 2026,
+      summary,
+      entries: [{
+        id: 'harvest:h1', kind: 'harvest', occurredAt: '2026-07-12',
+        title: 'Harvested tomatoes', detail: 'A harvest record was saved.',
+        sourceType: 'harvest', sourceId: 'h1',
+        sourcePath: '/garden/plants?crop=c1&action=harvest&harvest=h1',
+        isPrivate: true, manual: false, photoUrl: null,
+      }],
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText('Harvested tomatoes')).toBeInTheDocument();
+    expect(screen.getByText(/not a score, ranking, or AI estimate/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open source/i })).toHaveAttribute(
+      'href', '/garden/plants?crop=c1&action=harvest&harvest=h1'
+    );
+  });
+
+  it('gives a first-season path when no activity exists', async () => {
+    getGardenJournal.mockResolvedValue({ season: 2026, summary: { ...summary, plantedCount: 0 }, entries: [] });
+
+    renderPanel();
+
+    expect(await screen.findByText(/your first season entry starts here/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add a plant/i })).toBeInTheDocument();
+  });
+
+  it('moves between seasons and loads the selected year', async () => {
+    getGardenJournal.mockImplementation(async (season: number) => ({
+      season,
+      summary: { ...summary, season },
+      entries: [],
+    }));
+    renderPanel();
+    expect(await screen.findByRole('heading', { name: '2026 season' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /previous year/i }));
+
+    expect(await screen.findByRole('heading', { name: '2025 season' })).toBeInTheDocument();
+    await waitFor(() => expect(getGardenJournal).toHaveBeenCalledWith(2025));
+  });
+
+  it('saves a private note with an idempotency key', async () => {
+    getGardenJournal.mockResolvedValue({ season: 2026, summary, entries: [] });
+    createJournalNote.mockResolvedValue({
+      id: 'note:n1', kind: 'note', occurredAt: '2026-07-14', title: 'Ladybugs arrived',
+      detail: null, sourceType: 'note', sourceId: 'n1', sourcePath: null,
+      isPrivate: true, manual: true, photoUrl: null,
+    });
+    renderPanel();
+    await screen.findByText(/your first season entry starts here/i);
+
+    await userEvent.type(screen.getByLabelText(/^title$/i), 'Ladybugs arrived');
+    await userEvent.click(screen.getByRole('button', { name: /save private note/i }));
+
+    await waitFor(() => expect(createJournalNote).toHaveBeenCalledTimes(1));
+    expect(createJournalNote.mock.calls[0][0]).toMatchObject({ title: 'Ladybugs arrived' });
+    expect(createJournalNote.mock.calls[0][1]).toEqual(expect.any(String));
+  });
+
+  it('keeps cached journal reading available while offline and disables writes', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    getGardenJournal.mockResolvedValue({ season: 2026, summary, entries: [] });
+    renderPanel();
+
+    expect(await screen.findByText(/latest season loaded in this session/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save private note/i })).toBeDisabled();
+  });
+});

--- a/apps/grn/src/components/Journal/GardenJournalPanel.tsx
+++ b/apps/grn/src/components/Journal/GardenJournalPanel.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+import { Button, Card, Panel } from '@olivias/ui';
+import { PlantLoader } from '../branding/PlantLoader';
+import {
+  createJournalNote,
+  deleteJournalNote,
+  getGardenJournal,
+  requestJournalPhotoUpload,
+  uploadJournalPhoto,
+  type CreateJournalNoteRequest,
+  type JournalEntry,
+} from '../../services/api';
+
+const CURRENT_YEAR = new Date().getFullYear();
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+const PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const KIND_LABELS: Record<JournalEntry['kind'], string> = {
+  planned: 'Planned',
+  planted: 'Planted',
+  garden: 'Garden',
+  harvest: 'Harvest',
+  reminder: 'Tended',
+  share: 'Shared',
+  note: 'Private note',
+};
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function readSeason(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 2000 && parsed <= CURRENT_YEAR
+    ? parsed
+    : CURRENT_YEAR;
+}
+
+function formatEntryDate(value: string): string {
+  const dateOnly = value.length === 10 ? `${value}T12:00:00Z` : value;
+  const parsed = new Date(dateOnly);
+  return Number.isNaN(parsed.getTime())
+    ? value
+    : parsed.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() => navigator.onLine);
+  useEffect(() => {
+    const online = () => setIsOnline(true);
+    const offline = () => setIsOnline(false);
+    window.addEventListener('online', online);
+    window.addEventListener('offline', offline);
+    return () => {
+      window.removeEventListener('online', online);
+      window.removeEventListener('offline', offline);
+    };
+  }, []);
+  return isOnline;
+}
+
+export function GardenJournalPanel() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [season, setSeason] = useState(() => readSeason(searchParams.get('season')));
+  const [occurredOn, setOccurredOn] = useState(todayIsoDate);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [photo, setPhoto] = useState<File | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const idempotencyKey = useRef(uuidv4());
+  const uploadedPhotoKey = useRef<string | null>(null);
+  const isOnline = useOnlineStatus();
+
+  const journalQuery = useQuery({
+    queryKey: ['gardenJournal', season],
+    queryFn: () => getGardenJournal(season),
+    staleTime: 60_000,
+    networkMode: 'offlineFirst',
+  });
+
+  const noteMutation = useMutation({
+    mutationFn: async (payload: CreateJournalNoteRequest) => {
+      let photoKey: string | undefined;
+      if (photo) {
+        if (!uploadedPhotoKey.current) {
+          const intent = await requestJournalPhotoUpload(photo);
+          await uploadJournalPhoto(intent, photo);
+          uploadedPhotoKey.current = intent.photoKey;
+        }
+        photoKey = uploadedPhotoKey.current;
+      }
+      return createJournalNote({ ...payload, photoKey }, idempotencyKey.current);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['gardenJournal'] });
+      setTitle('');
+      setBody('');
+      setPhoto(null);
+      setOccurredOn(todayIsoDate());
+      setFormError(null);
+      idempotencyKey.current = uuidv4();
+      uploadedPhotoKey.current = null;
+    },
+    onError: (error) => {
+      setFormError(error instanceof Error ? error.message : 'Could not save that note.');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteJournalNote,
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['gardenJournal'] }),
+  });
+
+  const changeSeason = (nextSeason: number) => {
+    setSeason(nextSeason);
+    const next = new URLSearchParams(searchParams);
+    next.set('season', String(nextSeason));
+    setSearchParams(next, { replace: true });
+  };
+
+  useEffect(() => {
+    setSeason(readSeason(searchParams.get('season')));
+  }, [searchParams]);
+
+  const saveNote = () => {
+    if (!title.trim()) {
+      setFormError('Give this note a short title.');
+      return;
+    }
+    if (!isOnline) {
+      setFormError('Reconnect before saving a private note or photo.');
+      return;
+    }
+    if (photo && (!PHOTO_TYPES.includes(photo.type) || photo.size > MAX_PHOTO_BYTES)) {
+      setFormError('Choose a JPEG, PNG, or WebP photo no larger than 5 MB.');
+      return;
+    }
+    setFormError(null);
+    noteMutation.mutate({
+      occurredOn,
+      title: title.trim(),
+      body: body.trim() || undefined,
+    });
+  };
+
+  const removeNote = (entry: JournalEntry) => {
+    if (!isOnline) return;
+    if (!window.confirm(`Delete “${entry.title}”?`)) return;
+    deleteMutation.mutate(entry.sourceId);
+  };
+
+  if (journalQuery.isLoading && !journalQuery.data) {
+    return (
+      <Panel className="grn-page-status">
+        <PlantLoader size="md" />
+        <p>Gathering your {season} season…</p>
+      </Panel>
+    );
+  }
+
+  if (journalQuery.isError && !journalQuery.data) {
+    return (
+      <Panel className="grn-page-status">
+        <p className="grn-page-status__error">
+          {isOnline
+            ? 'Your garden journal could not be loaded right now.'
+            : 'Reconnect to load this season for the first time.'}
+        </p>
+        <Button variant="secondary" onClick={() => void journalQuery.refetch()} disabled={!isOnline}>
+          Try again
+        </Button>
+      </Panel>
+    );
+  }
+
+  const journal = journalQuery.data;
+  if (!journal) return null;
+
+  return (
+    <div className="grn-journal">
+      <div className="grn-journal__season" aria-label="Choose journal season">
+        <Button variant="secondary" onClick={() => changeSeason(season - 1)} disabled={season <= 2000}>
+          Previous year
+        </Button>
+        <h2>{season} season</h2>
+        <Button
+          variant="secondary"
+          onClick={() => changeSeason(season + 1)}
+          disabled={season >= CURRENT_YEAR}
+        >
+          Next year
+        </Button>
+      </div>
+
+      {!isOnline ? (
+        <p className="grn-journal__offline" role="status">
+          You are viewing the latest season loaded in this session. Notes and photos are read-only
+          until you reconnect.
+        </p>
+      ) : null}
+
+      <Card className="grn-journal__summary">
+        <div>
+          <h2>Your season, in recorded facts</h2>
+          <p>{journal.summary.explanation}</p>
+        </div>
+        <dl>
+          <div><dt>Plantings</dt><dd>{journal.summary.plantedCount}</dd></div>
+          <div><dt>Harvest days</dt><dd>{journal.summary.harvestCount}</dd></div>
+          <div><dt>Care tasks completed</dt><dd>{journal.summary.reminderCompletionCount}</dd></div>
+          <div><dt>Food handoffs</dt><dd>{journal.summary.completedShareCount}</dd></div>
+          <div><dt>Shared before expiry</dt><dd>{journal.summary.foodSharedBeforeExpiryCount}</dd></div>
+          <div><dt>Active months</dt><dd>{journal.summary.activeMonthCount}</dd></div>
+        </dl>
+        <p className="grn-journal__privacy">
+          Private to you. This summary comes from your saved garden activity—not a score, ranking,
+          or AI estimate.
+        </p>
+      </Card>
+
+      <Card className="grn-journal__note-form">
+        <div>
+          <h2>Add a private moment</h2>
+          <p>Capture what the records cannot: a lesson, observation, or photo from the garden.</p>
+        </div>
+        <div className="grn-journal__form-grid">
+          <label>
+            <span>Date</span>
+            <input type="date" value={occurredOn} onChange={(event) => setOccurredOn(event.target.value)} />
+          </label>
+          <label>
+            <span>Title</span>
+            <input value={title} maxLength={120} onChange={(event) => setTitle(event.target.value)} placeholder="What happened?" />
+          </label>
+          <label className="grn-journal__wide">
+            <span>Note (optional)</span>
+            <textarea value={body} maxLength={2000} onChange={(event) => setBody(event.target.value)} rows={3} />
+          </label>
+          <label className="grn-journal__wide">
+            <span>Photo (optional, JPEG, PNG, or WebP up to 5 MB)</span>
+            <input
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              onChange={(event) => {
+                setPhoto(event.target.files?.[0] ?? null);
+                uploadedPhotoKey.current = null;
+              }}
+            />
+          </label>
+        </div>
+        {formError ? <p className="grn-page-status__error" role="alert">{formError}</p> : null}
+        <Button variant="primary" onClick={saveNote} disabled={!isOnline || noteMutation.isPending}>
+          {noteMutation.isPending ? 'Saving…' : 'Save private note'}
+        </Button>
+      </Card>
+
+      <section className="grn-journal__timeline" aria-labelledby="journal-timeline-title">
+        <h2 id="journal-timeline-title">Season timeline</h2>
+        {journal.entries.length === 0 ? (
+          <Panel className="grn-journal__empty">
+            <h3>Your first season entry starts here.</h3>
+            <p>Plant something, create a garden bed, or save a private note to begin the story.</p>
+            <div>
+              <Button variant="primary" onClick={() => navigate('/garden/plants/new')}>Add a plant</Button>
+              <Button variant="secondary" onClick={() => navigate('/garden')}>Open garden map</Button>
+            </div>
+          </Panel>
+        ) : (
+          <ol>
+            {journal.entries.map((entry) => (
+              <li key={entry.id}>
+                <article className="grn-journal-entry">
+                  <div className="grn-journal-entry__meta">
+                    <span>{KIND_LABELS[entry.kind] ?? 'Garden'}</span>
+                    <time dateTime={entry.occurredAt}>{formatEntryDate(entry.occurredAt)}</time>
+                    {entry.isPrivate ? <span>Private</span> : null}
+                  </div>
+                  <h3>{entry.title}</h3>
+                  {entry.detail ? <p>{entry.detail}</p> : null}
+                  {entry.photoUrl ? <img src={entry.photoUrl} alt={`Garden journal: ${entry.title}`} loading="lazy" /> : null}
+                  <div className="grn-journal-entry__actions">
+                    {entry.sourcePath ? <Link to={entry.sourcePath}>Open source</Link> : null}
+                    {entry.manual ? (
+                      <Button variant="ghost" size="sm" onClick={() => removeNote(entry)} disabled={!isOnline || deleteMutation.isPending}>
+                        Delete note
+                      </Button>
+                    ) : null}
+                  </div>
+                </article>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default GardenJournalPanel;

--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -14,8 +14,10 @@ vi.mock('../../services/api', () => ({
 }));
 
 vi.mock('../Harvests/HarvestLogModal', () => ({
-  HarvestLogModal: ({ cropName }: { cropName: string }) => (
-    <div role="dialog" aria-label={`Harvest ${cropName}`}>Harvest {cropName}</div>
+  HarvestLogModal: ({ cropName, highlightedHarvestId }: { cropName: string; highlightedHarvestId?: string }) => (
+    <div role="dialog" aria-label={`Harvest ${cropName}`} data-highlighted-harvest={highlightedHarvestId}>
+      Harvest {cropName}
+    </div>
   ),
 }));
 
@@ -62,6 +64,28 @@ describe('CropLibraryPanel deep links', () => {
     );
 
     expect(await screen.findByRole('dialog', { name: 'Harvest Cherry tomatoes' })).toBeInTheDocument();
+  });
+
+  it('passes an exact harvest deep link into the harvest log', async () => {
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(listMyCrops).mockResolvedValue([{
+      id: 'crop-1', userId: 'grower-1', canonicalId: null, cropName: 'Tomato', varietyId: null,
+      status: 'growing', visibility: 'private', surplusEnabled: false, nickname: null,
+      defaultUnit: 'lb', notes: null, bedId: null, bedName: null, plantingDate: null,
+      expectedHarvestDate: null, plantCount: null, spacingInches: null, pyramidTier: null,
+      createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-01T00:00:00Z',
+    }]);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/garden/plants?crop=crop-1&action=harvest&harvest=h1']}>
+          <CropLibraryPanel viewerUserId="grower-1" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByRole('dialog')).toHaveAttribute('data-highlighted-harvest', 'h1');
   });
 
   it('changes a crop bed optimistically through the shared crop query', async () => {

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -52,6 +52,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
 
   const linkedCropId = searchParams.get('crop');
   const linkedAction = searchParams.get('action');
+  const linkedHarvestId = searchParams.get('harvest');
 
   const linkedHarvestCrop = useMemo(() => {
     if (linkedAction !== 'harvest' || !linkedCropId || !myCrops) return null;
@@ -368,6 +369,7 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
           cropId={activeHarvestCrop.id}
           cropName={activeHarvestCrop.nickname || activeHarvestCrop.cropName}
           defaultUnit={activeHarvestCrop.defaultUnit}
+          highlightedHarvestId={linkedHarvestId}
           onShareHarvest={(harvest) => openShareDraft(activeHarvestCrop, harvest)}
           onClose={() => {
             setHarvestCrop(null);

--- a/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { ReminderPanel } from './ReminderPanel';
-import { listReminders } from '../../services/api';
+import { listReminders, updateReminderStatus } from '../../services/api';
 
 vi.mock('../../services/api', () => ({
   createReminder: vi.fn(),
@@ -67,5 +68,35 @@ describe('ReminderPanel deep links', () => {
     const reminderRow = reminder.closest('li');
     expect(reminderRow).toHaveAttribute('aria-current', 'true');
     await waitFor(() => expect(document.activeElement).toBe(reminderRow));
+  });
+
+  it('records a real completion when the grower chooses done today', async () => {
+    vi.mocked(listReminders).mockResolvedValue({
+      items: [{
+        id: 'reminder-1', title: 'Water the raised beds', reminderType: 'watering',
+        cadenceDays: 1, startDate: '2026-07-14', timezone: 'UTC', status: 'active',
+        nextRunAt: '2026-07-14T09:00:00Z', lastRunAt: null, createdAt: '2026-07-01T00:00:00Z',
+      }],
+    });
+    vi.mocked(updateReminderStatus).mockResolvedValue({
+      id: 'reminder-1', title: 'Water the raised beds', reminderType: 'watering',
+      cadenceDays: 1, startDate: '2026-07-14', timezone: 'UTC', status: 'active',
+      nextRunAt: '2026-07-15T09:00:00Z', lastRunAt: '2026-07-14T09:00:00Z',
+      createdAt: '2026-07-01T00:00:00Z',
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter><ReminderPanel /></MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /done today/i }));
+    await waitFor(() =>
+      expect(updateReminderStatus).toHaveBeenCalledWith(
+        'reminder-1', 'completed', expect.any(String)
+      )
+    );
   });
 });

--- a/apps/grn/src/components/Reminders/ReminderPanel.tsx
+++ b/apps/grn/src/components/Reminders/ReminderPanel.tsx
@@ -8,6 +8,7 @@ import {
   updateReminderStatus,
 } from '../../services/api';
 import { Button } from '@olivias/ui';
+import { v4 as uuidv4 } from 'uuid';
 import { completeTodayAction } from '../../utils/todayActionTracking';
 
 const REMINDER_TYPES: Array<{ value: ReminderType; label: string }> = [
@@ -35,6 +36,7 @@ export function ReminderPanel() {
   const requestedTitle = searchParams.get('title')?.trim() ?? '';
   const requestedType = reminderTypeFromQuery(searchParams.get('type'));
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const completionKeys = useRef(new Map<string, string>());
   const [title, setTitle] = useState(() =>
     requestedNewReminder ? requestedTitle : ''
   );
@@ -67,11 +69,17 @@ export function ReminderPanel() {
   });
 
   const statusMutation = useMutation({
-    mutationFn: ({ reminderId, status }: { reminderId: string; status: 'active' | 'paused' }) =>
-      updateReminderStatus(reminderId, status),
-    onSuccess: () => {
+    mutationFn: ({ reminderId, status, idempotencyKey }: {
+      reminderId: string;
+      status: 'active' | 'paused' | 'completed';
+      idempotencyKey?: string;
+    }) => updateReminderStatus(reminderId, status, idempotencyKey),
+    onSuccess: (_reminder, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['reminders'] });
-      completeTodayAction('reminder');
+      if (variables.status === 'completed') {
+        completionKeys.current.delete(variables.reminderId);
+        completeTodayAction('reminder');
+      }
     },
   });
 
@@ -209,18 +217,33 @@ export function ReminderPanel() {
                     {new Date(reminder.nextRunAt).toLocaleString()}
                   </p>
                 </div>
-                <Button
-                  variant={isPaused ? 'primary' : 'secondary'}
-                  onClick={() =>
-                    statusMutation.mutate({
-                      reminderId: reminder.id,
-                      status: isPaused ? 'active' : 'paused',
-                    })
-                  }
-                  disabled={statusMutation.isPending}
-                >
-                  {isPaused ? 'Resume' : 'Pause'}
-                </Button>
+                <div className="flex flex-wrap justify-end gap-2">
+                  {!isPaused ? (
+                    <Button
+                      variant="primary"
+                      onClick={() => {
+                        const idempotencyKey = completionKeys.current.get(reminder.id) ?? uuidv4();
+                        completionKeys.current.set(reminder.id, idempotencyKey);
+                        statusMutation.mutate({ reminderId: reminder.id, status: 'completed', idempotencyKey });
+                      }}
+                      disabled={statusMutation.isPending}
+                    >
+                      Done today
+                    </Button>
+                  ) : null}
+                  <Button
+                    variant={isPaused ? 'primary' : 'secondary'}
+                    onClick={() =>
+                      statusMutation.mutate({
+                        reminderId: reminder.id,
+                        status: isPaused ? 'active' : 'paused',
+                      })
+                    }
+                    disabled={statusMutation.isPending}
+                  >
+                    {isPaused ? 'Resume' : 'Pause'}
+                  </Button>
+                </div>
               </li>
             );
           })}

--- a/apps/grn/src/pages/GardenJournalPage.tsx
+++ b/apps/grn/src/pages/GardenJournalPage.tsx
@@ -1,0 +1,16 @@
+import { SectionHeading } from '@olivias/ui';
+import { GardenJournalPanel } from '../components/Journal/GardenJournalPanel';
+
+export function GardenJournalPage() {
+  return (
+    <section className="grn-section">
+      <SectionHeading
+        title="Garden journal"
+        body="Look back on what you planted, tended, harvested, and shared—plus the private moments you chose to save."
+      />
+      <GardenJournalPanel />
+    </section>
+  );
+}
+
+export default GardenJournalPage;

--- a/apps/grn/src/pages/GardenWorkspacePage.test.tsx
+++ b/apps/grn/src/pages/GardenWorkspacePage.test.tsx
@@ -17,6 +17,7 @@ function renderWorkspace(initialEntry = '/garden') {
           <Route index element={<h2>Map view</h2>} />
           <Route path="plants" element={<h2>Plants view</h2>} />
           <Route path="plan" element={<h2>Plan view</h2>} />
+          <Route path="journal" element={<h2>Journal view</h2>} />
         </Route>
       </Routes>
       <LocationDisplay />
@@ -57,6 +58,15 @@ describe('GardenWorkspacePage', () => {
 
     expect(screen.getByRole('heading', { name: 'Plants view' })).toBeInTheDocument();
     expect(plantsLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('keeps the journal inside the shared garden workspace', async () => {
+    renderWorkspace('/garden?season=2026');
+
+    await userEvent.click(screen.getByRole('link', { name: /journal/i }));
+
+    expect(screen.getByRole('heading', { name: 'Journal view' })).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/garden/journal?season=2026');
   });
 
   it('announces offline garden behavior and clears it after reconnecting', () => {

--- a/apps/grn/src/pages/GardenWorkspacePage.tsx
+++ b/apps/grn/src/pages/GardenWorkspacePage.tsx
@@ -23,6 +23,13 @@ const GARDEN_VIEWS = [
     description: 'Balance the garden pyramid and planting ideas.',
     end: false,
   },
+  {
+    id: 'journal',
+    label: 'Journal',
+    path: '/garden/journal',
+    description: 'Remember what you planted, tended, harvested, and shared.',
+    end: false,
+  },
 ] as const;
 
 function readOnlineStatus(): boolean {

--- a/apps/grn/src/services/api.ts
+++ b/apps/grn/src/services/api.ts
@@ -929,6 +929,63 @@ export interface BackgroundUploadIntent {
   expiresInSeconds: number;
 }
 
+export type JournalEntryKind =
+  | 'planned'
+  | 'planted'
+  | 'garden'
+  | 'harvest'
+  | 'reminder'
+  | 'share'
+  | 'note';
+
+export interface JournalEntry {
+  id: string;
+  kind: JournalEntryKind;
+  occurredAt: string;
+  title: string;
+  detail: string | null;
+  sourceType: string;
+  sourceId: string;
+  sourcePath: string | null;
+  isPrivate: boolean;
+  manual: boolean;
+  photoUrl: string | null;
+}
+
+export interface JournalSummary {
+  season: number;
+  plantedCount: number;
+  harvestCount: number;
+  reminderCompletionCount: number;
+  completedShareCount: number;
+  foodSharedBeforeExpiryCount: number;
+  activeMonthCount: number;
+  explanation: string;
+  explanationSource: 'recorded_facts';
+  isAiGenerated: false;
+}
+
+export interface JournalResponse {
+  season: number;
+  entries: JournalEntry[];
+  summary: JournalSummary;
+}
+
+export interface CreateJournalNoteRequest {
+  occurredOn: string;
+  title: string;
+  body?: string;
+  photoKey?: string;
+}
+
+export interface JournalPhotoUploadIntent {
+  uploadUrl: string;
+  method: 'PUT';
+  headers: Record<string, string>;
+  photoKey: string;
+  expiresInSeconds: number;
+}
+
 // --- AI garden review -------------------------------------------------------
 
 export interface GardenReviewInsight {
@@ -1064,6 +1121,48 @@ export async function requestBackgroundUploadUrl(
     s3Key: response.s3_key,
     expiresInSeconds: response.expires_in_seconds,
   };
+}
+
+export async function getGardenJournal(season: number): Promise<JournalResponse> {
+  return apiFetch<JournalResponse>(`/journal?season=${encodeURIComponent(String(season))}`);
+}
+
+export async function createJournalNote(
+  payload: CreateJournalNoteRequest,
+  idempotencyKey = uuidv4()
+): Promise<JournalEntry> {
+  return apiFetch<JournalEntry>('/journal/notes', {
+    method: 'POST',
+    headers: { 'Idempotency-Key': idempotencyKey },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteJournalNote(noteId: string): Promise<void> {
+  await apiFetch(`/journal/notes/${encodeURIComponent(noteId)}`, { method: 'DELETE' });
+}
+
+export async function requestJournalPhotoUpload(
+  file: File
+): Promise<JournalPhotoUploadIntent> {
+  return apiFetch<JournalPhotoUploadIntent>('/journal/photo-upload-url', {
+    method: 'POST',
+    body: JSON.stringify({ contentType: file.type, contentLength: file.size }),
+  });
+}
+
+export async function uploadJournalPhoto(
+  intent: JournalPhotoUploadIntent,
+  file: File
+): Promise<void> {
+  const response = await fetch(intent.uploadUrl, {
+    method: intent.method,
+    headers: intent.headers,
+    body: file,
+  });
+  if (!response.ok) {
+    throw new ApiError('Could not upload that photo. Please try again.', response.status);
+  }
 }
 
 export async function listMyListings(
@@ -1261,10 +1360,16 @@ export async function createReminder(payload: CreateReminderRequest): Promise<Re
 
 export async function updateReminderStatus(
   reminderId: string,
-  status: 'active' | 'paused'
+  status: 'active' | 'paused' | 'completed',
+  idempotencyKey?: string
 ): Promise<ReminderItem> {
+  const headers: Record<string, string> = {};
+  if (status === 'completed') {
+    headers['Idempotency-Key'] = idempotencyKey ?? uuidv4();
+  }
   return apiFetch<ReminderItem>(`/reminders/${encodeURIComponent(reminderId)}`, {
     method: 'PUT',
+    headers,
     body: JSON.stringify({ status }),
   });
 }

--- a/apps/grn/src/shell/AuthenticatedRoot.test.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.test.tsx
@@ -38,6 +38,9 @@ vi.mock('../pages/RecommendationsPage', () => ({
 vi.mock('../pages/GardenDesignerPage', () => ({
   GardenDesignerPage: () => <h1>Garden map page</h1>,
 }));
+vi.mock('../pages/GardenJournalPage', () => ({
+  GardenJournalPage: () => <h1>Garden journal page</h1>,
+}));
 vi.mock('../pages/GardenWorkspacePage', async () => {
   const { Outlet } = await import('react-router-dom');
   return { GardenWorkspacePage: () => <><span>Garden workspace</span><Outlet /></> };
@@ -76,6 +79,7 @@ describe('AuthenticatedRoot routes', () => {
     ['/garden/plants/new', 'New plant page'],
     ['/garden/plan', 'Plan page'],
     ['/garden/plan/recommendations', 'Recommendations page'],
+    ['/garden/journal', 'Garden journal page'],
     ['/share', 'Share page'],
     ['/share/listings', 'Listings page'],
     ['/share/find', 'Find food page'],

--- a/apps/grn/src/shell/AuthenticatedRoot.tsx
+++ b/apps/grn/src/shell/AuthenticatedRoot.tsx
@@ -28,6 +28,9 @@ const GardenDesignerPage = lazy(() =>
 const GardenWorkspacePage = lazy(() =>
   import('../pages/GardenWorkspacePage').then((m) => ({ default: m.GardenWorkspacePage }))
 );
+const GardenJournalPage = lazy(() =>
+  import('../pages/GardenJournalPage').then((m) => ({ default: m.GardenJournalPage }))
+);
 const ListingsPage = lazy(() =>
   import('../pages/ListingsPage').then((m) => ({ default: m.ListingsPage }))
 );
@@ -79,6 +82,7 @@ export function AuthenticatedRoot() {
                 <Route path="plants/new" element={<NewCropPage />} />
                 <Route path="plan" element={<PlannerPage />} />
                 <Route path="plan/recommendations" element={<RecommendationsPage />} />
+                <Route path="journal" element={<GardenJournalPage />} />
               </Route>
               <Route path="/share" element={<ConnectPage />} />
               <Route path="/share/listings" element={<ListingsPage />} />

--- a/apps/grn/src/styles.css
+++ b/apps/grn/src/styles.css
@@ -336,7 +336,7 @@ body {
   gap: 1.25rem;
 }
 
-/* One garden, three related views. The shell stays deliberately compact so
+/* One garden, four related views. The shell stays deliberately compact so
    the illustrated map remains the visual home instead of competing with a
    second page hero. */
 .grn-garden-workspace {
@@ -363,7 +363,7 @@ body {
 
 .grn-garden-views {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.5rem;
   padding: 0.4rem;
   border: 1px solid rgba(79, 56, 37, 0.12);
@@ -423,6 +423,188 @@ body {
   min-width: 0;
 }
 
+.grn-journal {
+  display: grid;
+  gap: 1rem;
+}
+
+.grn-journal__season {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.grn-journal__season h2 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  font-size: 1.15rem;
+  letter-spacing: normal;
+  text-align: center;
+}
+
+.grn-journal__offline,
+.grn-journal__privacy {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.75);
+  font-size: 0.88rem;
+}
+
+.grn-journal__offline {
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(176, 106, 60, 0.35);
+  border-radius: var(--og-radius-md);
+  background: rgba(255, 244, 224, 0.82);
+}
+
+.grn-journal__summary,
+.grn-journal__note-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.grn-journal__summary h2,
+.grn-journal__note-form h2,
+.grn-journal__timeline > h2 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  font-size: 1.2rem;
+  letter-spacing: normal;
+}
+
+.grn-journal__summary p,
+.grn-journal__note-form p {
+  margin: 0.3rem 0 0;
+}
+
+.grn-journal__summary dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.grn-journal__summary dl > div {
+  padding: 0.7rem;
+  border-radius: var(--og-radius-md);
+  background: rgba(66, 107, 63, 0.07);
+}
+
+.grn-journal__summary dt {
+  color: rgba(79, 56, 37, 0.7);
+  font-size: 0.78rem;
+}
+
+.grn-journal__summary dd {
+  margin: 0.2rem 0 0;
+  color: var(--og-color-moss);
+  font-family: var(--og-font-display);
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.grn-journal__form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.grn-journal__form-grid label {
+  display: grid;
+  gap: 0.3rem;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.85rem;
+}
+
+.grn-journal__form-grid input,
+.grn-journal__form-grid textarea {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(79, 56, 37, 0.22);
+  border-radius: var(--og-radius-md);
+  color: var(--og-color-soil);
+  background: var(--og-color-paper);
+}
+
+.grn-journal__wide {
+  grid-column: 1 / -1;
+}
+
+.grn-journal__timeline {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.grn-journal__timeline ol {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grn-journal-entry {
+  display: grid;
+  gap: 0.55rem;
+  padding: 1rem;
+  border: 1px solid rgba(79, 56, 37, 0.14);
+  border-left: 4px solid var(--og-color-moss);
+  border-radius: var(--og-radius-md);
+  background: var(--og-color-paper);
+}
+
+.grn-journal-entry__meta,
+.grn-journal-entry__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  color: rgba(79, 56, 37, 0.68);
+  font-size: 0.78rem;
+}
+
+.grn-journal-entry h3,
+.grn-journal-entry p {
+  margin: 0;
+}
+
+.grn-journal-entry h3 {
+  color: var(--og-color-soil);
+  font-family: var(--og-font-display);
+  letter-spacing: normal;
+}
+
+.grn-journal-entry img {
+  max-width: min(100%, 32rem);
+  max-height: 24rem;
+  border-radius: var(--og-radius-md);
+  object-fit: cover;
+}
+
+.grn-journal-entry__actions {
+  justify-content: space-between;
+}
+
+.grn-journal__empty {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.grn-journal__empty h3,
+.grn-journal__empty p {
+  margin: 0;
+}
+
+.grn-journal__empty > div {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 @media (max-width: 640px) {
   .grn-garden-workspace {
     gap: 0.75rem;
@@ -446,6 +628,24 @@ body {
 
   .grn-garden-views__description {
     display: none;
+  }
+
+  .grn-journal__season {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .grn-journal__season h2 {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .grn-journal__summary dl,
+  .grn-journal__form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .grn-journal__wide {
+    grid-column: auto;
   }
 }
 

--- a/postman/collections/Good Roots Network API/Garden Journal/.resources/definition.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/.resources/definition.yaml
@@ -1,0 +1,4 @@
+$kind: collection
+name: Garden Journal
+description: Private, deterministic seasonal journal projection and grower-authored notes.
+order: 8500

--- a/postman/collections/Good Roots Network API/Garden Journal/1 - List Season.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/1 - List Season.request.yaml
@@ -1,0 +1,35 @@
+$kind: http-request
+name: List Garden Journal Season
+description: List the authenticated grower's deterministic private journal for one season.
+method: GET
+url: '{{baseUrl}}/journal?season=2026'
+order: 1000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Journal is factual, private, and source-linked", function () {
+          const journal = pm.response.json();
+          pm.expect(journal).to.have.property("season", 2026);
+          pm.expect(journal.entries).to.be.an("array");
+          pm.expect(journal.summary).to.include({
+            season: 2026,
+            explanationSource: "recorded_facts",
+            isAiGenerated: false
+          });
+          ["plantedCount", "harvestCount", "reminderCompletionCount", "completedShareCount", "foodSharedBeforeExpiryCount", "activeMonthCount"]
+            .forEach((key) => pm.expect(journal.summary[key], key).to.be.a("number"));
+          journal.entries.forEach((entry) => {
+            pm.expect(entry).to.have.property("id");
+            pm.expect(entry).to.have.property("sourceType");
+            pm.expect(entry).to.have.property("sourceId");
+            pm.expect(entry).to.have.property("isPrivate", true);
+          });
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/2 - Reject Invalid Season.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/2 - Reject Invalid Season.request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+name: Reject Invalid Journal Season
+description: Reject a non-year journal season before querying records.
+method: GET
+url: '{{baseUrl}}/journal?season=summer'
+order: 2000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 400", function () {
+          pm.response.to.have.status(400);
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/3 - Create Note.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/3 - Create Note.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+name: Create Private Journal Note
+description: Create a private note using an idempotency key and capture its ID.
+method: POST
+url: '{{baseUrl}}/journal/notes'
+order: 3000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: '{{journalNoteKey}}'
+body:
+  type: json
+  content: |-
+    {
+      "occurredOn": "2026-07-14",
+      "title": "{{journalNoteTitle}}",
+      "body": "A private contract-test observation."
+    }
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const suffix = Date.now().toString();
+      pm.collectionVariables.set("journalNoteKey", `journal-contract-${suffix}`);
+      pm.collectionVariables.set("journalNoteTitle", `Contract note ${suffix}`);
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+      pm.test("Private note contract is returned", function () {
+          const entry = pm.response.json();
+          pm.expect(entry).to.include({ kind: "note", manual: true, isPrivate: true });
+          pm.expect(entry).to.have.property("sourceId");
+          pm.collectionVariables.set("journalNoteId", entry.sourceId);
+          pm.collectionVariables.set("journalEntryId", entry.id);
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/4 - Replay Note.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/4 - Replay Note.request.yaml
@@ -1,0 +1,31 @@
+$kind: http-request
+name: Replay Private Journal Note
+description: Replaying the same idempotency key and body returns the same note.
+method: POST
+url: '{{baseUrl}}/journal/notes'
+order: 4000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: '{{journalNoteKey}}'
+body:
+  type: json
+  content: |-
+    {
+      "occurredOn": "2026-07-14",
+      "title": "{{journalNoteTitle}}",
+      "body": "A private contract-test observation."
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+      pm.test("Replay returns the original entry", function () {
+          pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get("journalEntryId"));
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/5 - Reject Foreign Photo Key.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/5 - Reject Foreign Photo Key.request.yaml
@@ -1,0 +1,28 @@
+$kind: http-request
+name: Reject Foreign Journal Photo Key
+description: A note cannot attach a photo outside the authenticated grower's owner scope.
+method: POST
+url: '{{baseUrl}}/journal/notes'
+order: 5000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: 'journal-invalid-photo-{{$guid}}'
+body:
+  type: json
+  content: |-
+    {
+      "occurredOn": "2026-07-14",
+      "title": "Invalid photo scope",
+      "photoKey": "journal-photos/not-the-owner/photo"
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 400", function () {
+          pm.response.to.have.status(400);
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/6 - Create Photo Upload Intent.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/6 - Create Photo Upload Intent.request.yaml
@@ -1,0 +1,33 @@
+$kind: http-request
+name: Create Journal Photo Upload Intent
+description: Issue a short-lived owner-scoped upload URL for a supported private photo.
+method: POST
+url: '{{baseUrl}}/journal/photo-upload-url'
+order: 6000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+body:
+  type: json
+  content: |-
+    {
+      "contentType": "image/jpeg",
+      "contentLength": 1024
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+      pm.test("Upload intent is private and owner-scoped", function () {
+          const intent = pm.response.json();
+          pm.expect(intent).to.have.property("method", "PUT");
+          pm.expect(intent.uploadUrl).to.be.a("string").and.not.empty;
+          pm.expect(intent.photoKey).to.match(new RegExp(`^journal-photos/${pm.collectionVariables.get("myUserId")}/`));
+          pm.expect(intent.headers).to.have.property("Content-Type", "image/jpeg");
+          pm.expect(intent.expiresInSeconds).to.be.greaterThan(0);
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/6 - Delete Note.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/6 - Delete Note.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+name: Delete Private Journal Note
+description: Soft-delete the note owned by the authenticated grower.
+method: DELETE
+url: '{{baseUrl}}/journal/notes/:noteId'
+order: 8000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+pathVariables:
+  - key: noteId
+    value: '{{journalNoteId}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 204", function () {
+          pm.response.to.have.status(204);
+      });

--- a/postman/collections/Good Roots Network API/Garden Journal/7 - Reject Unsupported Photo.request.yaml
+++ b/postman/collections/Good Roots Network API/Garden Journal/7 - Reject Unsupported Photo.request.yaml
@@ -1,0 +1,25 @@
+$kind: http-request
+name: Reject Unsupported Journal Photo
+description: Reject unsupported photo content before issuing an upload URL.
+method: POST
+url: '{{baseUrl}}/journal/photo-upload-url'
+order: 7000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+body:
+  type: json
+  content: |-
+    {
+      "contentType": "image/svg+xml",
+      "contentLength": 1024
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 400", function () {
+          pm.response.to.have.status(400);
+      });

--- a/postman/collections/Good Roots Network API/Reminders/.resources/definition.yaml
+++ b/postman/collections/Good Roots Network API/Reminders/.resources/definition.yaml
@@ -1,4 +1,4 @@
 $kind: collection
 name: Reminders
-description: Deterministic reminder scheduling and status management (`active` / `paused`) for authenticated users.
+description: Deterministic reminder scheduling, pause/resume, and recorded completion for authenticated users.
 order: 9000

--- a/postman/collections/Good Roots Network API/Reminders/Complete Reminder.request.yaml
+++ b/postman/collections/Good Roots Network API/Reminders/Complete Reminder.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+name: Complete Reminder Today
+description: Record a real completion and advance the deterministic recurring schedule.
+method: PUT
+url: '{{baseUrl}}/reminders/:reminderId'
+order: 5000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: '{{reminderCompletionKey}}'
+pathVariables:
+  - key: reminderId
+    value: '{{reminderId}}'
+body:
+  type: json
+  content: |-
+    {
+      "status": "completed"
+    }
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      pm.collectionVariables.set("reminderCompletionKey", `reminder-completion-${Date.now()}`);
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+      pm.test("Completion is recorded and the schedule advances", function () {
+          const reminder = pm.response.json();
+          pm.expect(reminder).to.have.property("id", pm.collectionVariables.get("reminderId"));
+          pm.expect(reminder.lastRunAt).to.be.a("string").and.not.empty;
+          pm.expect(new Date(reminder.nextRunAt).getTime()).to.be.greaterThan(new Date(reminder.lastRunAt).getTime());
+          pm.collectionVariables.set("reminderCompletionLastRunAt", reminder.lastRunAt);
+          pm.collectionVariables.set("reminderCompletionNextRunAt", reminder.nextRunAt);
+      });

--- a/postman/collections/Good Roots Network API/Reminders/Replay Reminder Completion.request.yaml
+++ b/postman/collections/Good Roots Network API/Reminders/Replay Reminder Completion.request.yaml
@@ -1,0 +1,34 @@
+$kind: http-request
+name: Replay Reminder Completion
+description: Retrying the same completion key does not advance the recurring schedule twice.
+method: PUT
+url: '{{baseUrl}}/reminders/:reminderId'
+order: 6000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: '{{reminderCompletionKey}}'
+pathVariables:
+  - key: reminderId
+    value: '{{reminderId}}'
+body:
+  type: json
+  content: |-
+    {
+      "status": "completed"
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+      pm.test("Replay returns the same completion timestamps", function () {
+          const reminder = pm.response.json();
+          pm.expect(reminder.lastRunAt).to.eql(pm.collectionVariables.get("reminderCompletionLastRunAt"));
+          pm.expect(reminder.nextRunAt).to.eql(pm.collectionVariables.get("reminderCompletionNextRunAt"));
+      });

--- a/services/grn-api/db/ddl.sql
+++ b/services/grn-api/db/ddl.sql
@@ -572,6 +572,45 @@ create index if not exists idx_crop_harvests_grower_crop on crop_harvests(grower
 create index if not exists idx_crop_harvests_user on crop_harvests(user_id);
 
 -- ============================
+-- REMINDER COMPLETIONS (private immutable facts)
+-- ============================
+create table if not exists reminder_completions (
+  id uuid primary key,
+  reminder_id uuid not null references reminder_rules(id) on delete cascade,
+  user_id uuid not null references users(id) on delete cascade,
+  completed_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_reminder_completions_user_season
+  on reminder_completions(user_id, completed_at desc, id desc);
+
+-- ============================
+-- GARDEN JOURNAL NOTES (private)
+-- ============================
+-- The full journal is a deterministic read projection over existing garden
+-- records. This table stores only optional gardener-authored notes/photos.
+create table if not exists garden_journal_notes (
+  id uuid primary key,
+  user_id uuid not null references users(id) on delete cascade,
+  occurred_on date not null,
+  title text not null,
+  body text,
+  photo_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+  constraint garden_journal_notes_title_not_empty check (length(trim(title)) > 0),
+  constraint garden_journal_notes_title_length check (length(title) <= 120),
+  constraint garden_journal_notes_body_length check (body is null or length(body) <= 2000),
+  constraint garden_journal_notes_photo_key_scope check (photo_key is null or photo_key like 'journal-photos/%')
+);
+
+create index if not exists idx_garden_journal_notes_user_season
+  on garden_journal_notes(user_id, occurred_on desc, id desc)
+  where deleted_at is null;
+
+-- ============================
 -- SURPLUS LISTINGS
 -- ============================
 create table if not exists surplus_listings (

--- a/services/grn-api/db/migrations/0040_garden_journal_notes.sql
+++ b/services/grn-api/db/migrations/0040_garden_journal_notes.sql
@@ -1,0 +1,40 @@
+-- Immutable, idempotent facts for each recurring-reminder completion. A
+-- reminder's last_run_at remains the fast current-state field, while this
+-- history preserves every season entry.
+create table if not exists reminder_completions (
+  id uuid primary key,
+  reminder_id uuid not null references reminder_rules(id) on delete cascade,
+  user_id uuid not null references users(id) on delete cascade,
+  completed_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_reminder_completions_user_season
+  on reminder_completions(user_id, completed_at desc, id desc);
+
+-- Private gardener-authored notes that complement the deterministic journal
+-- projection assembled from crops, harvests, reminders, beds, and completed
+-- sharing activity. Source activity remains in its owning transactional table.
+
+create table if not exists garden_journal_notes (
+  id uuid primary key,
+  user_id uuid not null references users(id) on delete cascade,
+  occurred_on date not null,
+  title text not null,
+  body text,
+  photo_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz,
+
+  constraint garden_journal_notes_title_not_empty check (length(trim(title)) > 0),
+  constraint garden_journal_notes_title_length check (length(title) <= 120),
+  constraint garden_journal_notes_body_length check (body is null or length(body) <= 2000),
+  constraint garden_journal_notes_photo_key_scope check (
+    photo_key is null or photo_key like 'journal-photos/%'
+  )
+);
+
+create index if not exists idx_garden_journal_notes_user_season
+  on garden_journal_notes(user_id, occurred_on desc, id desc)
+  where deleted_at is null;

--- a/services/grn-api/db/migrations/test_0040_garden_journal_notes.sql
+++ b/services/grn-api/db/migrations/test_0040_garden_journal_notes.sql
@@ -1,0 +1,55 @@
+-- Contract probes for the private journal-note storage added by migration 0040.
+
+do $$
+declare
+  test_user_id uuid := gen_random_uuid();
+  test_note_id uuid := gen_random_uuid();
+  test_reminder_id uuid := gen_random_uuid();
+  test_completion_id uuid := gen_random_uuid();
+begin
+  insert into users (id, email, user_type)
+  values (test_user_id, 'journal-migration-check@example.com', 'grower');
+
+  insert into reminder_rules
+    (id, user_id, title, reminder_type, cadence_days, start_date, timezone, next_run_at)
+  values
+    (test_reminder_id, test_user_id, 'Water herbs', 'watering', 2, date '2026-07-14', 'UTC', now());
+
+  insert into reminder_completions (id, reminder_id, user_id)
+  values (test_completion_id, test_reminder_id, test_user_id);
+
+  if not exists (
+    select 1 from reminder_completions
+     where id = test_completion_id and reminder_id = test_reminder_id and user_id = test_user_id
+  ) then
+    raise exception 'immutable reminder completion should be persisted';
+  end if;
+
+  insert into garden_journal_notes (id, user_id, occurred_on, title, body)
+  values (test_note_id, test_user_id, date '2026-07-14', 'First tomato', 'Private note');
+
+  if not exists (
+    select 1 from garden_journal_notes
+     where id = test_note_id and user_id = test_user_id and deleted_at is null
+  ) then
+    raise exception 'owner-scoped journal note should be persisted';
+  end if;
+
+  begin
+    update garden_journal_notes
+       set photo_key = 'other-prefix/photo'
+     where id = test_note_id;
+    raise exception 'photo key check should reject an out-of-scope prefix';
+  exception
+    when check_violation then
+      null; -- expected
+  end;
+
+  delete from users where id = test_user_id;
+  if exists (select 1 from garden_journal_notes where id = test_note_id) then
+    raise exception 'journal notes should cascade when the owner is removed';
+  end if;
+  if exists (select 1 from reminder_completions where id = test_completion_id) then
+    raise exception 'reminder completions should cascade when the owner is removed';
+  end if;
+end $$;

--- a/services/grn-api/src/api/handlers/journal.rs
+++ b/services/grn-api/src/api/handlers/journal.rs
@@ -1,0 +1,972 @@
+use crate::auth::{extract_auth_context_with_fallback, require_grower};
+use crate::db;
+use crate::handlers::crop::error_response;
+use aws_config::BehaviorVersion;
+use aws_sdk_eventbridge::types::PutEventsRequestEntry;
+use aws_sdk_s3::presigning::PresigningConfig;
+use chrono::{Datelike, NaiveDate, Utc};
+use lambda_http::{Body, Request, Response};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::time::Duration;
+use tokio_postgres::Row;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const MIN_SEASON_YEAR: i32 = 2000;
+const MAX_SEASON_YEAR: i32 = 2100;
+const JOURNAL_PHOTO_PREFIX: &str = "journal-photos";
+const MAX_PHOTO_BYTES: u64 = 5 * 1024 * 1024;
+const PHOTO_URL_EXPIRES_SECONDS: u64 = 900;
+const ALLOWED_PHOTO_CONTENT_TYPES: [&str; 3] = ["image/jpeg", "image/png", "image/webp"];
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEntry {
+    pub id: String,
+    pub kind: String,
+    pub occurred_at: String,
+    pub title: String,
+    pub detail: Option<String>,
+    pub source_type: String,
+    pub source_id: String,
+    pub source_path: Option<String>,
+    pub is_private: bool,
+    pub manual: bool,
+    pub photo_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalSummary {
+    pub season: i32,
+    pub planted_count: usize,
+    pub harvest_count: usize,
+    pub reminder_completion_count: usize,
+    pub completed_share_count: usize,
+    pub food_shared_before_expiry_count: usize,
+    pub active_month_count: usize,
+    pub explanation: String,
+    pub explanation_source: String,
+    pub is_ai_generated: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalResponse {
+    pub season: i32,
+    pub entries: Vec<JournalEntry>,
+    pub summary: JournalSummary,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateNoteRequest {
+    pub occurred_on: String,
+    pub title: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub photo_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhotoUploadRequest {
+    pub content_type: String,
+    pub content_length: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhotoUploadHeaders {
+    #[serde(rename = "Content-Type")]
+    pub content_type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhotoUploadResponse {
+    pub upload_url: String,
+    pub method: String,
+    pub headers: PhotoUploadHeaders,
+    pub photo_key: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Debug)]
+struct NormalizedNote {
+    occurred_on: NaiveDate,
+    title: String,
+    body: Option<String>,
+    photo_key: Option<String>,
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn list_journal(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = authenticated_grower_id(request).await?;
+    let season = parse_season(request.uri().query())?;
+    let (season_start, season_end) = season_bounds(season)?;
+    let client = db::connect().await?;
+    let mut entries = Vec::new();
+
+    let crop_rows = client
+        .query(
+            "
+            select g.id, g.crop_name, g.nickname, g.bed_id, b.name as bed_name,
+                   g.planting_date, g.created_at
+              from grower_crop_library g
+              left join garden_beds b on b.id = g.bed_id and b.user_id = g.user_id
+             where g.user_id = $1
+               and coalesce(g.planting_date, g.created_at::date) >= $2
+               and coalesce(g.planting_date, g.created_at::date) < $3
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    entries.extend(crop_rows.iter().map(crop_entry));
+
+    let bed_rows = client
+        .query(
+            "
+            select id, name, created_at
+              from garden_beds
+             where user_id = $1
+               and created_at >= $2::date
+               and created_at < $3::date
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    entries.extend(bed_rows.iter().map(bed_entry));
+
+    let harvest_rows = client
+        .query(
+            "
+            select h.id, h.grower_crop_id, h.harvested_on, h.created_at,
+                   g.crop_name, g.nickname
+              from crop_harvests h
+              inner join grower_crop_library g on g.id = h.grower_crop_id
+             where h.user_id = $1
+               and h.harvested_on >= $2
+               and h.harvested_on < $3
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    entries.extend(harvest_rows.iter().map(harvest_entry));
+
+    let reminder_rows = client
+        .query(
+            "
+            select c.id, c.reminder_id, c.completed_at, r.title, r.reminder_type
+              from reminder_completions c
+              inner join reminder_rules r on r.id = c.reminder_id
+             where c.user_id = $1
+               and c.completed_at >= $2::date
+               and c.completed_at < $3::date
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    entries.extend(reminder_rows.iter().map(reminder_entry));
+
+    let share_rows = client
+        .query(
+            "
+            select c.id, c.completed_at, c.claimer_id,
+                   l.id as listing_id, l.user_id as listing_owner_id,
+                   l.title, l.available_end,
+                   (l.user_id = $1 and c.completed_at <= l.available_end) as shared_before_expiry
+              from claims c
+              inner join surplus_listings l on l.id = c.listing_id
+             where c.status::text = 'completed'
+               and c.completed_at >= $2::date
+               and c.completed_at < $3::date
+               and (c.claimer_id = $1 or l.user_id = $1)
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    let food_shared_before_expiry_count = share_rows
+        .iter()
+        .filter(|row| row.get::<_, Option<bool>>("shared_before_expiry") == Some(true))
+        .count();
+    entries.extend(share_rows.iter().map(|row| share_entry(row, user_id)));
+
+    let note_rows = client
+        .query(
+            "
+            select id, occurred_on, title, body, photo_key, created_at
+              from garden_journal_notes
+             where user_id = $1
+               and occurred_on >= $2
+               and occurred_on < $3
+               and deleted_at is null
+             order by occurred_on desc, id desc
+            ",
+            &[&user_id, &season_start, &season_end],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    entries.extend(note_entries_with_urls(&note_rows, user_id).await);
+
+    let entries = dedupe_and_sort(entries);
+    let summary = summarize_entries(season, &entries, food_shared_before_expiry_count);
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        season,
+        entry_count = entries.len(),
+        "Built private garden journal from source records"
+    );
+
+    json_response(
+        200,
+        &JournalResponse {
+            season,
+            entries,
+            summary,
+        },
+    )
+}
+
+pub async fn create_note(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = authenticated_grower_id(request).await?;
+    let payload: CreateNoteRequest = parse_json_body(request)?;
+    let normalized = normalize_note(&payload, user_id)?;
+    let Some(idempotency_key) = extract_idempotency_key(request) else {
+        return error_response(400, "Idempotency-Key header is required");
+    };
+    let note_id = derive_note_id(user_id, &idempotency_key);
+    let client = db::connect().await?;
+
+    let inserted = client
+        .query_opt(
+            "
+            insert into garden_journal_notes
+              (id, user_id, occurred_on, title, body, photo_key)
+            values ($1, $2, $3, $4, $5, $6)
+            on conflict (id) do nothing
+            returning id, occurred_on, title, body, photo_key, created_at
+            ",
+            &[
+                &note_id,
+                &user_id,
+                &normalized.occurred_on,
+                &normalized.title,
+                &normalized.body,
+                &normalized.photo_key,
+            ],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+
+    let (row, is_new) = if let Some(row) = inserted {
+        (row, true)
+    } else {
+        let existing = client
+            .query_opt(
+                "
+                select id, occurred_on, title, body, photo_key, created_at
+                  from garden_journal_notes
+                 where id = $1 and user_id = $2 and deleted_at is null
+                ",
+                &[&note_id, &user_id],
+            )
+            .await
+            .map_err(|event| db_error(&event))?;
+        let Some(row) = existing else {
+            return error_response(409, "Idempotency key collision with another journal note");
+        };
+        if !note_matches(&row, &normalized) {
+            return error_response(
+                409,
+                "Idempotency key was already used for different note content",
+            );
+        }
+        (row, false)
+    };
+
+    if is_new {
+        emit_note_event_best_effort("journal.note.created", note_id, user_id, correlation_id).await;
+    }
+    let entry = note_entry_with_url(&row, user_id).await;
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        note_id = %note_id,
+        idempotency_replay = !is_new,
+        "Saved private garden journal note"
+    );
+    json_response(201, &entry)
+}
+
+pub async fn delete_note(
+    request: &Request,
+    correlation_id: &str,
+    note_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = authenticated_grower_id(request).await?;
+    let Ok(note_id) = Uuid::parse_str(note_id) else {
+        return error_response(400, "noteId must be a valid UUID");
+    };
+    let client = db::connect().await?;
+    let deleted = client
+        .query_opt(
+            "
+            update garden_journal_notes
+               set deleted_at = now(), updated_at = now()
+             where id = $1 and user_id = $2 and deleted_at is null
+            returning photo_key
+            ",
+            &[&note_id, &user_id],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+    let Some(row) = deleted else {
+        return error_response(404, "Journal note not found");
+    };
+
+    if let Some(photo_key) = row.get::<_, Option<String>>("photo_key") {
+        delete_photo_best_effort(&photo_key, correlation_id).await;
+    }
+    emit_note_event_best_effort("journal.note.deleted", note_id, user_id, correlation_id).await;
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        note_id = %note_id,
+        "Deleted private garden journal note"
+    );
+
+    Response::builder()
+        .status(204)
+        .body(Body::Empty)
+        .map_err(|event| lambda_http::Error::from(event.to_string()))
+}
+
+pub async fn create_photo_upload_url(
+    request: &Request,
+    correlation_id: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let user_id = authenticated_grower_id(request).await?;
+    let payload: PhotoUploadRequest = parse_json_body(request)?;
+    let content_type = payload.content_type.trim();
+    if !ALLOWED_PHOTO_CONTENT_TYPES.contains(&content_type) {
+        return error_response(
+            400,
+            "contentType must be one of image/jpeg, image/png, image/webp",
+        );
+    }
+    if payload.content_length == 0 || payload.content_length > MAX_PHOTO_BYTES {
+        return error_response(400, "contentLength must be between 1 byte and 5 MB");
+    }
+    let bucket = env::var("MEDIA_BUCKET_NAME")
+        .map_err(|_| lambda_http::Error::from("MEDIA_BUCKET_NAME is not configured"))?;
+    let photo_key = format!("{JOURNAL_PHOTO_PREFIX}/{user_id}/{}", Uuid::new_v4());
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let s3 = aws_sdk_s3::Client::new(&config);
+    let presigning = PresigningConfig::expires_in(Duration::from_secs(PHOTO_URL_EXPIRES_SECONDS))
+        .map_err(|event| lambda_http::Error::from(event.to_string()))?;
+    let content_length = i64::try_from(payload.content_length)
+        .map_err(|_| lambda_http::Error::from("contentLength is out of range"))?;
+    let presigned = s3
+        .put_object()
+        .bucket(bucket)
+        .key(&photo_key)
+        .content_type(content_type)
+        .content_length(content_length)
+        .presigned(presigning)
+        .await
+        .map_err(|event| {
+            lambda_http::Error::from(format!("Failed to presign journal photo upload: {event}"))
+        })?;
+
+    info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        photo_key = photo_key.as_str(),
+        "Issued private journal photo upload URL"
+    );
+    json_response(
+        201,
+        &PhotoUploadResponse {
+            upload_url: presigned.uri().to_string(),
+            method: "PUT".to_string(),
+            headers: PhotoUploadHeaders {
+                content_type: content_type.to_string(),
+            },
+            photo_key,
+            expires_in_seconds: PHOTO_URL_EXPIRES_SECONDS,
+        },
+    )
+}
+
+fn crop_entry(row: &Row) -> JournalEntry {
+    let crop_id = row.get::<_, Uuid>("id").to_string();
+    let crop_name = display_name(
+        row.get::<_, Option<String>>("nickname"),
+        row.get("crop_name"),
+    );
+    let planting_date = row.get::<_, Option<NaiveDate>>("planting_date");
+    let occurred_at = planting_date.map_or_else(
+        || {
+            row.get::<_, chrono::DateTime<Utc>>("created_at")
+                .to_rfc3339()
+        },
+        |date| date.to_string(),
+    );
+    let kind = if planting_date.is_some() {
+        "planted"
+    } else {
+        "planned"
+    };
+    let detail = row
+        .get::<_, Option<String>>("bed_name")
+        .map(|bed| format!("Garden record linked to {bed}."));
+    JournalEntry {
+        id: format!("crop:{crop_id}:{kind}:{occurred_at}"),
+        kind: kind.to_string(),
+        occurred_at,
+        title: if kind == "planted" {
+            format!("Planted {crop_name}")
+        } else {
+            format!("Added {crop_name} to the garden")
+        },
+        detail,
+        source_type: "crop".to_string(),
+        source_id: crop_id.clone(),
+        source_path: Some(format!("/garden/plants?crop={crop_id}")),
+        is_private: true,
+        manual: false,
+        photo_url: None,
+    }
+}
+
+fn bed_entry(row: &Row) -> JournalEntry {
+    let bed_id = row.get::<_, Uuid>("id").to_string();
+    let occurred_at = row
+        .get::<_, chrono::DateTime<Utc>>("created_at")
+        .to_rfc3339();
+    JournalEntry {
+        id: format!("bed:{bed_id}:created"),
+        kind: "garden".to_string(),
+        occurred_at,
+        title: format!("Created {}", row.get::<_, String>("name")),
+        detail: Some("A garden bed was added to the map.".to_string()),
+        source_type: "bed".to_string(),
+        source_id: bed_id.clone(),
+        source_path: Some(format!("/garden?bed={bed_id}")),
+        is_private: true,
+        manual: false,
+        photo_url: None,
+    }
+}
+
+fn harvest_entry(row: &Row) -> JournalEntry {
+    let harvest_id = row.get::<_, Uuid>("id").to_string();
+    let crop_id = row.get::<_, Uuid>("grower_crop_id").to_string();
+    let crop_name = display_name(
+        row.get::<_, Option<String>>("nickname"),
+        row.get("crop_name"),
+    );
+    JournalEntry {
+        id: format!("harvest:{harvest_id}"),
+        kind: "harvest".to_string(),
+        occurred_at: row.get::<_, NaiveDate>("harvested_on").to_string(),
+        title: format!("Harvested {crop_name}"),
+        detail: Some("A harvest record was saved. Open it for the recorded details.".to_string()),
+        source_type: "harvest".to_string(),
+        source_id: harvest_id.clone(),
+        source_path: Some(format!(
+            "/garden/plants?crop={crop_id}&action=harvest&harvest={harvest_id}"
+        )),
+        is_private: true,
+        manual: false,
+        photo_url: None,
+    }
+}
+
+fn reminder_entry(row: &Row) -> JournalEntry {
+    let completion_id = row.get::<_, Uuid>("id").to_string();
+    let reminder_id = row.get::<_, Uuid>("reminder_id").to_string();
+    JournalEntry {
+        id: format!("reminder-completion:{completion_id}"),
+        kind: "reminder".to_string(),
+        occurred_at: row
+            .get::<_, chrono::DateTime<Utc>>("completed_at")
+            .to_rfc3339(),
+        title: format!("Completed {}", row.get::<_, String>("title")),
+        detail: Some(format!(
+            "{} reminder completed.",
+            row.get::<_, String>("reminder_type")
+        )),
+        source_type: "reminder".to_string(),
+        source_id: reminder_id.clone(),
+        source_path: Some(format!("/today/reminders?reminder={reminder_id}")),
+        is_private: true,
+        manual: false,
+        photo_url: None,
+    }
+}
+
+fn share_entry(row: &Row, user_id: Uuid) -> JournalEntry {
+    let claim_id = row.get::<_, Uuid>("id").to_string();
+    let listing_id = row.get::<_, Uuid>("listing_id").to_string();
+    let is_owner = row.get::<_, Uuid>("listing_owner_id") == user_id;
+    let title = row
+        .get::<_, Option<String>>("title")
+        .unwrap_or_else(|| "shared food".to_string());
+    JournalEntry {
+        id: format!("share:{claim_id}:completed"),
+        kind: "share".to_string(),
+        occurred_at: row
+            .get::<_, chrono::DateTime<Utc>>("completed_at")
+            .to_rfc3339(),
+        title: format!("Pickup completed for {title}"),
+        detail: Some("A neighbor pickup was completed successfully.".to_string()),
+        source_type: "share".to_string(),
+        source_id: claim_id.clone(),
+        source_path: Some(if is_owner {
+            format!("/share/listings?listing={listing_id}&claim={claim_id}")
+        } else {
+            format!("/share/find?claim={claim_id}")
+        }),
+        is_private: true,
+        manual: false,
+        photo_url: None,
+    }
+}
+
+async fn note_entries_with_urls(rows: &[Row], user_id: Uuid) -> Vec<JournalEntry> {
+    let mut entries = Vec::with_capacity(rows.len());
+    for row in rows {
+        entries.push(note_entry_with_url(row, user_id).await);
+    }
+    entries
+}
+
+async fn note_entry_with_url(row: &Row, user_id: Uuid) -> JournalEntry {
+    let note_id = row.get::<_, Uuid>("id").to_string();
+    let photo_url = if let Some(photo_key) = row.get::<_, Option<String>>("photo_key") {
+        if validate_photo_key(&photo_key, user_id).is_ok() {
+            presign_photo_get(&photo_key).await
+        } else {
+            warn!(
+                note_id = note_id.as_str(),
+                "Ignored out-of-scope journal photo key"
+            );
+            None
+        }
+    } else {
+        None
+    };
+    JournalEntry {
+        id: format!("note:{note_id}"),
+        kind: "note".to_string(),
+        occurred_at: row.get::<_, NaiveDate>("occurred_on").to_string(),
+        title: row.get("title"),
+        detail: row.get("body"),
+        source_type: "note".to_string(),
+        source_id: note_id,
+        source_path: None,
+        is_private: true,
+        manual: true,
+        photo_url,
+    }
+}
+
+async fn presign_photo_get(photo_key: &str) -> Option<String> {
+    let bucket = env::var("MEDIA_BUCKET_NAME").ok()?;
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let s3 = aws_sdk_s3::Client::new(&config);
+    let presigning =
+        PresigningConfig::expires_in(Duration::from_secs(PHOTO_URL_EXPIRES_SECONDS)).ok()?;
+    match s3
+        .get_object()
+        .bucket(bucket)
+        .key(photo_key)
+        .presigned(presigning)
+        .await
+    {
+        Ok(value) => Some(value.uri().to_string()),
+        Err(event) => {
+            warn!(error = %event, "Could not presign private journal photo read");
+            None
+        }
+    }
+}
+
+async fn delete_photo_best_effort(photo_key: &str, correlation_id: &str) {
+    let Ok(bucket) = env::var("MEDIA_BUCKET_NAME") else {
+        return;
+    };
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let s3 = aws_sdk_s3::Client::new(&config);
+    if let Err(event) = s3
+        .delete_object()
+        .bucket(bucket)
+        .key(photo_key)
+        .send()
+        .await
+    {
+        error!(
+            correlation_id = correlation_id,
+            photo_key = photo_key,
+            error = %event,
+            "Failed to delete journal photo after note deletion"
+        );
+    }
+}
+
+fn summarize_entries(
+    season: i32,
+    entries: &[JournalEntry],
+    food_shared_before_expiry_count: usize,
+) -> JournalSummary {
+    let mut active_months = BTreeSet::new();
+    for entry in entries {
+        if let Some(month) = entry.occurred_at.get(0..7) {
+            active_months.insert(month.to_string());
+        }
+    }
+    JournalSummary {
+        season,
+        planted_count: entries.iter().filter(|entry| entry.kind == "planted").count(),
+        harvest_count: entries.iter().filter(|entry| entry.kind == "harvest").count(),
+        reminder_completion_count: entries
+            .iter()
+            .filter(|entry| entry.kind == "reminder")
+            .count(),
+        completed_share_count: entries.iter().filter(|entry| entry.kind == "share").count(),
+        food_shared_before_expiry_count,
+        active_month_count: active_months.len(),
+        explanation: "Built only from records saved in GRN. Regenerating this summary does not change crops, harvests, reminders, offers, or pickups.".to_string(),
+        explanation_source: "recorded_facts".to_string(),
+        is_ai_generated: false,
+    }
+}
+
+fn dedupe_and_sort(entries: Vec<JournalEntry>) -> Vec<JournalEntry> {
+    let mut by_id = BTreeMap::new();
+    for entry in entries {
+        by_id.entry(entry.id.clone()).or_insert(entry);
+    }
+    let mut entries = by_id.into_values().collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        right
+            .occurred_at
+            .cmp(&left.occurred_at)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    entries
+}
+
+fn normalize_note(
+    payload: &CreateNoteRequest,
+    user_id: Uuid,
+) -> Result<NormalizedNote, lambda_http::Error> {
+    let occurred_on = NaiveDate::parse_from_str(payload.occurred_on.trim(), "%Y-%m-%d")
+        .map_err(|_| lambda_http::Error::from("occurredOn must use YYYY-MM-DD"))?;
+    if !(MIN_SEASON_YEAR..=MAX_SEASON_YEAR).contains(&occurred_on.year()) {
+        return Err(lambda_http::Error::from(
+            "occurredOn year must be between 2000 and 2100",
+        ));
+    }
+    let title = payload.title.trim().to_string();
+    if title.is_empty() || title.chars().count() > 120 {
+        return Err(lambda_http::Error::from(
+            "title must be between 1 and 120 characters",
+        ));
+    }
+    let body = payload
+        .body
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    if body
+        .as_ref()
+        .is_some_and(|value| value.chars().count() > 2000)
+    {
+        return Err(lambda_http::Error::from(
+            "body must be 2000 characters or fewer",
+        ));
+    }
+    let photo_key = payload
+        .photo_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    if let Some(key) = photo_key.as_deref() {
+        validate_photo_key(key, user_id)?;
+    }
+    Ok(NormalizedNote {
+        occurred_on,
+        title,
+        body,
+        photo_key,
+    })
+}
+
+fn validate_photo_key(photo_key: &str, user_id: Uuid) -> Result<(), lambda_http::Error> {
+    let expected = format!("{JOURNAL_PHOTO_PREFIX}/{user_id}/");
+    if !photo_key.starts_with(&expected) || photo_key.contains("..") {
+        return Err(lambda_http::Error::from(
+            "photoKey must reference your private journal photo",
+        ));
+    }
+    Ok(())
+}
+
+fn note_matches(row: &Row, normalized: &NormalizedNote) -> bool {
+    row.get::<_, NaiveDate>("occurred_on") == normalized.occurred_on
+        && row.get::<_, String>("title") == normalized.title
+        && row.get::<_, Option<String>>("body") == normalized.body
+        && row.get::<_, Option<String>>("photo_key") == normalized.photo_key
+}
+
+fn parse_season(query: Option<&str>) -> Result<i32, lambda_http::Error> {
+    let default = Utc::now().year();
+    let season = query
+        .and_then(|query| {
+            query.split('&').find_map(|pair| {
+                let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+                (key == "season").then_some(value)
+            })
+        })
+        .filter(|value| !value.is_empty())
+        .map_or(Ok(default), |value| {
+            value
+                .parse::<i32>()
+                .map_err(|_| lambda_http::Error::from("season must be a four-digit year"))
+        })?;
+    if !(MIN_SEASON_YEAR..=MAX_SEASON_YEAR).contains(&season) {
+        return Err(lambda_http::Error::from(
+            "season must be between 2000 and 2100",
+        ));
+    }
+    Ok(season)
+}
+
+fn season_bounds(season: i32) -> Result<(NaiveDate, NaiveDate), lambda_http::Error> {
+    let start = NaiveDate::from_ymd_opt(season, 1, 1)
+        .ok_or_else(|| lambda_http::Error::from("Invalid season start"))?;
+    let end = NaiveDate::from_ymd_opt(season + 1, 1, 1)
+        .ok_or_else(|| lambda_http::Error::from("Invalid season end"))?;
+    Ok((start, end))
+}
+
+fn extract_idempotency_key(request: &Request) -> Option<String> {
+    request
+        .headers()
+        .get("Idempotency-Key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn derive_note_id(user_id: Uuid, idempotency_key: &str) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(user_id.as_bytes());
+    hasher.update(b":journal-note:");
+    hasher.update(idempotency_key.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+async fn authenticated_grower_id(request: &Request) -> Result<Uuid, lambda_http::Error> {
+    let auth = extract_auth_context_with_fallback(request).await?;
+    require_grower(&auth)?;
+    Uuid::parse_str(&auth.user_id).map_err(|_| lambda_http::Error::from("Invalid user ID format"))
+}
+
+async fn emit_note_event_best_effort(
+    detail_type: &str,
+    note_id: Uuid,
+    user_id: Uuid,
+    correlation_id: &str,
+) {
+    if let Err(event) = emit_note_event(detail_type, note_id, user_id, correlation_id).await {
+        error!(
+            correlation_id = correlation_id,
+            note_id = %note_id,
+            detail_type = detail_type,
+            error = %event,
+            "Failed to emit journal note event after successful write"
+        );
+    }
+}
+
+async fn emit_note_event(
+    detail_type: &str,
+    note_id: Uuid,
+    user_id: Uuid,
+    correlation_id: &str,
+) -> Result<(), lambda_http::Error> {
+    let event_bus_name = env::var("EVENT_BUS_NAME").unwrap_or_else(|_| "default".to_string());
+    let detail = serde_json::json!({
+        "noteId": note_id,
+        "userId": user_id,
+        "correlationId": correlation_id,
+        "occurredAt": Utc::now().to_rfc3339(),
+    });
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let events = aws_sdk_eventbridge::Client::new(&config);
+    let entry = PutEventsRequestEntry::builder()
+        .event_bus_name(event_bus_name)
+        .source("grn.api")
+        .detail_type(detail_type)
+        .detail(detail.to_string())
+        .build();
+    let response = events
+        .put_events()
+        .entries(entry)
+        .send()
+        .await
+        .map_err(|event| {
+            lambda_http::Error::from(format!("Failed to emit journal event: {event}"))
+        })?;
+    if response.failed_entry_count() > 0 {
+        return Err(lambda_http::Error::from(
+            "Failed to emit journal event: one or more entries were rejected",
+        ));
+    }
+    Ok(())
+}
+
+fn display_name(nickname: Option<String>, crop_name: String) -> String {
+    nickname
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(crop_name)
+}
+
+fn parse_json_body<T: serde::de::DeserializeOwned>(
+    request: &Request,
+) -> Result<T, lambda_http::Error> {
+    match request.body() {
+        Body::Text(text) => serde_json::from_str(text)
+            .map_err(|event| lambda_http::Error::from(format!("Invalid JSON body: {event}"))),
+        Body::Binary(bytes) => serde_json::from_slice(bytes)
+            .map_err(|event| lambda_http::Error::from(format!("Invalid JSON body: {event}"))),
+        Body::Empty => Err(lambda_http::Error::from("Request body is required")),
+    }
+}
+
+fn json_response<T: Serialize>(
+    status: u16,
+    payload: &T,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let body = serde_json::to_string(payload)
+        .map_err(|event| lambda_http::Error::from(event.to_string()))?;
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .map_err(|event| lambda_http::Error::from(event.to_string()))
+}
+
+fn db_error(event: &tokio_postgres::Error) -> lambda_http::Error {
+    lambda_http::Error::from(format!("Database error: {event}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, kind: &str, occurred_at: &str) -> JournalEntry {
+        JournalEntry {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            occurred_at: occurred_at.to_string(),
+            title: "Fact".to_string(),
+            detail: None,
+            source_type: kind.to_string(),
+            source_id: id.to_string(),
+            source_path: Some("/garden".to_string()),
+            is_private: true,
+            manual: false,
+            photo_url: None,
+        }
+    }
+
+    #[test]
+    fn season_parser_accepts_supported_year_and_rejects_invalid_values() {
+        assert_eq!(parse_season(Some("season=2026")).unwrap(), 2026);
+        assert!(parse_season(Some("season=1999")).is_err());
+        assert!(parse_season(Some("season=summer")).is_err());
+    }
+
+    #[test]
+    fn deterministic_note_id_is_stable_per_user_and_key() {
+        let user = Uuid::new_v4();
+        assert_eq!(derive_note_id(user, "retry"), derive_note_id(user, "retry"));
+        assert_ne!(derive_note_id(user, "retry"), derive_note_id(user, "new"));
+    }
+
+    #[test]
+    fn note_validation_enforces_private_photo_ownership() {
+        let user = Uuid::new_v4();
+        let valid = CreateNoteRequest {
+            occurred_on: "2026-07-15".to_string(),
+            title: "First tomato".to_string(),
+            body: Some("Spotted the first ripe fruit.".to_string()),
+            photo_key: Some(format!("journal-photos/{user}/photo")),
+        };
+        assert!(normalize_note(&valid, user).is_ok());
+        let wrong_user = Uuid::new_v4();
+        assert!(normalize_note(&valid, wrong_user).is_err());
+    }
+
+    #[test]
+    fn replayed_source_entries_are_deduplicated_and_sorted() {
+        let repeated = entry("harvest:1", "harvest", "2026-06-01");
+        let result = dedupe_and_sort(vec![
+            repeated.clone(),
+            repeated,
+            entry("crop:1", "planted", "2026-07-01"),
+        ]);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "crop:1");
+        assert_eq!(result[1].source_type, "harvest");
+        assert_eq!(result[1].source_path.as_deref(), Some("/garden"));
+        assert!(result[1].is_private);
+    }
+
+    #[test]
+    fn summary_uses_recorded_facts_without_volume_or_ai_scoring() {
+        let entries = vec![
+            entry("crop:1", "planted", "2026-04-01"),
+            entry("harvest:1", "harvest", "2026-07-01"),
+            entry("share:1", "share", "2026-07-15"),
+            entry("reminder:1", "reminder", "2026-08-01"),
+        ];
+        let summary = summarize_entries(2026, &entries, 1);
+        assert_eq!(summary.completed_share_count, 1);
+        assert_eq!(summary.food_shared_before_expiry_count, 1);
+        assert!(!summary.is_ai_generated);
+        assert_eq!(summary.explanation_source, "recorded_facts");
+        assert!(!summary.explanation.to_lowercase().contains("yield"));
+    }
+}

--- a/services/grn-api/src/api/handlers/mod.rs
+++ b/services/grn-api/src/api/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod feed;
 pub mod garden_canvas;
 pub mod garden_review;
 pub mod garden_share;
+pub mod journal;
 pub mod listing;
 pub mod listing_discovery;
 pub mod reminder;

--- a/services/grn-api/src/api/handlers/reminder.rs
+++ b/services/grn-api/src/api/handlers/reminder.rs
@@ -2,8 +2,28 @@ use crate::auth::extract_auth_context;
 use crate::db;
 use lambda_http::{Body, Request, Response};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio_postgres::Row;
 use uuid::Uuid;
+
+const COMPLETE_REMINDER_SQL: &str = "
+    update reminder_rules
+       set last_run_at = now(),
+           next_run_at = greatest(next_run_at, now()) + cadence_days * interval '1 day',
+           updated_at = now()
+     where id = $1
+       and user_id = $2
+       and deleted_at is null
+    returning id, title, reminder_type, cadence_days, start_date::text as start_date,
+              timezone, status, next_run_at, last_run_at, created_at
+";
+
+const SELECT_REMINDER_SQL: &str = "
+    select id, title, reminder_type, cadence_days, start_date::text as start_date,
+           timezone, status, next_run_at, last_run_at, created_at
+      from reminder_rules
+     where id = $1 and user_id = $2 and deleted_at is null
+";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -154,8 +174,15 @@ pub async fn update_reminder_status(
         .map_err(|_| lambda_http::Error::from("Invalid reminder id"))?;
     let payload: UpdateReminderStatusRequest = parse_json_body(request)?;
 
-    if !matches!(payload.status.as_str(), "active" | "paused") {
-        return error_response(400, "status must be active or paused");
+    if !is_valid_reminder_status(&payload.status) {
+        return error_response(400, "status must be active, paused, or completed");
+    }
+
+    if payload.status == "completed" {
+        let Some(idempotency_key) = extract_idempotency_key(request) else {
+            return error_response(400, "Idempotency-Key header is required for completion");
+        };
+        return complete_reminder(correlation_id, user_id, reminder_uuid, &idempotency_key).await;
     }
 
     let client = db::connect().await?;
@@ -189,6 +216,103 @@ pub async fn update_reminder_status(
     );
 
     json_response(200, &row_to_response(&row))
+}
+
+async fn complete_reminder(
+    correlation_id: &str,
+    user_id: Uuid,
+    reminder_id: Uuid,
+    idempotency_key: &str,
+) -> Result<Response<Body>, lambda_http::Error> {
+    let completion_id = derive_completion_id(user_id, reminder_id, idempotency_key);
+    let mut client = db::connect().await?;
+    let transaction = client
+        .transaction()
+        .await
+        .map_err(|event| db_error(&event))?;
+    let inserted = transaction
+        .query_opt(
+            "
+            insert into reminder_completions (id, reminder_id, user_id)
+            select $1, id, user_id
+              from reminder_rules
+             where id = $2 and user_id = $3 and deleted_at is null
+            on conflict (id) do nothing
+            returning id
+            ",
+            &[&completion_id, &reminder_id, &user_id],
+        )
+        .await
+        .map_err(|event| db_error(&event))?;
+
+    let (row, is_replay) = if inserted.is_some() {
+        let row = transaction
+            .query_opt(COMPLETE_REMINDER_SQL, &[&reminder_id, &user_id])
+            .await
+            .map_err(|event| db_error(&event))?;
+        (row, false)
+    } else {
+        let replay = transaction
+            .query_opt(
+                "select id from reminder_completions where id = $1 and reminder_id = $2 and user_id = $3",
+                &[&completion_id, &reminder_id, &user_id],
+            )
+            .await
+            .map_err(|event| db_error(&event))?;
+        if replay.is_none() {
+            return error_response(409, "Idempotency key collision for reminder completion");
+        }
+        let row = transaction
+            .query_opt(SELECT_REMINDER_SQL, &[&reminder_id, &user_id])
+            .await
+            .map_err(|event| db_error(&event))?;
+        (row, true)
+    };
+
+    let Some(row) = row else {
+        return error_response(404, "Reminder not found");
+    };
+    transaction
+        .commit()
+        .await
+        .map_err(|event| db_error(&event))?;
+
+    tracing::info!(
+        correlation_id = correlation_id,
+        user_id = %user_id,
+        reminder_id = %reminder_id,
+        completion_id = %completion_id,
+        idempotency_replay = is_replay,
+        "Recorded deterministic reminder completion"
+    );
+    json_response(200, &row_to_response(&row))
+}
+
+fn derive_completion_id(user_id: Uuid, reminder_id: Uuid, idempotency_key: &str) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(user_id.as_bytes());
+    hasher.update(reminder_id.as_bytes());
+    hasher.update(idempotency_key.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+fn extract_idempotency_key(request: &Request) -> Option<String> {
+    request
+        .headers()
+        .get("idempotency-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn is_valid_reminder_status(status: &str) -> bool {
+    matches!(status, "active" | "paused" | "completed")
 }
 
 fn calculate_next_run_at(
@@ -289,5 +413,33 @@ mod tests {
         let start_date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
         let next = calculate_next_run_at(start_date, 7);
         assert!(next > chrono::Utc::now() - chrono::Duration::days(7));
+    }
+
+    #[test]
+    fn completed_is_a_supported_reminder_action() {
+        assert!(is_valid_reminder_status("completed"));
+        assert!(!is_valid_reminder_status("done"));
+    }
+
+    #[test]
+    fn completion_records_the_run_and_advances_the_schedule() {
+        assert!(COMPLETE_REMINDER_SQL.contains("last_run_at = now()"));
+        assert!(COMPLETE_REMINDER_SQL.contains("greatest(next_run_at, now())"));
+        assert!(COMPLETE_REMINDER_SQL.contains("cadence_days"));
+    }
+
+    #[test]
+    fn completion_id_is_stable_for_retries_and_scoped_to_the_reminder() {
+        let user_id = Uuid::new_v4();
+        let reminder_a = Uuid::new_v4();
+        let reminder_b = Uuid::new_v4();
+        assert_eq!(
+            derive_completion_id(user_id, reminder_a, "retry-key"),
+            derive_completion_id(user_id, reminder_a, "retry-key")
+        );
+        assert_ne!(
+            derive_completion_id(user_id, reminder_a, "retry-key"),
+            derive_completion_id(user_id, reminder_b, "retry-key")
+        );
     }
 }

--- a/services/grn-api/src/api/router.rs
+++ b/services/grn-api/src/api/router.rs
@@ -1,7 +1,7 @@
 use crate::handlers::{
     agent_task, ai_copilot, analytics, annotation, api_key, bed, billing, catalog, claim,
-    claim_read, crop, feed, garden_canvas, garden_review, garden_share, listing, listing_discovery,
-    reminder, request, user,
+    claim_read, crop, feed, garden_canvas, garden_review, garden_share, journal, listing,
+    listing_discovery, reminder, request, user,
 };
 use crate::middleware::correlation::{
     add_correlation_id_to_response, extract_or_generate_correlation_id,
@@ -65,15 +65,7 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
     );
 
     if event.method().as_str() == "OPTIONS" {
-        let response = Response::builder()
-            .status(200)
-            .body(Body::Empty)
-            .map_err(|e| lambda_http::Error::from(e.to_string()))?;
-
-        return Ok(add_correlation_id_to_response(
-            add_cors_headers(response),
-            &correlation_id,
-        ));
+        return cors_preflight_response(&correlation_id);
     }
 
     let response = match (event.method().as_str(), request_path) {
@@ -137,7 +129,15 @@ pub async fn route_request(event: &Request) -> Result<Response<Body>, lambda_htt
         ("POST", "/reminders") => handle(reminder::create_reminder(event, &correlation_id).await)?,
 
         ("GET", "/catalog/crops") => handle(catalog::list_catalog_crops().await)?,
-        _ => route_dynamic_routes(event, &correlation_id, request_path).await?,
+        _ => {
+            if let Some(result) =
+                Box::pin(route_journal_request(event, &correlation_id, request_path)).await
+            {
+                handle(result)?
+            } else {
+                Box::pin(route_dynamic_routes(event, &correlation_id, request_path)).await?
+            }
+        }
     };
 
     let response_with_cors = add_cors_headers(response);
@@ -285,6 +285,40 @@ async fn route_dynamic_routes(
         .map_err(|e| lambda_http::Error::from(e.to_string()))
 }
 
+fn cors_preflight_response(correlation_id: &str) -> Result<Response<Body>, lambda_http::Error> {
+    let response = Response::builder()
+        .status(200)
+        .body(Body::Empty)
+        .map_err(|event| lambda_http::Error::from(event.to_string()))?;
+    Ok(add_correlation_id_to_response(
+        add_cors_headers(response),
+        correlation_id,
+    ))
+}
+
+async fn route_journal_request(
+    event: &Request,
+    correlation_id: &str,
+    request_path: &str,
+) -> Option<Result<Response<Body>, lambda_http::Error>> {
+    let result = match (event.method().as_str(), request_path) {
+        ("GET", "/journal") => Box::pin(journal::list_journal(event, correlation_id)).await,
+        ("POST", "/journal/notes") => journal::create_note(event, correlation_id).await,
+        ("POST", "/journal/photo-upload-url") => {
+            journal::create_photo_upload_url(event, correlation_id).await
+        }
+        (method, path) if path.starts_with("/journal/notes/") => {
+            let note_id = path.trim_start_matches("/journal/notes/");
+            match method {
+                "DELETE" => journal::delete_note(event, correlation_id, note_id).await,
+                _ => method_not_allowed(),
+            }
+        }
+        _ => return None,
+    };
+    Some(result)
+}
+
 async fn route_api_key_request(
     event: &Request,
     correlation_id: &str,
@@ -426,6 +460,15 @@ fn is_garden_designer_validation_message(message: &str) -> bool {
         || message.contains("contentLength must be")
 }
 
+fn is_journal_validation_message(message: &str) -> bool {
+    message.contains("season must be")
+        || message.contains("occurredOn")
+        || message.contains("body must be")
+        || message.contains("photoKey must")
+        || message.contains("noteId must")
+        || message.contains("Idempotency-Key header is required")
+}
+
 fn map_api_error_to_response(
     error: &lambda_http::Error,
 ) -> Result<Response<Body>, lambda_http::Error> {
@@ -434,6 +477,7 @@ fn map_api_error_to_response(
     if message.contains("Invalid JSON body")
         || message.contains("must be a valid UUID")
         || message.contains("Invalid status")
+        || message.contains("status must be")
         || message.contains("Invalid claim status")
         || message.contains("Invalid claim transition")
         || message.contains("Invalid visibility")
@@ -485,17 +529,19 @@ fn map_api_error_to_response(
         || message.contains("Listing is not claimable")
         || message.contains("requestId must reference an open request")
         || message.contains("requestId crop must match listing crop")
+        || is_journal_validation_message(&message)
     {
         return crop::error_response(400, &message);
     }
 
-    if message.contains("Insufficient quantity remaining") {
+    if message.contains("Insufficient quantity remaining") || message.contains("Idempotency key") {
         return crop::error_response(409, &message);
     }
 
     if message.contains("Request not found")
         || message.contains("Claim not found")
         || message.contains("Listing not found")
+        || message.contains("Journal note not found")
     {
         return crop::error_response(404, &message);
     }
@@ -655,6 +701,22 @@ mod tests {
     #[test]
     fn map_api_error_maps_insufficient_quantity_to_409() {
         let error = lambda_http::Error::from("Insufficient quantity remaining".to_string());
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 409);
+    }
+
+    #[test]
+    fn map_api_error_maps_journal_validation_to_400() {
+        let error = lambda_http::Error::from("season must be a year from 2000 to 2100".to_string());
+        let response = map_api_error_to_response(&error).unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+    }
+
+    #[test]
+    fn map_api_error_maps_idempotency_collision_to_409() {
+        let error = lambda_http::Error::from(
+            "Idempotency key collision for reminder completion".to_string(),
+        );
         let response = map_api_error_to_response(&error).unwrap();
         assert_eq!(response.status().as_u16(), 409);
     }

--- a/services/grn-api/template.yaml
+++ b/services/grn-api/template.yaml
@@ -346,6 +346,17 @@ Resources:
               Resource: !Sub
                 - '${SharedAssetsBucketArn}/garden-backgrounds/*'
                 - SharedAssetsBucketArn: !ImportValue OGF-AssetsBucketArn
+            # Journal photos are private application records. The API issues
+            # short-lived signed PUT/GET URLs and deletes the object when its
+            # owning note is removed.
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+                - s3:GetObject
+                - s3:DeleteObject
+              Resource: !Sub
+                - '${SharedAssetsBucketArn}/journal-photos/*'
+                - SharedAssetsBucketArn: !ImportValue OGF-AssetsBucketArn
       Environment:
         Variables:
           DATABASE_URL: !Ref DatabaseUrl


### PR DESCRIPTION
## Summary
- add a private, season-scoped Garden Journal assembled from planting, bed, harvest, reminder-completion, and completed-share records
- add optional idempotent notes and owner-scoped photo uploads without duplicating existing transactional activity
- record immutable reminder-completion facts so retries are safe and every completion remains available for journal rebuilds
- add source deep links, explicit empty/offline/loading/failure states, factual non-competitive impact summaries, and multi-season navigation
- add Postman contracts for journal reads/writes/photo validation and reminder completion replay

## Verification
- `npm run lint` (apps/grn)
- `npm run test` (apps/grn): 584 passed
- `npm run build` (apps/grn)
- `npm run perf:budget` (apps/grn)
- `cargo clippy --bin api --all-targets -- -D warnings`
- `cargo test --all-targets`
- `sam validate -t template.yaml`
- `git diff --check`

The new Postman contracts require the branch API deployment and will run in the staging validation workflow.

Closes #377