### PR TITLE
feat(grn): streamline custom crop sharing

### DIFF
--- a/apps/grn/src/components/CropPlanner/CropForm.test.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CropForm } from './CropForm';
+import { createMyCrop, listCatalogCrops, listMyBeds } from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  createMyBed: vi.fn(),
+  createMyCrop: vi.fn(),
+  listCatalogCrops: vi.fn(),
+  listMyBeds: vi.fn(),
+}));
+
+vi.mock('../../hooks/useGrowerCropSignals', () => ({
+  useGrowerCropSignals: () => ({
+    geoKey: null,
+    scarcityByCropId: new Map(),
+    scarceCropIds: new Set(),
+    topScarce: [],
+    growingCatalogCropIds: new Set(),
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+describe('CropForm user-defined crops', () => {
+  it('creates a custom crop without a catalog identifier', async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    const createdCrop = {
+      id: 'grower-custom-1',
+      userId: 'grower-1',
+      canonicalId: null,
+      cropName: 'Purple yard bean',
+      varietyId: null,
+      status: 'planning' as const,
+      visibility: 'local' as const,
+      surplusEnabled: false,
+      nickname: null,
+      defaultUnit: null,
+      notes: null,
+      bedId: null,
+      bedName: null,
+      plantingDate: null,
+      expectedHarvestDate: null,
+      plantCount: null,
+      spacingInches: null,
+      pyramidTier: null,
+      createdAt: '2026-07-15T00:00:00Z',
+      updatedAt: '2026-07-15T00:00:00Z',
+    };
+
+    vi.mocked(listCatalogCrops).mockResolvedValue([]);
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(createMyCrop).mockResolvedValue(createdCrop);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CropForm onSuccess={onSuccess} onCancel={vi.fn()} />
+      </QueryClientProvider>
+    );
+
+    const picker = await screen.findByRole('combobox', { name: /what are you growing/i });
+    await waitFor(() => expect(picker).not.toBeDisabled());
+    await user.type(picker, 'Purple yard bean');
+    await user.click(
+      await screen.findByRole('option', {
+        name: /add .*purple yard bean.* as a custom crop/i,
+      })
+    );
+    await user.click(screen.getByRole('button', { name: /add to my garden/i }));
+
+    await waitFor(() => expect(createMyCrop).toHaveBeenCalledTimes(1));
+    expect(createMyCrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canonicalId: undefined,
+        cropName: 'Purple yard bean',
+        status: 'planning',
+      }),
+      expect.anything()
+    );
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(createdCrop));
+  });
+});

--- a/apps/grn/src/components/Listings/ListingForm.test.tsx
+++ b/apps/grn/src/components/Listings/ListingForm.test.tsx
@@ -74,9 +74,107 @@ describe('ListingForm', () => {
     await user.selectOptions(screen.getByLabelText(/share something you already grow/i), 'grower-crop-1');
 
     expect(screen.getByLabelText(/share title/i)).toHaveValue('Patio Tomatoes');
-    expect(screen.getByLabelText(/crop/i)).toHaveValue('crop-1');
+    expect(screen.getByText('Catalog-linked crop')).toBeInTheDocument();
+    expect(screen.getByText(/linked to tomato in the crop catalog/i)).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /^crop/i })).not.toBeInTheDocument();
     expect(screen.getByLabelText(/unit/i)).toHaveValue('kg');
     expect(onCropChange).toHaveBeenCalledWith('crop-1');
+  });
+
+  it('submits a saved custom crop without asking for a catalog crop', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ListingForm
+        mode="create"
+        crops={crops}
+        varieties={[]}
+        quickPickOptions={[
+          {
+            id: 'grower-custom-1',
+            label: 'Back fence squash',
+            cropId: '',
+            growerCropId: 'grower-custom-1',
+            defaultUnit: 'item',
+            suggestedTitle: 'Back fence squash',
+          },
+        ]}
+        defaultLat={37.7}
+        defaultLng={-122.4}
+        isLoadingVarieties={false}
+        isSubmitting={false}
+        isOffline={false}
+        submitError={null}
+        onCropChange={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.selectOptions(
+      screen.getByLabelText(/share something you already grow/i),
+      'grower-custom-1'
+    );
+
+    expect(screen.getByText('Saved custom crop')).toBeInTheDocument();
+    expect(screen.getByText(/no catalog crop selection is needed/i)).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /^crop/i })).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/quantity/i), '3');
+    await user.click(screen.getByRole('button', { name: /review share/i }));
+    await user.click(screen.getByRole('button', { name: /confirm and share/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Back fence squash',
+        cropId: undefined,
+        growerCropId: 'grower-custom-1',
+        quantityTotal: 3,
+        unit: 'item',
+      })
+    );
+  });
+
+  it('requires a catalog crop after clearing a saved custom crop', async () => {
+    const user = userEvent.setup();
+    const onCropChange = vi.fn();
+
+    render(
+      <ListingForm
+        mode="create"
+        crops={crops}
+        varieties={[]}
+        quickPickOptions={[
+          {
+            id: 'grower-custom-1',
+            label: 'Back fence squash',
+            cropId: '',
+            growerCropId: 'grower-custom-1',
+            suggestedTitle: 'Back fence squash',
+          },
+        ]}
+        defaultLat={37.7}
+        defaultLng={-122.4}
+        isLoadingVarieties={false}
+        isSubmitting={false}
+        isOffline={false}
+        submitError={null}
+        onCropChange={onCropChange}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const quickPick = screen.getByLabelText(/share something you already grow/i);
+    await user.selectOptions(quickPick, 'grower-custom-1');
+    await user.selectOptions(quickPick, '');
+
+    expect(screen.getByRole('combobox', { name: /^crop/i })).toBeInTheDocument();
+    expect(onCropChange).toHaveBeenLastCalledWith('');
+
+    await user.type(screen.getByLabelText(/quantity/i), '3');
+    await user.click(screen.getByRole('button', { name: /review share/i }));
+    expect(await screen.findByText(/crop is required/i)).toBeInTheDocument();
   });
 
   it('prefills an editable draft from a saved harvest', async () => {

--- a/apps/grn/src/components/Listings/ListingForm.tsx
+++ b/apps/grn/src/components/Listings/ListingForm.tsx
@@ -11,7 +11,7 @@ export interface ListingQuickPickOption {
   id: string;
   label: string;
   cropId: string;
-  growerCropId?: string;  // For user-defined crops
+  growerCropId?: string;
   varietyId?: string;
   defaultUnit?: string;
   suggestedTitle: string;
@@ -173,6 +173,13 @@ export function ListingForm({
   }, [mode, initialListing, defaultLat, defaultLng, prefilledQuickPick, prefill]);
 
   const [formState, setFormState] = useState<ListingFormState>(initialState);
+  const selectedQuickPick = selectedQuickPickId
+    ? quickPickOptions.find((option) => option.id === selectedQuickPickId)
+    : undefined;
+  const selectedQuickPickIsCustom = selectedQuickPick?.cropId === '';
+  const selectedCatalogCropName = selectedQuickPick?.cropId
+    ? crops.find((crop) => crop.id === selectedQuickPick.cropId)?.commonName
+    : undefined;
 
   const validateForm = (): boolean => {
     const nextErrors: ListingFormErrors = {};
@@ -230,6 +237,13 @@ export function ListingForm({
     setSelectedQuickPickId(quickPickId);
 
     if (!quickPickId) {
+      setFormState((current) => ({
+        ...current,
+        cropId: '',
+        growerCropId: '',
+        varietyId: '',
+      }));
+      onCropChange('');
       return;
     }
 
@@ -241,8 +255,8 @@ export function ListingForm({
     setFormState((current) => ({
       ...current,
       title: selected.suggestedTitle,
-      cropId: selected.cropId || '',  // Empty for user-defined crops
-      growerCropId: selected.growerCropId || selected.id,  // Use growerCropId if available, otherwise the option id
+      cropId: selected.cropId || '',
+      growerCropId: selected.growerCropId || selected.id,
       varietyId: selected.varietyId ?? '',
       unit: selected.defaultUnit ?? current.unit,
     }));
@@ -278,8 +292,8 @@ export function ListingForm({
 
     const request: UpsertListingRequest = {
       title: formState.title.trim(),
-      cropId: formState.cropId || undefined,  // Only include if we have a catalog crop
-      growerCropId: formState.growerCropId || undefined,  // Include for user-defined crops
+      cropId: formState.cropId || undefined,
+      growerCropId: formState.growerCropId || undefined,
       quantityTotal: Number(formState.quantityTotal),
       unit: formState.unit,
       availableStart: new Date(formState.availableStart).toISOString(),
@@ -326,8 +340,29 @@ export function ListingForm({
             ))}
           </select>
           {!isLoadingQuickPicks && quickPickOptions.length === 0 && (
-            <p className="text-sm text-neutral-600">No saved grower crops yet. Fill the form manually below.</p>
+            <p className="text-sm text-neutral-600">
+              No saved crops yet. Choose a catalog crop below, or add a custom crop from Garden.
+            </p>
           )}
+          {selectedQuickPick ? (
+            <div
+              className="mt-2 rounded-base border border-primary-200 bg-primary-50 px-3 py-3 text-sm text-neutral-800"
+              role="status"
+              aria-live="polite"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <strong>{selectedQuickPick.label}</strong>
+                <span className="font-semibold text-primary-800">
+                  {selectedQuickPickIsCustom ? 'Saved custom crop' : 'Catalog-linked crop'}
+                </span>
+              </div>
+              <p className="mt-1 text-neutral-700">
+                {selectedQuickPickIsCustom
+                  ? 'This crop came from your garden. No catalog crop selection is needed.'
+                  : `Linked to ${selectedCatalogCropName ?? selectedQuickPick.label} in the crop catalog.`}
+              </p>
+            </div>
+          ) : null}
           {prefill?.sourceLabel ? (
             <p className="rounded-base border border-primary-200 bg-primary-50 px-3 py-2 text-sm text-primary-800" role="status">
               Prefilled from {prefill.sourceLabel}. Review every field before sharing.
@@ -350,67 +385,71 @@ export function ListingForm({
         error={errors.title}
       />
 
-      <div className="space-y-1">
-        <label htmlFor="crop-select" className="text-sm font-medium text-neutral-700">
-          Crop<span className="text-error ml-1" aria-label="required">*</span>
-        </label>
-        <select
-          id="crop-select"
-          value={formState.cropId}
-          onChange={(event) => {
-            const nextCrop = event.target.value;
-            setFormState((current) => ({
-              ...current,
-              cropId: nextCrop,
-              varietyId: '',
-            }));
-            onCropChange(nextCrop);
-            if (errors.cropId) {
-              setErrors((current) => ({ ...current, cropId: undefined }));
-            }
-          }}
-          className="w-full rounded-base border-2 border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
-          aria-invalid={!!errors.cropId}
-          aria-describedby={errors.cropId ? 'crop-select-error' : undefined}
-          required
-        >
-          <option value="">Select a crop</option>
-          {crops.map((crop) => (
-            <option key={crop.id} value={crop.id}>
-              {crop.commonName}
-            </option>
-          ))}
-        </select>
-        {errors.cropId && (
-          <p id="crop-select-error" className="text-sm text-error" role="alert">
-            {errors.cropId}
-          </p>
-        )}
-      </div>
+      {!selectedQuickPick ? (
+        <>
+          <div className="space-y-1">
+            <label htmlFor="crop-select" className="text-sm font-medium text-neutral-700">
+              Crop<span className="text-error ml-1" aria-label="required">*</span>
+            </label>
+            <select
+              id="crop-select"
+              value={formState.cropId}
+              onChange={(event) => {
+                const nextCrop = event.target.value;
+                setFormState((current) => ({
+                  ...current,
+                  cropId: nextCrop,
+                  varietyId: '',
+                }));
+                onCropChange(nextCrop);
+                if (errors.cropId) {
+                  setErrors((current) => ({ ...current, cropId: undefined }));
+                }
+              }}
+              className="w-full rounded-base border-2 border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              aria-invalid={!!errors.cropId}
+              aria-describedby={errors.cropId ? 'crop-select-error' : undefined}
+              required
+            >
+              <option value="">Select a crop</option>
+              {crops.map((crop) => (
+                <option key={crop.id} value={crop.id}>
+                  {crop.commonName}
+                </option>
+              ))}
+            </select>
+            {errors.cropId && (
+              <p id="crop-select-error" className="text-sm text-error" role="alert">
+                {errors.cropId}
+              </p>
+            )}
+          </div>
 
-      <div className="space-y-1">
-        <label htmlFor="variety-select" className="text-sm font-medium text-neutral-700">
-          Variety (optional)
-        </label>
-        <select
-          id="variety-select"
-          value={formState.varietyId}
-          onChange={(event) => {
-            setFormState((current) => ({ ...current, varietyId: event.target.value }));
-          }}
-          className="w-full rounded-base border-2 border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
-          disabled={!formState.cropId || isLoadingVarieties}
-        >
-          <option value="">
-            {isLoadingVarieties ? 'Loading varieties...' : 'No variety selected'}
-          </option>
-          {varieties.map((variety) => (
-            <option key={variety.id} value={variety.id}>
-              {variety.name}
-            </option>
-          ))}
-        </select>
-      </div>
+          <div className="space-y-1">
+            <label htmlFor="variety-select" className="text-sm font-medium text-neutral-700">
+              Variety (optional)
+            </label>
+            <select
+              id="variety-select"
+              value={formState.varietyId}
+              onChange={(event) => {
+                setFormState((current) => ({ ...current, varietyId: event.target.value }));
+              }}
+              className="w-full rounded-base border-2 border-neutral-300 bg-white px-4 py-2 text-base text-neutral-800 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              disabled={!formState.cropId || isLoadingVarieties}
+            >
+              <option value="">
+                {isLoadingVarieties ? 'Loading varieties...' : 'No variety selected'}
+              </option>
+              {varieties.map((variety) => (
+                <option key={variety.id} value={variety.id}>
+                  {variety.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      ) : null}
 
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">

--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -88,12 +88,12 @@ describe('CropLibraryPanel deep links', () => {
     expect(await screen.findByRole('dialog')).toHaveAttribute('data-highlighted-harvest', 'h1');
   });
 
-  it('changes a crop bed optimistically through the shared crop query', async () => {
-    const tomato = {
+  it('edits a user-defined crop without adding a catalog link', async () => {
+    const customCrop = {
       id: 'crop-1',
       userId: 'grower-1',
       canonicalId: null,
-      cropName: 'Tomato',
+      cropName: 'Purple yard bean',
       varietyId: null,
       status: 'growing',
       visibility: 'private',
@@ -134,15 +134,15 @@ describe('CropLibraryPanel deep links', () => {
         updatedAt: '2026-07-01T00:00:00Z',
       },
     ]);
-    const updatedTomato = {
-      ...tomato,
+    const updatedCustomCrop = {
+      ...customCrop,
       bedId: 'bed-1',
       bedName: 'Kitchen bed',
     };
     vi.mocked(listMyCrops)
-      .mockResolvedValueOnce([tomato])
-      .mockResolvedValue([updatedTomato]);
-    vi.mocked(updateMyCrop).mockResolvedValue(updatedTomato);
+      .mockResolvedValueOnce([customCrop])
+      .mockResolvedValue([updatedCustomCrop]);
+    vi.mocked(updateMyCrop).mockResolvedValue(updatedCustomCrop);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
     render(
@@ -154,17 +154,21 @@ describe('CropLibraryPanel deep links', () => {
     );
 
     await userEvent.selectOptions(
-      await screen.findByRole('combobox', { name: 'Bed assignment for Tomato' }),
+      await screen.findByRole('combobox', { name: 'Bed assignment for Purple yard bean' }),
       'bed-1'
     );
 
-    expect(screen.getByRole('combobox', { name: 'Bed assignment for Tomato' })).toHaveValue(
-      'bed-1'
-    );
+    expect(
+      screen.getByRole('combobox', { name: 'Bed assignment for Purple yard bean' })
+    ).toHaveValue('bed-1');
     await waitFor(() =>
       expect(updateMyCrop).toHaveBeenCalledWith(
         'crop-1',
-        expect.objectContaining({ cropName: 'Tomato', bedId: 'bed-1' })
+        expect.objectContaining({
+          canonicalId: undefined,
+          cropName: 'Purple yard bean',
+          bedId: 'bed-1',
+        })
       )
     );
   });


### PR DESCRIPTION
## Summary
- make saved custom crops a first-class quick-pick when creating a food listing
- clearly distinguish saved custom crops from catalog-linked crops and remove redundant catalog fields after selection
- clear stale crop identifiers when returning to manual entry
- add focused coverage for custom-crop creation, editing, quick-pick submission, and keyboard-accessible clearing

## Why
Growers could select a valid user-defined crop, but the form still presented a required catalog crop field. That made the mobile flow feel contradictory and risked stale crop state when switching paths.

## Impact
Custom crops saved in Garden can now be shared without a catalog crop ID. Catalog-linked quick picks retain their catalog association, and manual entry becomes required again when the quick pick is cleared.

## Checks
- `npm run lint` (apps/grn)
- `npm run typecheck` (apps/grn)
- `npm test` (apps/grn): 70 files, 587 tests
- `npm run build` (apps/grn)
- `npm run perf:budget` (apps/grn)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`
- `cargo test --bins --all-features`: 254 tests

## Validation notes
- Postman tests were not run because no API endpoint or contract changed.
- `cargo fmt --all -- --check` is locally blocked by Git for Windows translating untouched Rust files to CRLF. No backend files changed; please rely on the Linux check if backend paths are evaluated, or advise if an additional LF-only validation is desired before merge.

Closes #203