### PR TITLE
test(grn): cover custom crop listing lifecycle

### DIFF
--- a/.github/workflows/pull-request-staging-validation-reusable.yml
+++ b/.github/workflows/pull-request-staging-validation-reusable.yml
@@ -1190,7 +1190,10 @@ jobs:
   postman-api-tests:
     name: GRN Staging Postman Validation
     runs-on: ubuntu-latest
-    needs: [deploy-staging-backend, deploy-staging-frontend, staging-public-api-smoke]
+    # These suites exercise the API directly. Keeping them independent from
+    # the frontend deploy lets backend-only and Postman-only PRs run instead
+    # of being skipped when the frontend job is intentionally skipped.
+    needs: [deploy-staging-backend, staging-public-api-smoke]
     if: inputs.shared_all == 'true' || inputs.grn_backend == 'true' || inputs.grn_frontend == 'true'
     env:
       AWS_REGION: us-east-1

--- a/postman/collections/Good Roots Network API - E2E Flows/.resources/definition.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/.resources/definition.yaml
@@ -43,6 +43,15 @@ variables:
   - key: reminderId
     value: ''
     description: Reminder ID for consistency checks
+  - key: customCropE2eId
+    value: ''
+    description: User-defined crop ID captured by the custom-crop listing flow
+  - key: customCropE2eListingId
+    value: ''
+    description: Listing ID captured by the custom-crop listing flow
+  - key: customCropE2eListingGeoKey
+    value: ''
+    description: Listing geohash captured for custom-crop discovery verification
 auth:
   type: bearer
   credentials:

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/.resources/definition.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/.resources/definition.yaml
@@ -1,0 +1,4 @@
+$kind: collection
+name: Custom Crop Listing
+description: User-defined crop CRUD, custom-crop-backed listing discovery, and repeatable cleanup.
+order: 3000

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 0 - Initialize Custom Crop Flow.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 0 - Initialize Custom Crop Flow.request.yaml
@@ -1,0 +1,46 @@
+$kind: http-request
+name: 'Step 0 - Initialize Custom Crop Flow'
+description: |-
+  Initializes the authenticated grower and run-scoped values used by the
+  custom-crop CRUD and listing flow.
+method: GET
+url: '{{baseUrl}}/me'
+order: 500
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const growerToken = pm.variables.get("growerAuthToken");
+      if (!growerToken) {
+          console.error("growerAuthToken not set; aborting custom-crop flow.");
+          pm.execution.setNextRequest(null);
+      } else {
+          pm.collectionVariables.set("authToken", growerToken);
+      }
+
+      if (growerToken) {
+          [
+              "customCropE2eId",
+              "customCropE2eListingId",
+              "customCropE2eListingGeoKey"
+          ].forEach((key) => pm.collectionVariables.unset(key));
+
+          const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+          const now = Date.now();
+          pm.collectionVariables.set("customCropE2eRunId", runId);
+          pm.collectionVariables.set("customCropE2eName", `Purple yard bean ${runId}`);
+          pm.collectionVariables.set("customCropE2eNickname", `Trellis favorite ${runId}`);
+          pm.collectionVariables.set("customCropE2eListingTitle", `Custom crop share ${runId}`);
+          pm.collectionVariables.set("customCropE2eIdempotencyKey", `custom-crop-e2e-${runId}`);
+          pm.collectionVariables.set("customCropE2eAvailableStart", new Date(now - 300000).toISOString());
+          pm.collectionVariables.set("customCropE2eAvailableEnd", new Date(now + 172800000).toISOString());
+      }
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 1 - Create Custom Crop.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 1 - Create Custom Crop.request.yaml
@@ -1,0 +1,53 @@
+$kind: http-request
+name: 'Step 1 - Create Custom Crop'
+description: |-
+  Creates a user-defined crop with a free-text name and no catalog link.
+
+  **Chaining**: Captures `customCropE2eId` for the remaining flow.
+method: POST
+url: '{{baseUrl}}/crops'
+order: 1000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+body:
+  type: json
+  content: |-
+    {
+      "crop_name": "{{customCropE2eName}}",
+      "status": "planning",
+      "visibility": "local",
+      "surplus_enabled": false,
+      "nickname": "{{customCropE2eNickname}}",
+      "default_unit": "bunch",
+      "notes": "Custom crop E2E create"
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+
+      pm.test("Created crop is user-defined and preserves its name", function () {
+          const crop = pm.response.json();
+          pm.expect(crop).to.have.property("id");
+          pm.expect(crop).to.have.property("canonical_id", null);
+          pm.expect(crop).to.have.property("crop_id", null);
+          pm.expect(crop).to.have.property("crop_name", pm.collectionVariables.get("customCropE2eName"));
+          pm.expect(crop).to.have.property("status", "planning");
+          pm.expect(crop).to.have.property("surplus_enabled", false);
+      });
+
+      if (pm.response.code === 201) {
+          const crop = pm.response.json();
+          if (!crop.id) {
+              pm.expect.fail("Missing crop.id; aborting custom-crop flow.");
+              pm.execution.setNextRequest(null);
+          } else {
+              pm.collectionVariables.set("customCropE2eId", crop.id);
+          }
+      }

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 10 - Verify Custom Crop Deleted.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 10 - Verify Custom Crop Deleted.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+name: 'Step 10 - Verify Custom Crop Deleted'
+description: Confirms cleanup removed the custom crop and clears run-scoped variables.
+method: GET
+url: '{{baseUrl}}/crops/:cropLibraryId'
+order: 10000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+pathVariables:
+  - key: cropLibraryId
+    value: '{{customCropE2eId}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 404", function () {
+          pm.response.to.have.status(404);
+      });
+
+      [
+          "customCropE2eId",
+          "customCropE2eListingId",
+          "customCropE2eListingGeoKey",
+          "customCropE2eRunId",
+          "customCropE2eName",
+          "customCropE2eNickname",
+          "customCropE2eListingTitle",
+          "customCropE2eIdempotencyKey",
+          "customCropE2eAvailableStart",
+          "customCropE2eAvailableEnd"
+      ].forEach((key) => pm.collectionVariables.unset(key));

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 2 - Get Custom Crop.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 2 - Get Custom Crop.request.yaml
@@ -1,0 +1,40 @@
+$kind: http-request
+name: 'Step 2 - Get Custom Crop'
+description: Reads the newly created user-defined crop back by ID.
+method: GET
+url: '{{baseUrl}}/crops/:cropLibraryId'
+order: 2000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+pathVariables:
+  - key: cropLibraryId
+    value: '{{customCropE2eId}}'
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const cropId = pm.collectionVariables.get("customCropE2eId");
+      const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      pm.test("customCropE2eId is a valid UUID", function () {
+          pm.expect(cropId).to.be.a("string");
+          pm.expect(cropId).to.match(uuidRe);
+      });
+      if (!cropId || !uuidRe.test(cropId)) {
+          pm.execution.setNextRequest(null);
+      }
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Detail read matches the custom crop write", function () {
+          const crop = pm.response.json();
+          pm.expect(crop).to.have.property("id", pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(crop).to.have.property("canonical_id", null);
+          pm.expect(crop).to.have.property("crop_name", pm.collectionVariables.get("customCropE2eName"));
+          pm.expect(crop).to.have.property("total_harvested");
+          pm.expect(crop).to.have.property("harvest_count");
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 3 - Update Custom Crop.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 3 - Update Custom Crop.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+name: 'Step 3 - Update Custom Crop'
+description: Updates the user-defined crop without introducing a catalog link.
+method: PUT
+url: '{{baseUrl}}/crops/:cropLibraryId'
+order: 3000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+pathVariables:
+  - key: cropLibraryId
+    value: '{{customCropE2eId}}'
+body:
+  type: json
+  content: |-
+    {
+      "crop_name": "{{customCropE2eName}}",
+      "status": "growing",
+      "visibility": "local",
+      "surplus_enabled": true,
+      "nickname": "{{customCropE2eNickname}}",
+      "default_unit": "bunch",
+      "notes": "Custom crop E2E update"
+    }
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Updated custom crop remains unlinked", function () {
+          const crop = pm.response.json();
+          pm.expect(crop).to.have.property("id", pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(crop).to.have.property("canonical_id", null);
+          pm.expect(crop).to.have.property("crop_name", pm.collectionVariables.get("customCropE2eName"));
+          pm.expect(crop).to.have.property("nickname", pm.collectionVariables.get("customCropE2eNickname"));
+          pm.expect(crop).to.have.property("status", "growing");
+          pm.expect(crop).to.have.property("surplus_enabled", true);
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 4 - Verify Custom Crop in List.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 4 - Verify Custom Crop in List.request.yaml
@@ -1,0 +1,27 @@
+$kind: http-request
+name: 'Step 4 - Verify Custom Crop in List'
+description: Verifies read-your-write behavior through the crop-library list endpoint.
+method: GET
+url: '{{baseUrl}}/crops'
+order: 4000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Updated custom crop appears in the library list", function () {
+          const body = pm.response.json();
+          const items = Array.isArray(body) ? body : (body.items || []);
+          const crop = items.find((item) => item.id === pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(crop, "Custom crop not found in crop-library list").to.not.be.undefined;
+          pm.expect(crop.canonical_id).to.be.null;
+          pm.expect(crop.crop_name).to.eql(pm.collectionVariables.get("customCropE2eName"));
+          pm.expect(crop.nickname).to.eql(pm.collectionVariables.get("customCropE2eNickname"));
+          pm.expect(crop.status).to.eql("growing");
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 5 - Create Custom Crop Listing.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 5 - Create Custom Crop Listing.request.yaml
@@ -1,0 +1,68 @@
+$kind: http-request
+name: 'Step 5 - Create Custom Crop Listing'
+description: |-
+  Creates a listing using only `growerCropId`; no catalog crop is supplied.
+
+  **Chaining**: Captures the listing ID and geohash for read and discovery checks.
+method: POST
+url: '{{baseUrl}}/listings'
+order: 5000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+  - key: Idempotency-Key
+    value: '{{customCropE2eIdempotencyKey}}'
+body:
+  type: json
+  content: |-
+    {
+      "title": "{{customCropE2eListingTitle}}",
+      "growerCropId": "{{customCropE2eId}}",
+      "quantityTotal": 3,
+      "unit": "bunch",
+      "availableStart": "{{customCropE2eAvailableStart}}",
+      "availableEnd": "{{customCropE2eAvailableEnd}}",
+      "pickupLocationText": "Front porch",
+      "pickupAddress": "1100 Congress Ave, Austin, TX 78701",
+      "pickupDisclosurePolicy": "after_confirmed",
+      "pickupNotes": "Custom crop E2E share",
+      "contactPref": "app_message",
+      "status": "active"
+    }
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const cropId = pm.collectionVariables.get("customCropE2eId");
+      pm.test("custom crop is available for listing creation", function () {
+          pm.expect(cropId).to.be.a("string").and.not.empty;
+      });
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 201", function () {
+          pm.response.to.have.status(201);
+      });
+
+      pm.test("Listing response preserves the custom-crop link", function () {
+          const listing = pm.response.json();
+          pm.expect(listing).to.have.property("id");
+          pm.expect(listing).to.have.property("growerCropId", pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(listing).to.have.property("cropId", null);
+          pm.expect(listing).to.have.property("title", pm.collectionVariables.get("customCropE2eListingTitle"));
+          pm.expect(listing).to.have.property("status", "active");
+          pm.expect(listing).to.have.property("geoKey").that.is.a("string").and.not.empty;
+      });
+
+      if (pm.response.code === 201) {
+          const listing = pm.response.json();
+          if (!listing.id || !listing.geoKey) {
+              pm.expect.fail("Missing listing id or geoKey; aborting custom-crop flow.");
+              pm.execution.setNextRequest(null);
+          } else {
+              pm.collectionVariables.set("customCropE2eListingId", listing.id);
+              pm.collectionVariables.set("customCropE2eListingGeoKey", listing.geoKey);
+          }
+      }

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 6 - Verify Custom Listing Detail.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 6 - Verify Custom Listing Detail.request.yaml
@@ -1,0 +1,27 @@
+$kind: http-request
+name: 'Step 6 - Verify Custom Listing Detail'
+description: Verifies the custom-crop link through the owner listing read endpoint.
+method: GET
+url: '{{baseUrl}}/my/listings/:listingId'
+order: 6000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+pathVariables:
+  - key: listingId
+    value: '{{customCropE2eListingId}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Owner read preserves the custom-crop link", function () {
+          const listing = pm.response.json();
+          pm.expect(listing).to.have.property("id", pm.collectionVariables.get("customCropE2eListingId"));
+          pm.expect(listing).to.have.property("growerCropId", pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(listing).to.have.property("cropId", null);
+          pm.expect(listing).to.have.property("title", pm.collectionVariables.get("customCropE2eListingTitle"));
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 7 - Verify Custom Listing Discovery.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 7 - Verify Custom Listing Discovery.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+name: 'Step 7 - Verify Custom Listing Discovery'
+description: Verifies downstream discovery returns the custom-crop-backed listing intact.
+method: GET
+url: '{{baseUrl}}/listings/discover'
+order: 7000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+queryParams:
+  - key: geoKey
+    value: '{{customCropE2eListingGeoKey}}'
+  - key: status
+    value: active
+  - key: limit
+    value: '100'
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      const geoKey = pm.collectionVariables.get("customCropE2eListingGeoKey");
+      if (!geoKey) {
+          console.error("customCropE2eListingGeoKey not set; aborting custom-crop flow.");
+          pm.execution.setNextRequest(null);
+      }
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Discovery returns the custom-crop-backed listing", function () {
+          const body = pm.response.json();
+          pm.expect(body).to.have.property("items").that.is.an("array");
+          const listing = body.items.find((item) => item.id === pm.collectionVariables.get("customCropE2eListingId"));
+          pm.expect(listing, "Custom-crop listing not found in discovery").to.not.be.undefined;
+          pm.expect(listing.growerCropId).to.eql(pm.collectionVariables.get("customCropE2eId"));
+          pm.expect(listing.cropId).to.be.null;
+          pm.expect(listing.title).to.eql(pm.collectionVariables.get("customCropE2eListingTitle"));
+      });

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 8 - Cleanup Expire and Detach Listing.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 8 - Cleanup Expire and Detach Listing.request.yaml
@@ -1,0 +1,66 @@
+$kind: http-request
+name: 'Step 8 - Cleanup Expire and Detach Listing'
+description: |-
+  Removes the listing from active discovery and replaces its custom-crop link
+  with a catalog link so the temporary custom crop can be deleted safely.
+method: PUT
+url: '{{baseUrl}}/listings/:listingId'
+order: 8000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+  - key: Content-Type
+    value: application/json
+pathVariables:
+  - key: listingId
+    value: '{{customCropE2eListingId}}'
+body:
+  type: json
+  content: |-
+    {
+      "title": "{{customCropE2eListingTitle}} cleanup",
+      "cropId": "{{catalogCropId}}",
+      "quantityTotal": 3,
+      "unit": "bunch",
+      "availableStart": "{{customCropE2eAvailableStart}}",
+      "availableEnd": "{{customCropE2eAvailableEnd}}",
+      "pickupLocationText": "Front porch",
+      "pickupAddress": "1100 Congress Ave, Austin, TX 78701",
+      "pickupDisclosurePolicy": "after_confirmed",
+      "pickupNotes": "Expired by custom crop E2E cleanup",
+      "contactPref": "app_message",
+      "status": "expired"
+    }
+scripts:
+  - type: beforeRequest
+    language: text/javascript
+    code: |-
+      let cropId = pm.collectionVariables.get("catalogCropId");
+      const fallbackCropId = pm.collectionVariables.get("defaultCatalogCropId");
+      const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      if ((!cropId || !uuidRe.test(cropId)) && fallbackCropId && uuidRe.test(fallbackCropId)) {
+          cropId = fallbackCropId;
+          pm.collectionVariables.set("catalogCropId", cropId);
+      }
+      pm.test("catalogCropId is available for cleanup", function () {
+          pm.expect(cropId).to.be.a("string");
+          pm.expect(cropId).to.match(uuidRe);
+      });
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 200", function () {
+          pm.response.to.have.status(200);
+      });
+
+      pm.test("Cleanup expires and detaches the custom-crop listing", function () {
+          const listing = pm.response.json();
+          pm.expect(listing).to.have.property("id", pm.collectionVariables.get("customCropE2eListingId"));
+          pm.expect(listing).to.have.property("status", "expired");
+          pm.expect(listing).to.have.property("cropId", pm.collectionVariables.get("catalogCropId"));
+          pm.expect(listing).to.have.property("growerCropId", null);
+      });
+
+      if (pm.response.code !== 200) {
+          pm.execution.setNextRequest(null);
+      }

--- a/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 9 - Cleanup Delete Custom Crop.request.yaml
+++ b/postman/collections/Good Roots Network API - E2E Flows/Custom Crop Listing/Step 9 - Cleanup Delete Custom Crop.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+name: 'Step 9 - Cleanup Delete Custom Crop'
+description: Deletes the temporary custom crop after its listing has been detached.
+method: DELETE
+url: '{{baseUrl}}/crops/:cropLibraryId'
+order: 9000
+headers:
+  - key: Authorization
+    value: 'Bearer {{authToken}}'
+pathVariables:
+  - key: cropLibraryId
+    value: '{{customCropE2eId}}'
+scripts:
+  - type: afterResponse
+    language: text/javascript
+    code: |-
+      pm.test("Status code is 204", function () {
+          pm.response.to.have.status(204);
+      });

--- a/services/grn-api/openapi/paths/listings.yaml
+++ b/services/grn-api/openapi/paths/listings.yaml
@@ -70,7 +70,7 @@
         name: status
         schema:
           type: string
-          enum: [active, claimed, expired]
+          enum: [active, expired, completed]
       - in: query
         name: limit
         schema:

--- a/services/grn-api/openapi/schemas/listings.yaml
+++ b/services/grn-api/openapi/schemas/listings.yaml
@@ -1,6 +1,6 @@
 ListingItem:
   type: object
-  required: [id, userId, cropId, status, pickupDisclosurePolicy, contactPref, createdAt]
+  required: [id, userId, growerCropId, cropId, status, pickupDisclosurePolicy, contactPref, createdAt]
   properties:
     id:
       type: string
@@ -15,6 +15,7 @@ ListingItem:
     cropId:
       type: string
       format: uuid
+      nullable: true
     varietyId:
       type: string
       format: uuid
@@ -41,7 +42,7 @@ ListingItem:
       nullable: true
     status:
       type: string
-      enum: [active, claimed, expired]
+      enum: [active, pending, claimed, expired, completed]
     pickupLocationText:
       type: string
       nullable: true
@@ -53,13 +54,13 @@ ListingItem:
       nullable: true
     pickupDisclosurePolicy:
       type: string
-      enum: [address_visible, after_confirmed, never]
+      enum: [immediate, after_confirmed, after_accepted]
     pickupNotes:
       type: string
       nullable: true
     contactPref:
       type: string
-      enum: [in_app, email, either]
+      enum: [app_message, phone, knock]
     geoKey:
       type: string
       nullable: true
@@ -77,11 +78,21 @@ ListingItem:
 
 UpsertListingRequest:
   type: object
-  required: [title, cropId, quantityTotal, unit, availableStart, availableEnd]
+  description: |
+    Create or update a surplus listing. Either `cropId` or `growerCropId`
+    must be provided. User-defined crops use `growerCropId` without a
+    catalog `cropId`.
+  required: [title, quantityTotal, unit, availableStart, availableEnd]
+  anyOf:
+    - required: [cropId]
+    - required: [growerCropId]
   properties:
     title:
       type: string
     cropId:
+      type: string
+      format: uuid
+    growerCropId:
       type: string
       format: uuid
     varietyId:
@@ -108,18 +119,18 @@ UpsertListingRequest:
       nullable: true
     pickupDisclosurePolicy:
       type: string
-      enum: [address_visible, after_confirmed, never]
+      enum: [immediate, after_confirmed, after_accepted]
       nullable: true
     pickupNotes:
       type: string
       nullable: true
     contactPref:
       type: string
-      enum: [in_app, email, either]
+      enum: [app_message, phone, knock]
       nullable: true
     status:
       type: string
-      enum: [active]
+      enum: [active, pending, claimed, expired, completed]
       nullable: true
 
 PaginatedListings:

--- a/services/grn-api/src/api/handlers/listing.rs
+++ b/services/grn-api/src/api/handlers/listing.rs
@@ -103,32 +103,6 @@ struct ListMyListingsQuery {
     offset: i64,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ListingWriteResponse {
-    pub id: String,
-    pub user_id: String,
-    pub crop_id: String,
-    pub variety_id: Option<String>,
-    pub title: String,
-    pub quantity_total: String,
-    pub quantity_remaining: String,
-    pub unit: String,
-    pub available_start: String,
-    pub available_end: String,
-    pub status: String,
-    pub pickup_location_text: Option<String>,
-    pub pickup_address: Option<String>,
-    pub effective_pickup_address: Option<String>,
-    pub pickup_disclosure_policy: String,
-    pub pickup_notes: Option<String>,
-    pub contact_pref: String,
-    pub geo_key: String,
-    pub lat: f64,
-    pub lng: f64,
-    pub created_at: String,
-}
-
 pub async fn list_my_listings(
     request: &Request,
     correlation_id: &str,
@@ -375,7 +349,7 @@ pub async fn create_listing(
         let existing_row = client
             .query_opt(
                 "
-                select id, user_id, crop_id, variety_id, title,
+                select id, user_id, crop_id, grower_crop_id, variety_id, title,
                        quantity_total::text as quantity_total,
                        quantity_remaining::text as quantity_remaining,
                        unit, available_start, available_end, status::text,
@@ -412,7 +386,7 @@ pub async fn create_listing(
         "Created surplus listing"
     );
 
-    json_response(201, &row_to_write_response(&row))
+    json_response(201, &row_to_listing_item(&row))
 }
 
 pub async fn update_listing(
@@ -499,7 +473,7 @@ pub async fn update_listing(
             "Updated surplus listing"
         );
 
-        return json_response(200, &row_to_write_response(&row));
+        return json_response(200, &row_to_listing_item(&row));
     }
 
     error_response(404, "Listing not found")
@@ -862,34 +836,6 @@ fn parse_json_body<T: serde::de::DeserializeOwned>(
         Body::Empty => Err(lambda_http::Error::from(
             "Request body is required".to_string(),
         )),
-    }
-}
-
-fn row_to_write_response(row: &Row) -> ListingWriteResponse {
-    ListingWriteResponse {
-        id: row.get::<_, Uuid>("id").to_string(),
-        user_id: row.get::<_, Uuid>("user_id").to_string(),
-        crop_id: row.get::<_, Uuid>("crop_id").to_string(),
-        variety_id: row
-            .get::<_, Option<Uuid>>("variety_id")
-            .map(|v| v.to_string()),
-        title: row.get("title"),
-        quantity_total: row.get("quantity_total"),
-        quantity_remaining: row.get("quantity_remaining"),
-        unit: row.get("unit"),
-        available_start: row.get::<_, DateTime<Utc>>("available_start").to_rfc3339(),
-        available_end: row.get::<_, DateTime<Utc>>("available_end").to_rfc3339(),
-        status: row.get("status"),
-        pickup_location_text: row.get("pickup_location_text"),
-        pickup_address: row.get("pickup_address"),
-        effective_pickup_address: row.get("effective_pickup_address"),
-        pickup_disclosure_policy: row.get("pickup_disclosure_policy"),
-        pickup_notes: row.get("pickup_notes"),
-        contact_pref: row.get("contact_pref"),
-        geo_key: row.get("geo_key"),
-        lat: location::round_for_response(row.get("lat")),
-        lng: location::round_for_response(row.get("lng")),
-        created_at: row.get::<_, DateTime<Utc>>("created_at").to_rfc3339(),
     }
 }
 

--- a/services/grn-api/src/api/models/listing.rs
+++ b/services/grn-api/src/api/models/listing.rs
@@ -46,3 +46,41 @@ pub struct DiscoverListingsResponse {
     pub has_more: bool,
     pub next_offset: Option<i64>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ListingItem;
+
+    #[test]
+    fn custom_crop_listing_serializes_without_a_catalog_crop() {
+        let listing = ListingItem {
+            id: "listing-id".to_string(),
+            user_id: "user-id".to_string(),
+            grower_crop_id: Some("grower-crop-id".to_string()),
+            crop_id: None,
+            variety_id: None,
+            title: Some("Purple yard beans".to_string()),
+            unit: Some("bunch".to_string()),
+            quantity_total: Some("3".to_string()),
+            quantity_remaining: Some("3".to_string()),
+            available_start: Some("2026-07-15T12:00:00Z".to_string()),
+            available_end: Some("2026-07-17T12:00:00Z".to_string()),
+            status: "active".to_string(),
+            pickup_location_text: Some("Front porch".to_string()),
+            pickup_address: None,
+            effective_pickup_address: Some("1100 Congress Ave, Austin, TX 78701".to_string()),
+            pickup_disclosure_policy: "after_confirmed".to_string(),
+            pickup_notes: None,
+            contact_pref: "app_message".to_string(),
+            geo_key: Some("9v6kpv".to_string()),
+            lat: Some(30.2747),
+            lng: Some(-97.7404),
+            created_at: "2026-07-15T12:00:00Z".to_string(),
+        };
+
+        let serialized = serde_json::json!(listing);
+
+        assert_eq!(serialized["growerCropId"], "grower-crop-id");
+        assert!(serialized["cropId"].is_null());
+    }
+}


### PR DESCRIPTION
## Summary

- add a run-scoped Postman E2E flow for user-defined crop create, read, update, list, custom-crop-backed listing discovery, and cleanup
- make listing write responses use the nullable `cropId` / `growerCropId` contract so valid custom-crop listings serialize correctly, including idempotency replays
- align the listing OpenAPI schema with the implemented crop-link and enum contracts
- let authenticated Postman validation run for backend/Postman-only changes without depending on an intentionally skipped frontend deploy

## Root cause

The listing write response mapper unconditionally read `crop_id` as a UUID and did not expose `growerCropId`. A valid listing backed only by a user-defined crop stores a null catalog crop ID, so the write could succeed in PostgreSQL and then panic while building the response.

The first staged run also exposed that the authenticated Postman matrix depended on the frontend deployment. Backend-only changes intentionally skip that frontend job, which caused GitHub to skip the contract, utility, and E2E suites instead of validating them.

## Validation

- `cargo test --bins --all-features` (255 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`
- changed Rust files pass `rustfmt --check`
- `npm run lint`
- GRN frontend: 587 tests, typecheck, production build, and performance budget pass
- parsed all changed Postman/OpenAPI YAML and all 16 embedded Postman JavaScript scripts
- GitHub full platform matrix, staging deployments, and contract/utility/E2E Postman suites pass

## Local environment notes

- full `cargo fmt --all -- --check` is blocked locally by the repository-wide Windows CRLF checkout issue across untouched Rust files; the changed Rust files pass isolated formatting and Linux CI passed the authoritative full check
- root `npm test` stops at the existing `@olivias/store` package because it has no test files; the scoped GRN frontend suite passes all 587 tests and the full GitHub test matrix passes

Closes #202