### PR TITLE
Make signed-in Good Roots Network nav launch the app

### DIFF
--- a/apps/web/scripts/seo-data.mjs
+++ b/apps/web/scripts/seo-data.mjs
@@ -134,7 +134,7 @@ export const seoRoutes = [
       <h2>Programs and ways to take part</h2>
       <ul>
         <li><a href="/okra">The Okra Project</a> &mdash; request free okra seeds from Olivia's own seed line, and add your garden to the project map.</li>
-        <li><a href="/good-roots">Good Roots Network</a> &mdash; a community platform connecting home growers with neighbors and organizations who need fresh food.</li>
+        <li><a href="/good-roots">Good Roots Network</a> &mdash; a garden planning app for deciding what to plant, designing your beds, and staying on top of the season, with neighbor-to-neighbor food sharing built in.</li>
         <li><a href="/get-involved">Get involved</a> &mdash; volunteer at work days, request seeds, or join workshops as they launch.</li>
         <li><a href="/donate">Donate</a> &mdash; one-time gifts and Garden Club recurring support, with a permanent named marker placed in the memorial garden for every donor.</li>
         <li><a href="/about">About Olivia's Garden</a> &mdash; the story behind the foundation and the family who runs it.</li>
@@ -371,7 +371,7 @@ export const seoRoutes = [
     path: '/good-roots',
     title: 'Good Roots Network',
     description:
-      'A community platform that connects home growers with neighbors and organizations who need fresh food. Plan your garden, see local food gaps, and share what you have extra.',
+      'A garden planning app that helps you decide what to plant, design your beds, and stay on top of watering and harvest — then share your extra harvest with neighbors when you have it.',
     seoImage: defaultImage,
     allowIndex: false,
     prerender: true,
@@ -379,21 +379,21 @@ export const seoRoutes = [
     bodyFallback: `
       <h1>Good Roots Network</h1>
       <p>
-        Good Roots Network is part of Olivia's Garden Foundation. It's a community platform that
-        connects home growers with the people and organizations who need fresh food: families,
-        food pantries, shelters, schools, and mutual-aid groups.
+        Good Roots Network is part of Olivia's Garden Foundation. It's a garden planning app that
+        helps home gardeners decide what to plant, design their beds, and keep up with the season.
+        When your garden gives you more than you can use, sharing the extra with neighbors is built in.
       </p>
       <h2>How it works</h2>
       <ol>
-        <li>Register your garden and tell the network what you're planting this season.</li>
-        <li>See the local picture &mdash; every garden in the network shows up on a map so you can spot what's over-planted and what's missing.</li>
-        <li>List what's extra when a crop comes in heavy.</li>
-        <li>Gather what you need from nearby listings, claim it, and pick it up directly from the grower.</li>
+        <li>Set up your garden and add the beds you're working with this season.</li>
+        <li>Plan what to plant with crops suited to your space, and see what grows well nearby.</li>
+        <li>Stay on track with watering, fertilizer, and harvest reminders.</li>
+        <li>Share the extra when a crop comes in heavy by offering the surplus to neighbors who can use it.</li>
       </ol>
       <p>
-        Free is live today: one garden, basic planner, browsing, and your neighborhood food map.
-        Paid Supporter and Pro tiers are in the works and will add things like multiple gardens,
-        season history, advanced planning, and AI planting recommendations based on local gaps.
+        Free is live today: plan and design one garden, track your crops, and get reminders, with
+        neighbor food sharing included. Paid Supporter and Pro tiers are in the works and will add
+        things like multi-garden planning, season history, and richer planting recommendations.
         Sign up on the page to be notified when they open.
       </p>
     `,

--- a/apps/web/src/site/chrome.tsx
+++ b/apps/web/src/site/chrome.tsx
@@ -78,14 +78,32 @@ export function SiteHeader({
   const avatarLabel = authSession
     ? authSession.user.name ?? authSession.user.email ?? 'Signed-in account'
     : 'Go to login page';
-  const marketingNavItems = navRoutes.map((route) => ({
-    id: route.path,
-    label: route.label,
-    href: route.path,
-    active: pathname === route.path,
-    accent: route.path === '/donate',
-    onSelect: () => onNavigate(route.path),
-  }));
+  const marketingNavItems = navRoutes.map((route) => {
+    // Learn vs. launch: the marketing page at /good-roots is the front door for
+    // people who don't have an account yet. Once someone is signed in they've
+    // already "learned" what the network is, so the same nav item launches them
+    // straight into the app instead of showing marketing copy again. This keeps
+    // "Good Roots Network" meaning exactly one thing within a given auth state
+    // and matches the app launcher in the account menu.
+    if (route.path === '/good-roots' && authSession) {
+      return {
+        id: route.path,
+        label: route.label,
+        // No onSelect → the shared header renders a plain anchor and follows the
+        // href, performing a real cross-app navigation rather than SPA routing.
+        href: buildCrossAppUrl(goodRootsNetworkUrl, authSession),
+      };
+    }
+
+    return {
+      id: route.path,
+      label: route.label,
+      href: route.path,
+      active: pathname === route.path,
+      accent: route.path === '/donate',
+      onSelect: () => onNavigate(route.path),
+    };
+  });
 
   const accountMobileItems = authSession
     ? [

--- a/apps/web/src/site/pages/TransparencyPage.tsx
+++ b/apps/web/src/site/pages/TransparencyPage.tsx
@@ -111,8 +111,9 @@ export function TransparencyPage() {
             preparation, animal care, food preservation, and related practical skills.
           </li>
           <li>
-            <strong>The Good Roots Network</strong> &mdash; an online platform that
-            connects home growers with neighbors and organizations who need fresh food.
+            <strong>The Good Roots Network</strong> &mdash; a garden planning app that
+            helps home gardeners plan and grow more food, with neighbor-to-neighbor
+            food sharing built in.
           </li>
           <li>
             <strong>Community workdays</strong> &mdash; regular volunteer days on the

--- a/apps/web/src/site/pages/content-pages.tsx
+++ b/apps/web/src/site/pages/content-pages.tsx
@@ -1091,11 +1091,11 @@ export function TermsOfServicePage() {
 }
 
 const ORG_TYPE_OPTIONS = [
-  { value: 'food-pantry', label: 'Food pantry' },
-  { value: 'shelter', label: 'Shelter' },
+  { value: 'community-garden', label: 'Community garden' },
   { value: 'school', label: 'School or youth program' },
-  { value: 'mutual-aid', label: 'Mutual aid / community fridge' },
   { value: 'faith', label: 'Faith community' },
+  { value: 'mutual-aid', label: 'Nonprofit or mutual aid' },
+  { value: 'food-pantry', label: 'Food pantry or shelter' },
   { value: 'other', label: 'Something else' },
 ];
 
@@ -1109,8 +1109,8 @@ interface GoodRootsHeroCopy {
 function heroForSession(session: AuthSession | null): GoodRootsHeroCopy {
   if (!session) {
     return {
-      title: 'A local food network starts with neighbors.',
-      body: "The Good Roots Network helps gardeners, families, food pantries, schools, and community groups see what is growing nearby and share fresh food while it is still at its best.",
+      title: 'Plan a garden you can actually keep up with.',
+      body: 'The Good Roots Network helps you decide what to plant, lay out your beds, and stay on top of watering and harvest all season long. When your garden gives you more than you can use, sharing it with neighbors is built right in.',
       primary: { label: 'Create your account', href: '/login', signup: true, internal: true },
       secondary: { label: 'See how it works', href: '#how-it-works', internal: true },
     };
@@ -1119,8 +1119,8 @@ function heroForSession(session: AuthSession | null): GoodRootsHeroCopy {
   const appHref = buildCrossAppUrl(goodRootsNetworkUrl, session);
 
   return {
-    title: 'A local food network starts with neighbors.',
-    body: 'The Good Roots Network helps gardeners, families, food pantries, schools, and community groups see what is growing nearby and share fresh food while it is still at its best.',
+    title: 'Plan a garden you can actually keep up with.',
+    body: 'The Good Roots Network helps you decide what to plant, lay out your beds, and stay on top of watering and harvest all season long. When your garden gives you more than you can use, sharing it with neighbors is built right in.',
     primary: { label: 'Open the Good Roots Network', href: appHref },
   };
 }
@@ -1408,38 +1408,38 @@ export function GoodRootsPage({
       <section className="home-mission-band good-roots-mission" aria-label="Mission">
         <div className="home-mission-band__copy">
           <p className="home-mission-band__eyebrow">What it is</p>
-          <h2>More food, grown closer to home, shared with the people around you.</h2>
+          <h2>Everything you need to plan and grow a better garden.</h2>
           <p>
-            The Good Roots Network is a living map of the gardens in your area and the people who want to eat
-            from them. Register your garden, watch the local picture take shape, and turn your extra harvest
-            into something your neighbors will thank you for. And because it's built around real gardens
-            run by real people, every season you spend in the network is a season you get better. Follow
-            growers near you, see what worked for them, and borrow those lessons for next year.
+            The Good Roots Network gives you one place to plan each season, design your beds, track what
+            you've planted, and get reminders so nothing slips through the cracks. Because it's built
+            around real gardens run by real people near you, you can see what grows well in your area and
+            carry those lessons into next year. And when a crop comes in heavy, passing the extra along to
+            a neighbor is right there whenever you want it.
           </p>
         </div>
       </section>
 
-      <Section id="how-it-works" title="How it works" intro="Four steps. No middle layer between the people growing food and the people eating it.">
+      <Section id="how-it-works" title="How it works" intro="From an empty bed to a season you can actually keep up with.">
         <div className="good-roots-steps">
           <article className="good-roots-step">
             <span className="good-roots-step__number">01</span>
-            <h3>Register your garden</h3>
-            <p>Tell us where you are and what you're planting this season.</p>
+            <h3>Set up your garden</h3>
+            <p>Tell us where you garden and add the beds you're working with this season.</p>
           </article>
           <article className="good-roots-step">
             <span className="good-roots-step__number">02</span>
-            <h3>See the local picture</h3>
-            <p>We map every garden in the network so you can spot what's over-planted and what's missing.</p>
+            <h3>Plan what to plant</h3>
+            <p>Build a season plan with crops suited to your space, and see what grows well nearby.</p>
           </article>
           <article className="good-roots-step">
             <span className="good-roots-step__number">03</span>
-            <h3>List what's extra</h3>
-            <p>When a crop comes in heavy, post it for neighbors or local organizations to claim.</p>
+            <h3>Stay on track</h3>
+            <p>Get watering, fertilizer, and harvest reminders so the day-to-day never piles up.</p>
           </article>
           <article className="good-roots-step">
             <span className="good-roots-step__number">04</span>
-            <h3>Gather what you need</h3>
-            <p>Browse nearby listings, claim what you'll use, and pick it up from the grower.</p>
+            <h3>Share the extra</h3>
+            <p>When a crop comes in heavy, offer the surplus to neighbors who can use it.</p>
           </article>
         </div>
       </Section>
@@ -1448,21 +1448,18 @@ export function GoodRootsPage({
         <div className="good-roots-persona">
           <div className="good-roots-persona__media" aria-hidden="true" />
           <div className="good-roots-persona__copy">
-            <p className="page-eyebrow">For growers</p>
-            <h2>Plant with purpose.</h2>
+            <p className="page-eyebrow">Plan your season</p>
+            <h2>Know what to plant, and where.</h2>
             <p>
-              Most home gardens end in a pile of zucchini no one can keep up with. The Good Roots Network helps you plan
-              around what your community actually needs. It also turns surplus into something your neighbors
-              will thank you for. Whether you're growing at home, on church land, at a school, or in a
-              community garden, you can join as a grower, track your beds, set watering and harvest reminders,
-              and watch your patch of ground become part of something bigger.
+              Most gardens start with good intentions and a pile of seed packets. The Good Roots Network
+              helps you turn that into an actual plan: pick crops that fit your space and your climate, lay
+              them out bed by bed, and keep track of everything from "thinking about it" to "in the ground."
             </p>
             <ul className="site-list">
-              <li>Garden planner with what-to-plant-when</li>
-              <li>Watering, fertilizer, and harvest reminders</li>
-              <li>Listings for surplus produce</li>
-              <li>Organization growers can show who they grow on behalf of</li>
-              <li>A running picture of what's growing nearby</li>
+              <li>Season planner with what-to-plant-when</li>
+              <li>Bed-by-bed garden designer</li>
+              <li>A plant library that tracks every crop's status</li>
+              <li>Local planting context so you can see what does well nearby</li>
             </ul>
           </div>
         </div>
@@ -1470,26 +1467,27 @@ export function GoodRootsPage({
         <div className="good-roots-persona good-roots-persona--reverse">
           <div className="good-roots-persona__media" aria-hidden="true" />
           <div className="good-roots-persona__copy">
-            <p className="page-eyebrow">For gatherers</p>
-            <h2>Eat closer to home.</h2>
+            <p className="page-eyebrow">Keep it going</p>
+            <h2>Stay on top of the day-to-day.</h2>
             <p>
-              Whether you're a family looking for fresh produce or a food pantry, shelter, or community
-              kitchen trying to feed more people, the Good Roots Network connects you to gardens in your area. Claim
-              what's ready, meet the growers, and build a food system that doesn't start in a warehouse.
+              A garden is a hundred small tasks spread across a season. The Good Roots Network keeps them
+              from slipping: reminders for the things that matter, a journal for what you've harvested and
+              learned, and a simple daily view of what needs doing. And if you end up with more than you
+              need, sharing it with a neighbor is only a tap away.
             </p>
             <ul className="site-list">
-              <li>Search listings by crop, distance, and availability</li>
-              <li>Claim produce in a few taps</li>
-              <li>Direct pickup from the grower, with no middle layer</li>
-              <li>Free to use for individuals and community organizations</li>
+              <li>Watering, fertilizer, and harvest reminders</li>
+              <li>A garden journal for harvests and notes</li>
+              <li>A daily view of what needs doing today</li>
+              <li>Share surplus with neighbors whenever you have extra</li>
             </ul>
           </div>
         </div>
       </section>
 
       <Section
-        title="Know what your neighborhood is growing."
-        intro="The Good Roots Network tracks and consolidates every registered garden into a living map of local abundance and scarcity. If everyone on your block is growing tomatoes and nobody has greens, we'll tell you. Plant into the gap and you'll always have a home for your harvest."
+        title="Learn from the gardens around you."
+        intro="Every garden in the network adds to a living picture of what people nearby are planting and how it's doing. Use it to choose crops that thrive in your area, time your plantings with the seasons, and — when you want to — see where your extra harvest could do the most good."
         className="good-roots-map-section"
       >
         <div className="good-roots-map-placeholder" aria-hidden="true" />
@@ -1503,10 +1501,10 @@ export function GoodRootsPage({
               <p className="good-roots-tier__price">$0</p>
             </header>
             <ul className="site-list">
-              <li>Register one garden</li>
-              <li>Basic planner and reminders</li>
-              <li>Browse local listings and claim produce</li>
-              <li>See what is not being grown nearby so you can plant into the gaps</li>
+              <li>Plan and design one garden</li>
+              <li>Crop tracking and planting suggestions</li>
+              <li>Watering, fertilizer, and harvest reminders</li>
+              <li>Share surplus with neighbors when you have extra</li>
             </ul>
           </article>
 
@@ -1516,9 +1514,9 @@ export function GoodRootsPage({
               <p className="good-roots-tier__price">In the works</p>
             </header>
             <p>
-              We're building out the paid tiers that will keep the network free for families and food
-              organizations, with extras like AI planting recommendations, local gap signals, and
-              multi-garden tracking. Get on the list and we'll email you the moment they open.
+              We're building paid tiers that keep the core planning tools free for home gardeners, with
+              extras like richer planting recommendations, multi-garden planning, and deeper local growing
+              insights. Get on the list and we'll email you the moment they open.
             </p>
             <TierInterestForm tier="either" source="good-roots-tiers" />
           </article>
@@ -1527,24 +1525,24 @@ export function GoodRootsPage({
 
       <Section
         id="organizations"
-        title="Feeding a community? Let's make it easier."
-        intro="Community gardens, schools, churches, food pantries, shelters, and mutual-aid groups can now join the Good Roots Network directly as growers or gatherers. If you're coordinating shared community plots or regular local pickups, we'll help you choose the right starting setup."
+        title="Gardening as a group?"
+        intro="Community gardens, schools, churches, and other groups can use the Good Roots Network to plan shared plots, keep track of who's tending what, and stay organized across a season with a lot of hands. If your group grows more than it needs, sharing the surplus locally comes built in."
         className="good-roots-orgs-section"
       >
         <div className="good-roots-orgs">
-          <Card title="How organizations can use the Good Roots Network" className="good-roots-orgs__perks">
+          <Card title="How groups use the Good Roots Network" className="good-roots-orgs__perks">
             <ul className="site-list">
-              <li>Grower onboarding for shared gardens and community plots</li>
-              <li>Organization name visible in the app for grower accounts</li>
-              <li>Gatherer onboarding for food pantries, shelters, schools, and mutual-aid groups</li>
-              <li>Direct coordination with local growers through the existing listing flow</li>
+              <li>Plan and design shared gardens and community plots</li>
+              <li>Keep track of who is growing what across your group</li>
+              <li>Your organization's name shown on member garden profiles</li>
+              <li>Share surplus harvest with the people you serve</li>
               <li>Light-touch onboarding guidance from our team when you need it</li>
             </ul>
           </Card>
           <Card title="Apply for organization access" className="good-roots-orgs__form">
-            <p className="contact-card__eyebrow">Tell us about your org</p>
+            <p className="contact-card__eyebrow">Tell us about your group</p>
             <p>
-              Share a few details and we'll reach out to help you get set up in the right role for how your organization participates.
+              Share a few details and we'll reach out to help your group get set up in the Good Roots Network.
             </p>
             <OrganizationInquiryForm />
           </Card>
@@ -1555,8 +1553,9 @@ export function GoodRootsPage({
         <div className="good-roots-closing__copy">
           <h2>Roots grow where hands meet dirt.</h2>
           <p>
-            Whether you have a half-acre or a few pots on a balcony, the Good Roots Network has a place for you.
-            Start with one garden, one listing, or one pickup and let the local picture grow from there.
+            Whether you have a half-acre or a few pots on a balcony, the Good Roots Network helps you plan
+            it, grow it, and make the most of everything it gives you. Start with a single bed and let it
+            grow from there.
           </p>
           {authSession ? (
             <CtaButton href={buildCrossAppUrl(goodRootsNetworkUrl, authSession)}>

--- a/apps/web/src/site/routes.ts
+++ b/apps/web/src/site/routes.ts
@@ -71,7 +71,7 @@ export const routes: AppRoute[] = [
     label: 'Good Roots Network',
     showInNav: true,
     title: 'Good Roots Network',
-    description: 'A community platform that connects home growers with neighbors and organizations who need fresh food. Plan your garden, see local food gaps, and share what you have extra.',
+    description: 'A garden planning app that helps you decide what to plant, design your beds, and stay on top of watering and harvest — then share your extra harvest with neighbors when you have it.',
     seoImage: socialShareImage,
     allowIndex: false,
     prerender: true,

--- a/services/notifications/src/services/renderers.mjs
+++ b/services/notifications/src/services/renderers.mjs
@@ -23,10 +23,11 @@ function adminUrl(suffix) {
 
 function orgTypeLabel(type) {
   const map = {
-    'food-pantry': 'Food pantry',
+    'community-garden': 'Community garden',
+    'food-pantry': 'Food pantry or shelter',
     shelter: 'Shelter',
     school: 'School or youth program',
-    'mutual-aid': 'Mutual aid / community fridge',
+    'mutual-aid': 'Nonprofit or mutual aid',
     faith: 'Faith community',
     other: 'Other'
   };

--- a/services/notifications/test/renderers.test.mjs
+++ b/services/notifications/test/renderers.test.mjs
@@ -140,7 +140,7 @@ describe('renderEvent', () => {
   it('renders Good Roots org inquiries with org-type label and optional fields', () => {
     const result = renderEvent('ogf.contact', 'org-inquiry.received', {
       orgName: 'Harvest House',
-      orgType: 'food-pantry',
+      orgType: 'community-garden',
       contactName: 'Jordan Rivers',
       email: 'jordan@harvesthouse.org',
       city: 'McKinney',
@@ -149,7 +149,7 @@ describe('renderEvent', () => {
     });
 
     expect(result.summary).toBe('Good Roots inquiry from Harvest House');
-    expect(result.slack.text).toContain('Organization: Harvest House (Food pantry)');
+    expect(result.slack.text).toContain('Organization: Harvest House (Community garden)');
     expect(result.slack.text).toContain('Location: McKinney, TX');
     expect(result.slack.text).toContain('We feed 200 families a week.');
   });


### PR DESCRIPTION
The string "Good Roots Network" appeared twice for signed-in users: the
top-nav item opened the /good-roots marketing page while the account-menu
"Apps" launcher opened the actual application. Same name, two destinations.

Adopt a learn-vs-launch model: the /good-roots marketing page stays the
front door for logged-out visitors, but once a user is signed in the same
top-nav item launches them straight into the app (matching the Apps
launcher), so "Good Roots Network" means exactly one thing within a given
auth state. The marketing route still exists for deep links and sharing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011nfPDCSpKzoYzFhRcQaTS1