### PR TITLE
Add local seasonality and a harvest timeline

### DIFF
--- a/apps/grn/src/components/CropPlanner/CropForm.test.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -25,6 +25,10 @@ vi.mock('../../hooks/useGrowerCropSignals', () => ({
 }));
 
 describe('CropForm user-defined crops', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('creates a custom crop without a catalog identifier', async () => {
     const user = userEvent.setup();
     const onSuccess = vi.fn();
@@ -82,5 +86,72 @@ describe('CropForm user-defined crops', () => {
       expect.anything()
     );
     await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(createdCrop));
+  });
+
+  it('links a route-provided seasonal suggestion to its catalog crop', async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    const createdCrop = {
+      id: 'grower-okra-1',
+      userId: 'grower-1',
+      canonicalId: 'catalog-okra',
+      cropName: 'Okra',
+      varietyId: null,
+      status: 'planning',
+      visibility: 'local',
+      surplusEnabled: false,
+      nickname: null,
+      defaultUnit: null,
+      notes: null,
+      bedId: null,
+      bedName: null,
+      plantingDate: null,
+      expectedHarvestDate: null,
+      plantCount: null,
+      spacingInches: null,
+      pyramidTier: null,
+      createdAt: '2026-07-15T00:00:00Z',
+      updatedAt: '2026-07-15T00:00:00Z',
+    };
+
+    vi.mocked(listCatalogCrops).mockResolvedValue([
+      {
+        id: 'catalog-okra',
+        slug: 'okra',
+        commonName: 'Okra',
+        scientificName: 'Abelmoschus esculentus',
+        category: 'vegetable',
+        description: null,
+        pyramidTier: 2,
+      },
+    ]);
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(createMyCrop).mockResolvedValue(createdCrop);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CropForm
+          initialCropName="Okra"
+          onSuccess={onSuccess}
+          onCancel={vi.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    const picker = await screen.findByRole('combobox', { name: /what are you growing/i });
+    await waitFor(() => expect(picker).toHaveValue('Okra'));
+    await waitFor(() => expect(picker).not.toBeDisabled());
+    await user.click(screen.getByRole('button', { name: /add to my garden/i }));
+
+    await waitFor(() => expect(createMyCrop).toHaveBeenCalledTimes(1));
+    expect(createMyCrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canonicalId: 'catalog-okra',
+        cropName: 'Okra',
+        status: 'planning',
+      }),
+      expect.anything()
+    );
   });
 });

--- a/apps/grn/src/components/CropPlanner/CropForm.tsx
+++ b/apps/grn/src/components/CropPlanner/CropForm.tsx
@@ -74,6 +74,8 @@ export interface CropFormProps {
   lockedBed?: GardenBed | null;
   /** Initial bed selection when the bed selector is shown. */
   initialBedId?: string | null;
+  /** Initial crop name from a trusted in-app suggestion. */
+  initialCropName?: string | null;
   /** Called after the crop is created successfully. */
   onSuccess: (created: GrowerCropItem) => void;
   /** Called when the user clicks Cancel. */
@@ -92,6 +94,7 @@ export interface CropFormProps {
 export function CropForm({
   lockedBed = null,
   initialBedId = null,
+  initialCropName = null,
   onSuccess,
   onCancel,
   submitLabel = 'Add to my garden',
@@ -112,7 +115,12 @@ export function CropForm({
 
   const growerSignals = useGrowerCropSignals();
 
-  const [selection, setSelection] = useState<CropPickerSelection | null>(null);
+  const trimmedInitialCropName = initialCropName?.trim() ?? '';
+  const [selection, setSelection] = useState<CropPickerSelection | null>(() =>
+    trimmedInitialCropName
+      ? { catalogCropId: null, cropName: trimmedInitialCropName, category: null }
+      : null
+  );
   const [planting, setPlanting] = useState<PlantingDetails>({
     bedId: lockedBed?.id ?? initialBedId,
     plantingDate: '',
@@ -131,9 +139,28 @@ export function CropForm({
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // Resolve a route-provided name to its catalog identity without adding a
+  // synchronization render. If the grower changes the field, their selection
+  // takes precedence immediately.
+  const resolvedSelection = useMemo<CropPickerSelection | null>(() => {
+    if (!trimmedInitialCropName || selection?.catalogCropId || !catalog.length) return selection;
+    if (selection?.cropName.toLocaleLowerCase() !== trimmedInitialCropName.toLocaleLowerCase()) {
+      return selection;
+    }
+    const catalogMatch = catalog.find(
+      (crop) => crop.commonName.toLocaleLowerCase() === trimmedInitialCropName.toLocaleLowerCase()
+    );
+    if (!catalogMatch) return selection;
+    return {
+      catalogCropId: catalogMatch.id,
+      cropName: catalogMatch.commonName,
+      category: catalogMatch.category,
+    };
+  }, [catalog, selection, trimmedInitialCropName]);
+
   const visual = useMemo(
-    () => visualForCrop(selection?.cropName, selection?.category),
-    [selection]
+    () => visualForCrop(resolvedSelection?.cropName, resolvedSelection?.category),
+    [resolvedSelection]
   );
 
   const daysToHarvest = useMemo(
@@ -155,18 +182,18 @@ export function CropForm({
   });
 
   const canSubmit =
-    selection !== null &&
-    selection.cropName.trim().length > 0 &&
+    resolvedSelection !== null &&
+    resolvedSelection.cropName.trim().length > 0 &&
     !createMutation.isPending;
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
     setSubmitError(null);
-    if (!selection) {
+    if (!resolvedSelection) {
       setSubmitError('Pick a crop first.');
       return;
     }
-    const trimmedName = selection.cropName.trim();
+    const trimmedName = resolvedSelection.cropName.trim();
     if (!trimmedName) {
       setSubmitError('Crop needs a name.');
       return;
@@ -174,7 +201,7 @@ export function CropForm({
 
     const payload: UpsertGrowerCropRequest = {
       cropName: trimmedName,
-      canonicalId: selection.catalogCropId ?? undefined,
+      canonicalId: resolvedSelection.catalogCropId ?? undefined,
       status: planting.status,
       visibility: advanced.visibility,
       surplusEnabled: advanced.surplusEnabled,
@@ -198,7 +225,7 @@ export function CropForm({
         catalog={catalog}
         isLoading={isLoadingCatalog || growerSignals.isLoading}
         onSelect={setSelection}
-        selectedCatalogCropId={selection?.catalogCropId ?? null}
+        selectedCatalogCropId={resolvedSelection?.catalogCropId ?? null}
         growingCropIds={growerSignals.growingCatalogCropIds}
       />
       <Card className="grn-new-crop__hero" padding="6">
@@ -215,7 +242,7 @@ export function CropForm({
           <CropPicker
             catalog={catalog}
             isLoading={isLoadingCatalog}
-            value={selection}
+            value={resolvedSelection}
             onChange={setSelection}
             scarceCropIds={growerSignals.scarceCropIds}
             growingCropIds={growerSignals.growingCatalogCropIds}

--- a/apps/grn/src/components/HarvestTimeline/HarvestTimeline.css
+++ b/apps/grn/src/components/HarvestTimeline/HarvestTimeline.css
@@ -1,0 +1,332 @@
+.grn-harvest-timeline {
+  overflow: hidden;
+  padding: clamp(1rem, 2vw, 1.4rem);
+  border: 1px solid rgba(79, 56, 37, 0.13);
+  border-radius: 1.25rem;
+  background:
+    radial-gradient(circle at 94% 0%, rgba(225, 181, 83, 0.16), transparent 30%),
+    linear-gradient(145deg, rgba(255, 253, 248, 0.98), rgba(244, 239, 224, 0.94));
+  box-shadow: 0 14px 34px rgba(49, 34, 22, 0.07);
+}
+
+.grn-harvest-timeline__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.grn-harvest-timeline__header h2 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: normal;
+}
+
+.grn-harvest-timeline__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(79, 56, 37, 0.72);
+  font-size: 0.88rem;
+}
+
+.grn-harvest-timeline__ready-count {
+  flex: 0 0 auto;
+  padding: 0.38rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(225, 181, 83, 0.2);
+  color: #6d521d;
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.grn-harvest-timeline__rail {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 1.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grn-harvest-period {
+  position: relative;
+  min-width: 0;
+  padding: 0 0.45rem;
+}
+
+.grn-harvest-period__marker {
+  position: relative;
+  height: 1rem;
+  margin: 0 -0.45rem;
+}
+
+.grn-harvest-period__marker::before {
+  position: absolute;
+  top: 0.43rem;
+  right: 0;
+  left: 0;
+  height: 2px;
+  background: rgba(66, 107, 63, 0.24);
+  content: '';
+}
+
+.grn-harvest-period:first-child .grn-harvest-period__marker::before {
+  left: 0.45rem;
+}
+
+.grn-harvest-period:last-child .grn-harvest-period__marker::before {
+  right: 0.45rem;
+}
+
+.grn-harvest-period__marker span {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0.45rem;
+  width: 0.92rem;
+  height: 0.92rem;
+  border: 3px solid #f9f6ec;
+  border-radius: 50%;
+  background: #739069;
+  box-shadow: 0 0 0 1px rgba(66, 107, 63, 0.28);
+}
+
+.grn-harvest-period--ready .grn-harvest-period__marker span {
+  background: #d29a32;
+  box-shadow: 0 0 0 1px rgba(154, 104, 25, 0.32), 0 0 0 0.35rem rgba(225, 181, 83, 0.12);
+}
+
+.grn-harvest-period__heading {
+  margin: 0.4rem 0 0.7rem;
+}
+
+.grn-harvest-period__heading span {
+  color: var(--og-color-moss);
+  font-size: 0.67rem;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.grn-harvest-period__heading h3 {
+  margin: 0.12rem 0 0;
+  color: var(--og-color-soil);
+  font-size: 0.9rem;
+  letter-spacing: normal;
+}
+
+.grn-harvest-period__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grn-harvest-period__empty {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.5);
+  font-size: 0.78rem;
+}
+
+.grn-harvest-crop {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.5rem;
+  padding: 0.65rem;
+  border: 1px solid rgba(79, 56, 37, 0.1);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.grn-harvest-crop--ready {
+  border-color: rgba(192, 137, 43, 0.25);
+  background: rgba(255, 249, 231, 0.9);
+}
+
+.grn-harvest-crop__icon {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.72rem;
+  background: color-mix(in srgb, var(--harvest-crop-accent) 15%, white);
+  color: var(--harvest-crop-accent);
+}
+
+.grn-harvest-crop__copy {
+  min-width: 0;
+}
+
+.grn-harvest-crop__copy h4 {
+  overflow: hidden;
+  margin: 0;
+  color: var(--og-color-soil);
+  font-size: 0.86rem;
+  line-height: 1.25;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.grn-harvest-crop__copy p,
+.grn-harvest-crop__copy span {
+  display: block;
+  margin: 0.15rem 0 0;
+  color: rgba(79, 56, 37, 0.68);
+  font-size: 0.69rem;
+  line-height: 1.35;
+}
+
+.grn-harvest-crop__copy span {
+  color: var(--og-color-moss);
+}
+
+.grn-harvest-crop__action {
+  grid-column: 1 / -1;
+  min-height: 2rem;
+  padding: 0.25rem 0;
+  border: none;
+  background: transparent;
+  color: var(--og-color-moss);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 750;
+  text-align: left;
+  cursor: pointer;
+}
+
+.grn-harvest-crop__action:hover,
+.grn-harvest-crop__action:focus-visible {
+  color: color-mix(in srgb, var(--og-color-moss) 75%, black);
+  text-decoration: underline;
+  text-underline-offset: 0.18rem;
+  outline: none;
+}
+
+.grn-harvest-timeline__empty {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-top: 1rem;
+  padding: 0.85rem;
+  border: 1px dashed rgba(79, 56, 37, 0.2);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.grn-harvest-timeline__empty > span {
+  font-size: 2rem;
+}
+
+.grn-harvest-timeline__empty h3,
+.grn-harvest-timeline__empty p {
+  margin: 0;
+}
+
+.grn-harvest-timeline__empty h3 {
+  color: var(--og-color-soil);
+  font-size: 0.95rem;
+  letter-spacing: normal;
+}
+
+.grn-harvest-timeline__empty p {
+  margin-top: 0.2rem;
+  color: rgba(79, 56, 37, 0.68);
+  font-size: 0.8rem;
+}
+
+.grn-harvest-timeline__missing {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding: 0.55rem 0.7rem 0.55rem 0.85rem;
+  border-radius: 0.8rem;
+  background: rgba(66, 107, 63, 0.08);
+}
+
+.grn-harvest-timeline__missing p {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.78);
+  font-size: 0.78rem;
+}
+
+.grn-harvest-timeline__note {
+  margin: 0.8rem 0 0;
+  color: rgba(79, 56, 37, 0.58);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 820px) {
+  .grn-harvest-timeline__rail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .grn-harvest-timeline__header,
+  .grn-harvest-timeline__missing {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .grn-harvest-timeline__rail {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .grn-harvest-period {
+    display: grid;
+    grid-template-columns: 1.1rem minmax(0, 1fr);
+    padding: 0 0 1rem;
+  }
+
+  .grn-harvest-period__marker {
+    grid-row: 1 / 3;
+    height: 100%;
+    margin: 0;
+  }
+
+  .grn-harvest-period__marker::before,
+  .grn-harvest-period:first-child .grn-harvest-period__marker::before,
+  .grn-harvest-period:last-child .grn-harvest-period__marker::before {
+    top: 0.45rem;
+    right: auto;
+    bottom: -1rem;
+    left: 0.43rem;
+    width: 2px;
+    height: auto;
+  }
+
+  .grn-harvest-period:last-child .grn-harvest-period__marker::before {
+    display: none;
+  }
+
+  .grn-harvest-period__marker span {
+    left: 0;
+  }
+
+  .grn-harvest-period__heading {
+    margin: 0 0 0.6rem 0.35rem;
+  }
+
+  .grn-harvest-period__items,
+  .grn-harvest-period__empty {
+    margin-left: 0.35rem;
+  }
+
+  .grn-harvest-crop {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .grn-harvest-crop__action {
+    grid-column: auto;
+    min-height: 2.75rem;
+  }
+}

--- a/apps/grn/src/components/HarvestTimeline/HarvestTimeline.test.tsx
+++ b/apps/grn/src/components/HarvestTimeline/HarvestTimeline.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { GrowerCropItem } from '../../types/listing';
+import { HarvestTimeline } from './HarvestTimeline';
+
+function crop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
+  return {
+    id: 'crop-1',
+    userId: 'grower-1',
+    canonicalId: null,
+    cropName: 'Tomato',
+    varietyId: null,
+    status: 'growing',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: null,
+    bedName: null,
+    plantingDate: '2026-05-20',
+    expectedHarvestDate: null,
+    plantCount: null,
+    spacingInches: null,
+    pyramidTier: null,
+    createdAt: '2026-05-20',
+    updatedAt: '2026-05-20',
+    ...overrides,
+  };
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+}
+
+function renderTimeline(crops: GrowerCropItem[]) {
+  return render(
+    <MemoryRouter>
+      <HarvestTimeline crops={crops} now={new Date('2026-07-21T12:00:00Z')} />
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('HarvestTimeline', () => {
+  it('opens the harvest log for a crop ready to check', async () => {
+    renderTimeline([
+      crop({ id: 'tomato', nickname: 'Sun Gold', expectedHarvestDate: '2026-07-21' }),
+    ]);
+
+    expect(screen.getByRole('heading', { name: 'Coming harvests' })).toBeInTheDocument();
+    expect(screen.getByText('Estimated today · Jul 21')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Log Sun Gold harvest' }));
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plants?crop=tomato&action=harvest'
+    );
+  });
+
+  it('sends a growing crop without an estimate to the timing editor', async () => {
+    renderTimeline([crop({ id: 'basil', cropName: 'Basil' })]);
+
+    expect(screen.getByText(/give your growing plants a harvest estimate/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Add timing' }));
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plants?crop=basil&action=timing'
+    );
+  });
+
+  it('stays out of the way when no crops are actively growing', () => {
+    renderTimeline([crop({ status: 'planning', expectedHarvestDate: '2026-08-01' })]);
+    expect(screen.queryByRole('heading', { name: 'Coming harvests' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/grn/src/components/HarvestTimeline/HarvestTimeline.tsx
+++ b/apps/grn/src/components/HarvestTimeline/HarvestTimeline.tsx
@@ -1,0 +1,163 @@
+import { useMemo, type CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@olivias/ui';
+import type { GrowerCropItem } from '../../types/listing';
+import { CropIcon } from '../CropPlanner/cropIcons';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { createLogger } from '../../utils/logging';
+import {
+  buildHarvestTimeline,
+  cropDisplayName,
+  harvestDateLabel,
+  type HarvestHorizon,
+  type HarvestTimelineItem,
+} from './harvestTimelineData';
+import './HarvestTimeline.css';
+
+const logger = createLogger('harvest-timeline');
+
+const HORIZONS: Array<{ id: HarvestHorizon; label: string; shortLabel: string }> = [
+  { id: 'ready', label: 'Ready to check', shortLabel: 'Now' },
+  { id: 'week', label: 'Next 7 days', shortLabel: 'Soon' },
+  { id: 'month', label: 'This month', shortLabel: 'Ahead' },
+  { id: 'later', label: 'Later', shortLabel: 'Later' },
+];
+
+export interface HarvestTimelineProps {
+  crops: GrowerCropItem[];
+  now?: Date;
+}
+
+export function HarvestTimeline({ crops, now }: HarvestTimelineProps) {
+  const navigate = useNavigate();
+  const timeline = useMemo(() => buildHarvestTimeline(crops, now), [crops, now]);
+  const growingCount = crops.filter((crop) => crop.status === 'growing').length;
+
+  if (growingCount === 0) return null;
+
+  const openCrop = (item: HarvestTimelineItem) => {
+    const isReady = item.horizon === 'ready';
+    logger.info('Harvest timeline item opened', {
+      cropId: item.crop.id,
+      horizon: item.horizon,
+      dayOffset: item.dayOffset,
+    });
+    const params = new URLSearchParams({ crop: item.crop.id });
+    if (isReady) params.set('action', 'harvest');
+    navigate(`/garden/plants?${params.toString()}`);
+  };
+
+  const firstMissing = timeline.missingTiming[0];
+
+  return (
+    <section className="grn-harvest-timeline" aria-labelledby="harvest-timeline-heading">
+      <header className="grn-harvest-timeline__header">
+        <div>
+          <h2 id="harvest-timeline-heading">Coming harvests</h2>
+          <p>Approximate first harvests from the dates saved with your plants.</p>
+        </div>
+        {timeline.groups.ready.length > 0 ? (
+          <span className="grn-harvest-timeline__ready-count">
+            {timeline.groups.ready.length} ready to check
+          </span>
+        ) : null}
+      </header>
+
+      {timeline.scheduledCount > 0 ? (
+        <ol className="grn-harvest-timeline__rail" aria-label="Harvest timeline">
+          {HORIZONS.map((horizon) => (
+            <li
+              key={horizon.id}
+              className={`grn-harvest-period grn-harvest-period--${horizon.id}`}
+            >
+              <div className="grn-harvest-period__marker" aria-hidden="true">
+                <span />
+              </div>
+              <div className="grn-harvest-period__heading">
+                <span>{horizon.shortLabel}</span>
+                <h3>{horizon.label}</h3>
+              </div>
+              {timeline.groups[horizon.id].length > 0 ? (
+                <ul className="grn-harvest-period__items">
+                  {timeline.groups[horizon.id].map((item) => (
+                    <li key={item.crop.id}>
+                      <HarvestCrop item={item} onOpen={() => openCrop(item)} />
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="grn-harvest-period__empty">Nothing scheduled</p>
+              )}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="grn-harvest-timeline__empty">
+          <span aria-hidden="true">🌾</span>
+          <div>
+            <h3>Give your growing plants a harvest estimate</h3>
+            <p>Add an expected first harvest and this space will become your garden timeline.</p>
+          </div>
+        </div>
+      )}
+
+      {firstMissing ? (
+        <div className="grn-harvest-timeline__missing">
+          <p>
+            <strong>
+              {timeline.missingTiming.length} growing plant{timeline.missingTiming.length === 1 ? '' : 's'}
+            </strong>{' '}
+            {timeline.missingTiming.length === 1 ? 'needs' : 'need'} a harvest estimate.
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              const params = new URLSearchParams({ crop: firstMissing.id, action: 'timing' });
+              navigate(`/garden/plants?${params.toString()}`);
+            }}
+          >
+            Add timing
+          </Button>
+        </div>
+      ) : null}
+
+      <p className="grn-harvest-timeline__note">
+        Harvest dates are estimates. Weather, variety, and your garden’s conditions can move them.
+      </p>
+    </section>
+  );
+}
+
+function HarvestCrop({ item, onOpen }: { item: HarvestTimelineItem; onOpen: () => void }) {
+  const visual = visualForCrop(item.crop.cropName);
+  const name = cropDisplayName(item.crop);
+  const isReady = item.horizon === 'ready';
+
+  return (
+    <article
+      className={`grn-harvest-crop ${isReady ? 'grn-harvest-crop--ready' : ''}`.trim()}
+      style={{ '--harvest-crop-accent': visual.accent } as CSSProperties}
+    >
+      <div className="grn-harvest-crop__icon" aria-hidden="true">
+        <CropIcon iconKey={visual.iconKey} size={28} />
+      </div>
+      <div className="grn-harvest-crop__copy">
+        <h4>{name}</h4>
+        <p>{harvestDateLabel(item)}</p>
+        {item.crop.bedName ? <span>{item.crop.bedName}</span> : null}
+      </div>
+      <button
+        type="button"
+        className="grn-harvest-crop__action"
+        onClick={onOpen}
+        aria-label={isReady ? `Log ${name} harvest` : `View ${name}`}
+      >
+        {isReady ? 'Log harvest' : 'View'}
+        <span aria-hidden="true"> →</span>
+      </button>
+    </article>
+  );
+}
+
+export default HarvestTimeline;

--- a/apps/grn/src/components/HarvestTimeline/harvestTimelineData.test.ts
+++ b/apps/grn/src/components/HarvestTimeline/harvestTimelineData.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { GrowerCropItem } from '../../types/listing';
+import { buildHarvestTimeline, harvestDateLabel } from './harvestTimelineData';
+
+function crop(overrides: Partial<GrowerCropItem>): GrowerCropItem {
+  return {
+    id: 'crop-1',
+    userId: 'grower-1',
+    canonicalId: null,
+    cropName: 'Tomato',
+    varietyId: null,
+    status: 'growing',
+    visibility: 'private',
+    surplusEnabled: false,
+    nickname: null,
+    defaultUnit: null,
+    notes: null,
+    bedId: null,
+    bedName: null,
+    plantingDate: '2026-05-20',
+    expectedHarvestDate: null,
+    plantCount: null,
+    spacingInches: null,
+    pyramidTier: null,
+    createdAt: '2026-05-20',
+    updatedAt: '2026-05-20',
+    ...overrides,
+  };
+}
+
+describe('buildHarvestTimeline', () => {
+  const now = new Date('2026-07-21T18:00:00Z');
+
+  it('sorts growing crops into useful harvest horizons', () => {
+    const timeline = buildHarvestTimeline(
+      [
+        crop({ id: 'later', cropName: 'Pumpkin', expectedHarvestDate: '2026-09-15' }),
+        crop({ id: 'today', cropName: 'Tomato', expectedHarvestDate: '2026-07-21' }),
+        crop({ id: 'week', cropName: 'Beans', expectedHarvestDate: '2026-07-25' }),
+        crop({ id: 'month', cropName: 'Pepper', expectedHarvestDate: '2026-08-10' }),
+        crop({ id: 'overdue', cropName: 'Cucumber', expectedHarvestDate: '2026-07-18' }),
+      ],
+      now
+    );
+
+    expect(timeline.groups.ready.map((item) => item.crop.id)).toEqual(['overdue', 'today']);
+    expect(timeline.groups.week.map((item) => item.crop.id)).toEqual(['week']);
+    expect(timeline.groups.month.map((item) => item.crop.id)).toEqual(['month']);
+    expect(timeline.groups.later.map((item) => item.crop.id)).toEqual(['later']);
+    expect(timeline.scheduledCount).toBe(5);
+  });
+
+  it('keeps missing timing separate and ignores crops that are not growing', () => {
+    const timeline = buildHarvestTimeline(
+      [
+        crop({ id: 'missing', nickname: 'Sun Gold' }),
+        crop({ id: 'invalid', cropName: 'Basil', expectedHarvestDate: 'soon' }),
+        crop({ id: 'planning', status: 'planning', expectedHarvestDate: '2026-08-01' }),
+      ],
+      now
+    );
+
+    expect(timeline.scheduledCount).toBe(0);
+    expect(timeline.missingTiming.map((item) => item.id)).toEqual(['invalid', 'missing']);
+  });
+
+  it('describes due and future estimates without claiming exact readiness', () => {
+    const timeline = buildHarvestTimeline(
+      [
+        crop({ id: 'due', expectedHarvestDate: '2026-07-21' }),
+        crop({ id: 'future', expectedHarvestDate: '2026-07-22' }),
+      ],
+      now
+    );
+
+    expect(harvestDateLabel(timeline.groups.ready[0], 'en-US')).toBe('Estimated today · Jul 21');
+    expect(harvestDateLabel(timeline.groups.week[0], 'en-US')).toBe('Tomorrow · Jul 22');
+  });
+});

--- a/apps/grn/src/components/HarvestTimeline/harvestTimelineData.ts
+++ b/apps/grn/src/components/HarvestTimeline/harvestTimelineData.ts
@@ -1,0 +1,99 @@
+import type { GrowerCropItem } from '../../types/listing';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type HarvestHorizon = 'ready' | 'week' | 'month' | 'later';
+
+export interface HarvestTimelineItem {
+  crop: GrowerCropItem;
+  dayOffset: number;
+  expectedHarvestDate: string;
+  horizon: HarvestHorizon;
+}
+
+export interface HarvestTimelineData {
+  groups: Record<HarvestHorizon, HarvestTimelineItem[]>;
+  scheduledCount: number;
+  missingTiming: GrowerCropItem[];
+}
+
+function parseCalendarDay(value: string | null): number | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const timestamp = new Date(`${value}T00:00:00Z`).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function horizonFor(dayOffset: number): HarvestHorizon {
+  if (dayOffset <= 0) return 'ready';
+  if (dayOffset <= 7) return 'week';
+  if (dayOffset <= 30) return 'month';
+  return 'later';
+}
+
+export function cropDisplayName(crop: GrowerCropItem): string {
+  return crop.nickname?.trim() || crop.cropName;
+}
+
+export function buildHarvestTimeline(
+  crops: GrowerCropItem[],
+  now: Date = new Date()
+): HarvestTimelineData {
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const groups: HarvestTimelineData['groups'] = {
+    ready: [],
+    week: [],
+    month: [],
+    later: [],
+  };
+  const missingTiming: GrowerCropItem[] = [];
+
+  for (const crop of crops) {
+    if (crop.status !== 'growing') continue;
+    const target = parseCalendarDay(crop.expectedHarvestDate);
+    if (target === null) {
+      missingTiming.push(crop);
+      continue;
+    }
+
+    const dayOffset = Math.round((target - today) / DAY_MS);
+    const horizon = horizonFor(dayOffset);
+    groups[horizon].push({
+      crop,
+      dayOffset,
+      expectedHarvestDate: crop.expectedHarvestDate as string,
+      horizon,
+    });
+  }
+
+  for (const group of Object.values(groups)) {
+    group.sort(
+      (left, right) =>
+        left.dayOffset - right.dayOffset ||
+        cropDisplayName(left.crop).localeCompare(cropDisplayName(right.crop))
+    );
+  }
+  missingTiming.sort((left, right) => cropDisplayName(left).localeCompare(cropDisplayName(right)));
+
+  return {
+    groups,
+    scheduledCount: Object.values(groups).reduce((total, group) => total + group.length, 0),
+    missingTiming,
+  };
+}
+
+export function harvestDateLabel(item: HarvestTimelineItem, locale?: string): string {
+  const date = new Date(`${item.expectedHarvestDate}T00:00:00Z`);
+  const formatted = date.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  if (item.dayOffset < 0) {
+    const daysPast = Math.abs(item.dayOffset);
+    return `${daysPast} day${daysPast === 1 ? '' : 's'} past estimate · ${formatted}`;
+  }
+  if (item.dayOffset === 0) return `Estimated today · ${formatted}`;
+  if (item.dayOffset === 1) return `Tomorrow · ${formatted}`;
+  return `In ${item.dayOffset} days · ${formatted}`;
+}

--- a/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.test.tsx
@@ -88,6 +88,48 @@ describe('CropLibraryPanel deep links', () => {
     expect(await screen.findByRole('dialog')).toHaveAttribute('data-highlighted-harvest', 'h1');
   });
 
+  it('opens a linked timing editor and saves the estimate onto the crop', async () => {
+    const tomato = {
+      id: 'crop-1', userId: 'grower-1', canonicalId: 'catalog-tomato', cropName: 'Tomato',
+      varietyId: null, status: 'growing', visibility: 'private', surplusEnabled: false,
+      nickname: null, defaultUnit: 'lb', notes: null, bedId: null, bedName: null,
+      plantingDate: '2026-05-20', expectedHarvestDate: null, plantCount: null,
+      spacingInches: null, pyramidTier: null, createdAt: '2026-05-20T00:00:00Z',
+      updatedAt: '2026-05-20T00:00:00Z',
+    };
+    vi.mocked(listMyBeds).mockResolvedValue([]);
+    vi.mocked(listMyCrops).mockResolvedValue([tomato]);
+    vi.mocked(updateMyCrop).mockClear();
+    vi.mocked(updateMyCrop).mockResolvedValue({
+      ...tomato,
+      expectedHarvestDate: '2026-07-19',
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/garden/plants?crop=crop-1&action=timing']}>
+          <CropLibraryPanel viewerUserId="grower-1" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByRole('dialog', { name: 'Timing for Tomato' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: '60 days' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save timing' }));
+
+    await waitFor(() =>
+      expect(updateMyCrop).toHaveBeenCalledWith(
+        'crop-1',
+        expect.objectContaining({
+          cropName: 'Tomato',
+          plantingDate: '2026-05-20',
+          expectedHarvestDate: '2026-07-19',
+        })
+      )
+    );
+  });
+
   it('edits a user-defined crop without adding a catalog link', async () => {
     const customCrop = {
       id: 'crop-1',

--- a/apps/grn/src/components/Profile/CropLibraryPanel.tsx
+++ b/apps/grn/src/components/Profile/CropLibraryPanel.tsx
@@ -16,6 +16,7 @@ import { visualForCrop } from '../CropPlanner/cropVisuals';
 import { CropIcon } from '../CropPlanner/cropIcons';
 import { HarvestLogModal } from '../Harvests/HarvestLogModal';
 import { daysUntil, formatDate, harvestProgress } from '../../utils/cropTiming';
+import { CropTimingModal } from './CropTimingModal';
 
 const logger = createLogger('crop-library');
 
@@ -37,7 +38,9 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<'all' | 'growing' | 'planning' | 'interested'>('all');
   const [harvestCrop, setHarvestCrop] = useState<GrowerCropItem | null>(null);
+  const [timingCrop, setTimingCrop] = useState<GrowerCropItem | null>(null);
   const [dismissedLinkedHarvestId, setDismissedLinkedHarvestId] = useState<string | null>(null);
+  const [dismissedLinkedTimingId, setDismissedLinkedTimingId] = useState<string | null>(null);
   const [bedUpdateError, setBedUpdateError] = useState<string | null>(null);
 
   const { data: myCrops, isLoading: isLoadingCrops } = useQuery({
@@ -58,9 +61,16 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
     if (linkedAction !== 'harvest' || !linkedCropId || !myCrops) return null;
     return myCrops.find((crop) => crop.id === linkedCropId) ?? null;
   }, [linkedAction, linkedCropId, myCrops]);
+  const linkedTimingCrop = useMemo(() => {
+    if (linkedAction !== 'timing' || !linkedCropId || !myCrops) return null;
+    return myCrops.find((crop) => crop.id === linkedCropId) ?? null;
+  }, [linkedAction, linkedCropId, myCrops]);
   const activeHarvestCrop =
     harvestCrop ??
     (linkedHarvestCrop?.id !== dismissedLinkedHarvestId ? linkedHarvestCrop : null);
+  const activeTimingCrop =
+    timingCrop ??
+    (linkedTimingCrop?.id !== dismissedLinkedTimingId ? linkedTimingCrop : null);
 
   const deleteMutation = useMutation({
     mutationFn: deleteMyCrop,
@@ -98,6 +108,33 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
     },
     onSuccess: () => {
       logger.info('Updated crop bed assignment');
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['myCrops'] });
+    },
+  });
+
+  const timingMutation = useMutation({
+    mutationFn: ({
+      crop,
+      plantingDate,
+      expectedHarvestDate,
+    }: {
+      crop: GrowerCropItem;
+      plantingDate: string | null;
+      expectedHarvestDate: string | null;
+    }) =>
+      updateMyCrop(crop.id, {
+        ...cropUpdatePayload(crop, crop.bedId),
+        plantingDate,
+        expectedHarvestDate,
+      }),
+    onSuccess: () => {
+      logger.info('Updated crop timing');
+      setTimingCrop(null);
+      if (activeTimingCrop?.id === linkedCropId) {
+        setDismissedLinkedTimingId(activeTimingCrop.id);
+      }
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ['myCrops'] });
@@ -333,6 +370,16 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
                   >
                     Harvests
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      timingMutation.reset();
+                      setTimingCrop(crop);
+                    }}
+                  >
+                    Timing
+                  </Button>
                   {crop.bedId ? (
                     <Button
                       variant="ghost"
@@ -375,6 +422,28 @@ export function CropLibraryPanel({ viewerUserId }: CropLibraryPanelProps) {
             setHarvestCrop(null);
             if (activeHarvestCrop.id === linkedCropId) {
               setDismissedLinkedHarvestId(activeHarvestCrop.id);
+            }
+          }}
+        />
+      ) : null}
+
+      {activeTimingCrop ? (
+        <CropTimingModal
+          crop={activeTimingCrop}
+          isSaving={timingMutation.isPending}
+          saveError={
+            timingMutation.error instanceof Error
+              ? timingMutation.error.message
+              : timingMutation.isError
+                ? 'Could not save crop timing.'
+                : null
+          }
+          onSave={(dates) => timingMutation.mutate({ crop: activeTimingCrop, ...dates })}
+          onClose={() => {
+            setTimingCrop(null);
+            timingMutation.reset();
+            if (activeTimingCrop.id === linkedCropId) {
+              setDismissedLinkedTimingId(activeTimingCrop.id);
             }
           }}
         />

--- a/apps/grn/src/components/Profile/CropTimingModal.css
+++ b/apps/grn/src/components/Profile/CropTimingModal.css
@@ -1,0 +1,183 @@
+.grn-timing-modal {
+  position: fixed;
+  z-index: 60;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(38, 27, 20, 0.52);
+  backdrop-filter: blur(3px);
+}
+
+.grn-timing-modal__dialog {
+  width: min(34rem, 100%);
+  max-height: 92vh;
+  overflow-y: auto;
+  border: 1px solid rgba(79, 56, 37, 0.14);
+  border-radius: 1.15rem;
+  background: #fffdf8;
+  box-shadow: 0 24px 70px rgba(35, 24, 17, 0.24);
+}
+
+.grn-timing-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.2rem 0.95rem;
+  border-bottom: 1px solid rgba(79, 56, 37, 0.1);
+  background: linear-gradient(135deg, rgba(225, 181, 83, 0.13), rgba(66, 107, 63, 0.08));
+}
+
+.grn-timing-modal__header span {
+  color: var(--og-color-moss);
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.grn-timing-modal__header h2 {
+  margin: 0.2rem 0 0;
+  color: var(--og-color-soil);
+  font-size: 1.2rem;
+  letter-spacing: normal;
+}
+
+.grn-timing-modal__header > button {
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--og-color-soil);
+  font: inherit;
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+
+.grn-timing-modal form {
+  padding: 1.15rem 1.2rem 1.2rem;
+}
+
+.grn-timing-modal__intro {
+  margin: 0 0 1rem;
+  color: rgba(79, 56, 37, 0.76);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.grn-timing-modal__fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.grn-timing-modal__fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--og-color-soil);
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
+.grn-timing-modal__fields input {
+  min-width: 0;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid rgba(79, 56, 37, 0.22);
+  border-radius: 0.65rem;
+  background: white;
+  color: var(--og-color-soil);
+  font: inherit;
+}
+
+.grn-timing-modal__fields input:focus-visible {
+  border-color: var(--og-color-moss);
+  outline: 2px solid color-mix(in srgb, var(--og-color-moss) 26%, transparent);
+  outline-offset: 1px;
+}
+
+.grn-timing-modal__quick-picks {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+}
+
+.grn-timing-modal__quick-picks > span {
+  margin-right: 0.15rem;
+  color: rgba(79, 56, 37, 0.68);
+  font-size: 0.75rem;
+}
+
+.grn-timing-modal__quick-picks button {
+  min-height: 2.25rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid rgba(66, 107, 63, 0.2);
+  border-radius: 999px;
+  background: rgba(66, 107, 63, 0.07);
+  color: var(--og-color-moss);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.grn-timing-modal__quick-picks button:hover,
+.grn-timing-modal__quick-picks button:focus-visible {
+  border-color: rgba(66, 107, 63, 0.45);
+  background: rgba(66, 107, 63, 0.13);
+  outline: none;
+}
+
+.grn-timing-modal__hint,
+.grn-timing-modal__error {
+  margin: 0.8rem 0 0;
+  font-size: 0.8rem;
+}
+
+.grn-timing-modal__hint {
+  color: var(--og-color-moss);
+}
+
+.grn-timing-modal__error {
+  color: #a12b23;
+}
+
+.grn-timing-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.15rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid rgba(79, 56, 37, 0.1);
+}
+
+@media (max-width: 520px) {
+  .grn-timing-modal {
+    align-items: end;
+    padding: 0;
+  }
+
+  .grn-timing-modal__dialog {
+    width: 100%;
+    max-height: 94vh;
+    border-radius: 1.15rem 1.15rem 0 0;
+  }
+
+  .grn-timing-modal__fields {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grn-timing-modal,
+  .grn-timing-modal * {
+    transition: none !important;
+  }
+}

--- a/apps/grn/src/components/Profile/CropTimingModal.test.tsx
+++ b/apps/grn/src/components/Profile/CropTimingModal.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { GrowerCropItem } from '../../types/listing';
+import { CropTimingModal } from './CropTimingModal';
+
+const crop = {
+  id: 'crop-1',
+  userId: 'grower-1',
+  canonicalId: null,
+  cropName: 'Tomato',
+  varietyId: null,
+  status: 'growing',
+  visibility: 'private',
+  surplusEnabled: false,
+  nickname: 'Sun Gold',
+  defaultUnit: null,
+  notes: null,
+  bedId: null,
+  bedName: null,
+  plantingDate: '2026-05-20',
+  expectedHarvestDate: null,
+  plantCount: null,
+  spacingInches: null,
+  pyramidTier: null,
+  createdAt: '2026-05-20',
+  updatedAt: '2026-05-20',
+} satisfies GrowerCropItem;
+
+describe('CropTimingModal', () => {
+  it('saves a quick estimate from the recorded planting date', async () => {
+    const onSave = vi.fn();
+    render(
+      <CropTimingModal crop={crop} isSaving={false} onSave={onSave} onClose={vi.fn()} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '75 days' }));
+    expect(screen.getByLabelText('Expected first harvest')).toHaveValue('2026-08-03');
+    await userEvent.click(screen.getByRole('button', { name: 'Save timing' }));
+    expect(onSave).toHaveBeenCalledWith({
+      plantingDate: '2026-05-20',
+      expectedHarvestDate: '2026-08-03',
+    });
+  });
+
+  it('rejects a harvest estimate before the planting date', async () => {
+    const onSave = vi.fn();
+    render(
+      <CropTimingModal crop={crop} isSaving={false} onSave={onSave} onClose={vi.fn()} />
+    );
+
+    await userEvent.type(screen.getByLabelText('Expected first harvest'), '2026-05-01');
+    await userEvent.click(screen.getByRole('button', { name: 'Save timing' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/on or after the planting date/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/grn/src/components/Profile/CropTimingModal.tsx
+++ b/apps/grn/src/components/Profile/CropTimingModal.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@olivias/ui';
+import type { GrowerCropItem } from '../../types/listing';
+import './CropTimingModal.css';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDaysIso(base: string, days: number): string {
+  const date = new Date(`${base}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function daysBetween(start: string, end: string): number | null {
+  if (!start || !end) return null;
+  const startAt = new Date(`${start}T00:00:00Z`).getTime();
+  const endAt = new Date(`${end}T00:00:00Z`).getTime();
+  if (Number.isNaN(startAt) || Number.isNaN(endAt)) return null;
+  return Math.round((endAt - startAt) / DAY_MS);
+}
+
+interface CropTimingModalProps {
+  crop: GrowerCropItem;
+  isSaving: boolean;
+  saveError?: string | null;
+  onSave: (dates: { plantingDate: string | null; expectedHarvestDate: string | null }) => void;
+  onClose: () => void;
+}
+
+export function CropTimingModal({
+  crop,
+  isSaving,
+  saveError,
+  onSave,
+  onClose,
+}: CropTimingModalProps) {
+  const [plantingDate, setPlantingDate] = useState(crop.plantingDate ?? '');
+  const [expectedHarvestDate, setExpectedHarvestDate] = useState(crop.expectedHarvestDate ?? '');
+  const [formError, setFormError] = useState<string | null>(null);
+  const cropName = crop.nickname?.trim() || crop.cropName;
+  const harvestDays = useMemo(
+    () => daysBetween(plantingDate, expectedHarvestDate),
+    [expectedHarvestDate, plantingDate]
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+    if (harvestDays !== null && harvestDays < 0) {
+      setFormError('Expected harvest must be on or after the planting date.');
+      return;
+    }
+    onSave({
+      plantingDate: plantingDate || null,
+      expectedHarvestDate: expectedHarvestDate || null,
+    });
+  };
+
+  return (
+    <div className="grn-timing-modal" onClick={onClose}>
+      <div
+        className="grn-timing-modal__dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="crop-timing-heading"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="grn-timing-modal__header">
+          <div>
+            <span>Harvest timeline</span>
+            <h2 id="crop-timing-heading">Timing for {cropName}</h2>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close timing editor">
+            ×
+          </button>
+        </header>
+
+        <form onSubmit={submit}>
+          <p className="grn-timing-modal__intro">
+            Save your best estimate for the first harvest. The timeline will treat it as a helpful
+            check-in, not a guarantee.
+          </p>
+
+          <div className="grn-timing-modal__fields">
+            <label>
+              <span>Planting date</span>
+              <input
+                type="date"
+                value={plantingDate}
+                onChange={(event) => setPlantingDate(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>Expected first harvest</span>
+              <input
+                type="date"
+                value={expectedHarvestDate}
+                onChange={(event) => setExpectedHarvestDate(event.target.value)}
+              />
+            </label>
+          </div>
+
+          <div className="grn-timing-modal__quick-picks" role="group" aria-label="Quick harvest estimates">
+            <span>Estimate from planting:</span>
+            {[60, 75, 90, 120].map((days) => (
+              <button
+                key={days}
+                type="button"
+                onClick={() => {
+                  const start = plantingDate || todayIso();
+                  setPlantingDate(start);
+                  setExpectedHarvestDate(addDaysIso(start, days));
+                }}
+              >
+                {days} days
+              </button>
+            ))}
+          </div>
+
+          {harvestDays !== null && harvestDays >= 0 ? (
+            <p className="grn-timing-modal__hint">
+              About {harvestDays} day{harvestDays === 1 ? '' : 's'} from planting to first harvest.
+            </p>
+          ) : null}
+
+          {formError || saveError ? (
+            <p className="grn-timing-modal__error" role="alert">
+              {formError || saveError}
+            </p>
+          ) : null}
+
+          <footer className="grn-timing-modal__actions">
+            <Button type="button" variant="ghost" size="md" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="md" disabled={isSaving}>
+              {isSaving ? 'Saving…' : 'Save timing'}
+            </Button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/grn/src/components/Seasonality/SeasonalGuide.css
+++ b/apps/grn/src/components/Seasonality/SeasonalGuide.css
@@ -1,0 +1,468 @@
+.grn-season-guide {
+  --season-sky-top: #d7ead7;
+  --season-sky-bottom: #f5d998;
+  --season-sun: #edb649;
+  --season-far-hill: #8da86c;
+  --season-near-hill: #567848;
+  --season-soil: #705239;
+  --season-plant: #355d37;
+  overflow: hidden;
+  border: 1px solid rgba(79, 56, 37, 0.14);
+  border-radius: 1.4rem;
+  background: rgba(255, 252, 246, 0.92);
+  box-shadow: 0 18px 44px rgba(49, 34, 22, 0.09);
+}
+
+.grn-season-guide--spring {
+  --season-sky-top: #cfe8db;
+  --season-sky-bottom: #f7e4aa;
+  --season-sun: #f1bd50;
+  --season-far-hill: #97b77a;
+  --season-near-hill: #5f8a50;
+  --season-soil: #79583c;
+  --season-plant: #3f7141;
+}
+
+.grn-season-guide--summer {
+  --season-sky-top: #b9dce8;
+  --season-sky-bottom: #f8dea0;
+  --season-sun: #f0ae35;
+  --season-far-hill: #789856;
+  --season-near-hill: #476f40;
+  --season-soil: #6e4c31;
+  --season-plant: #294f31;
+}
+
+.grn-season-guide--fall {
+  --season-sky-top: #e8c9aa;
+  --season-sky-bottom: #f2d49a;
+  --season-sun: #d97836;
+  --season-far-hill: #a17548;
+  --season-near-hill: #72533a;
+  --season-soil: #62452f;
+  --season-plant: #7d4b2c;
+}
+
+.grn-season-guide--winter {
+  --season-sky-top: #cfdfe2;
+  --season-sky-bottom: #ecede5;
+  --season-sun: #d9c98e;
+  --season-far-hill: #96a59a;
+  --season-near-hill: #63756d;
+  --season-soil: #63584d;
+  --season-plant: #4c5a4f;
+}
+
+.grn-season-guide--unset {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.8fr);
+  gap: 1rem;
+  padding: 1.1rem;
+  background: linear-gradient(135deg, rgba(255, 252, 246, 0.98), rgba(229, 239, 218, 0.92));
+}
+
+.grn-season-guide__empty-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(0.35rem, 1.5vw, 1.2rem);
+}
+
+.grn-season-guide__empty-copy h2,
+.grn-season-guide__copy h2 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-size: clamp(1.35rem, 2.4vw, 2rem);
+  line-height: 1.15;
+  letter-spacing: normal;
+}
+
+.grn-season-guide__empty-copy p,
+.grn-season-guide__copy p {
+  max-width: 58ch;
+  margin: 0.7rem 0 1rem;
+  color: rgba(79, 56, 37, 0.82);
+  line-height: 1.55;
+}
+
+.grn-season-guide__intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(20rem, 0.9fr);
+  min-height: 13rem;
+  padding: 1.1rem;
+  gap: 1rem;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(255, 255, 255, 0.7), transparent 38%),
+    linear-gradient(135deg, color-mix(in srgb, var(--season-sky-bottom) 42%, white), rgba(255, 252, 246, 0.92));
+}
+
+.grn-season-guide__copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(0.35rem, 1.5vw, 1.2rem);
+}
+
+.grn-season-guide__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
+  color: var(--og-color-moss);
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.grn-season-scene {
+  position: relative;
+  isolation: isolate;
+  min-height: 11rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 1.15rem;
+  background: linear-gradient(180deg, var(--season-sky-top), var(--season-sky-bottom));
+  box-shadow: inset 0 0 50px rgba(255, 255, 255, 0.3), 0 12px 28px rgba(65, 48, 31, 0.12);
+}
+
+.grn-season-scene::after {
+  position: absolute;
+  z-index: 8;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1.1rem;
+  background: linear-gradient(180deg, var(--season-soil), color-mix(in srgb, var(--season-soil) 78%, black));
+  content: '';
+}
+
+.grn-season-scene__sun {
+  position: absolute;
+  z-index: 1;
+  top: 1.2rem;
+  right: 15%;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  background: var(--season-sun);
+  box-shadow: 0 0 0 0.7rem color-mix(in srgb, var(--season-sun) 24%, transparent),
+              0 0 2.2rem color-mix(in srgb, var(--season-sun) 58%, transparent);
+}
+
+.grn-season-scene__cloud {
+  position: absolute;
+  z-index: 2;
+  width: 3.4rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.66);
+  box-shadow: 0.8rem -0.35rem 0 -0.08rem rgba(255, 255, 255, 0.66),
+              1.65rem 0.03rem 0 -0.08rem rgba(255, 255, 255, 0.66);
+}
+
+.grn-season-scene__cloud--one {
+  top: 2rem;
+  left: 12%;
+}
+
+.grn-season-scene__cloud--two {
+  top: 4.5rem;
+  left: 47%;
+  scale: 0.65;
+  opacity: 0.72;
+}
+
+.grn-season-scene__hill {
+  position: absolute;
+  border-radius: 50% 50% 0 0;
+  transform-origin: bottom;
+}
+
+.grn-season-scene__hill--far {
+  z-index: 3;
+  right: -13%;
+  bottom: 2.7rem;
+  width: 78%;
+  height: 6.2rem;
+  background: var(--season-far-hill);
+  transform: rotate(4deg);
+}
+
+.grn-season-scene__hill--near {
+  z-index: 4;
+  bottom: 0.9rem;
+  left: -18%;
+  width: 90%;
+  height: 6.8rem;
+  background: var(--season-near-hill);
+  transform: rotate(-3deg);
+}
+
+.grn-season-scene__row {
+  position: absolute;
+  z-index: 5;
+  right: -4%;
+  bottom: 1rem;
+  width: 72%;
+  height: 3.8rem;
+  border-radius: 65% 0 0;
+  background: repeating-linear-gradient(
+    102deg,
+    color-mix(in srgb, var(--season-soil) 94%, white) 0 0.55rem,
+    color-mix(in srgb, var(--season-soil) 73%, black) 0.55rem 0.85rem
+  );
+  opacity: 0.88;
+  transform: skewY(-4deg);
+}
+
+.grn-season-scene__plant {
+  position: absolute;
+  z-index: 7;
+  bottom: 1.05rem;
+  width: 0.2rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--season-plant);
+  transform-origin: bottom;
+}
+
+.grn-season-scene__plant::before,
+.grn-season-scene__plant::after {
+  position: absolute;
+  width: 1.2rem;
+  height: 0.62rem;
+  border-radius: 100% 0 100% 0;
+  background: var(--season-plant);
+  content: '';
+}
+
+.grn-season-scene__plant::before {
+  top: 0.55rem;
+  right: 0.1rem;
+  transform: rotate(18deg);
+}
+
+.grn-season-scene__plant::after {
+  top: 1.15rem;
+  left: 0.1rem;
+  transform: scaleX(-1) rotate(18deg);
+}
+
+.grn-season-scene__plant--one {
+  left: 21%;
+  height: 2.7rem;
+  transform: rotate(-5deg);
+}
+
+.grn-season-scene__plant--two {
+  left: 36%;
+  height: 3.4rem;
+}
+
+.grn-season-scene__plant--three {
+  left: 53%;
+  height: 2.35rem;
+  transform: rotate(5deg);
+}
+
+.grn-season-scene__spark {
+  display: none;
+  position: absolute;
+  z-index: 6;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 1.8rem 2.4rem 0 rgba(255, 255, 255, 0.78),
+              4.2rem 0.8rem 0 rgba(255, 255, 255, 0.72);
+}
+
+.grn-season-scene__spark--one { top: 1.2rem; left: 8%; }
+.grn-season-scene__spark--two { top: 3.7rem; left: 54%; scale: 0.7; }
+.grn-season-scene__spark--three { top: 2rem; left: 72%; scale: 0.5; }
+
+.grn-season-scene--winter .grn-season-scene__spark {
+  display: block;
+}
+
+.grn-season-scene--winter .grn-season-scene__plant::before,
+.grn-season-scene--winter .grn-season-scene__plant::after {
+  width: 0.85rem;
+  height: 0.18rem;
+}
+
+.grn-season-guide__suggestions {
+  padding: 1.1rem clamp(1rem, 2vw, 1.5rem) 1.25rem;
+  border-top: 1px solid rgba(79, 56, 37, 0.1);
+}
+
+.grn-season-guide__suggestion-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.grn-season-guide__suggestion-heading h3 {
+  margin: 0;
+  color: var(--og-color-soil);
+  font-size: 1.05rem;
+  letter-spacing: normal;
+}
+
+.grn-season-guide__suggestion-heading span {
+  color: rgba(79, 56, 37, 0.68);
+  font-size: 0.8rem;
+}
+
+.grn-season-guide__crop-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.grn-season-crop {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 0.7rem;
+  min-width: 0;
+  padding: 0.85rem;
+  border: 1px solid rgba(79, 56, 37, 0.11);
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.grn-season-crop__icon {
+  display: grid;
+  place-items: center;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--season-crop-accent) 16%, white);
+  color: var(--season-crop-accent);
+}
+
+.grn-season-crop__copy {
+  min-width: 0;
+}
+
+.grn-season-crop__topline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 1.25rem;
+}
+
+.grn-season-crop__action,
+.grn-season-crop__owned {
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.grn-season-crop__action {
+  color: var(--og-color-moss);
+}
+
+.grn-season-crop__owned {
+  padding: 0.12rem 0.36rem;
+  border-radius: 999px;
+  background: rgba(216, 167, 65, 0.18);
+  color: #795b20;
+}
+
+.grn-season-crop h4 {
+  margin: 0.18rem 0 0.28rem;
+  color: var(--og-color-soil);
+  font-size: 0.98rem;
+  line-height: 1.25;
+  letter-spacing: normal;
+}
+
+.grn-season-crop p {
+  margin: 0;
+  color: rgba(79, 56, 37, 0.73);
+  font-size: 0.78rem;
+  line-height: 1.42;
+}
+
+.grn-season-crop__link {
+  min-height: 2.3rem;
+  margin: 0.45rem 0 -0.4rem;
+  padding: 0.35rem 0;
+  border: none;
+  background: transparent;
+  color: var(--og-color-moss);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.grn-season-crop__link:hover,
+.grn-season-crop__link:focus-visible {
+  color: color-mix(in srgb, var(--og-color-moss) 78%, black);
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+  outline: none;
+}
+
+.grn-season-guide__note {
+  margin: 0.85rem 0 0;
+  color: rgba(79, 56, 37, 0.66);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 900px) {
+  .grn-season-guide__intro,
+  .grn-season-guide--unset {
+    grid-template-columns: minmax(0, 1fr) minmax(15rem, 0.8fr);
+  }
+
+  .grn-season-guide__crop-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .grn-season-guide__intro,
+  .grn-season-guide--unset {
+    grid-template-columns: 1fr;
+    padding: 0.75rem;
+  }
+
+  .grn-season-guide__copy,
+  .grn-season-guide__empty-copy {
+    padding: 0.65rem 0.5rem 0.25rem;
+  }
+
+  .grn-season-scene {
+    min-height: 9rem;
+  }
+
+  .grn-season-guide__suggestion-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grn-season-guide *,
+  .grn-season-guide *::before,
+  .grn-season-guide *::after {
+    scroll-behavior: auto;
+    transition: none !important;
+  }
+}

--- a/apps/grn/src/components/Seasonality/SeasonalGuide.test.tsx
+++ b/apps/grn/src/components/Seasonality/SeasonalGuide.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { GrowerCropItem } from '../../types/listing';
+import type { GrowerProfile } from '../../types/user';
+import { SeasonalGuide } from './SeasonalGuide';
+
+const growerProfile: GrowerProfile = {
+  homeZone: '8b',
+  address: 'McKinney, Texas',
+  geoKey: 'geo-8b',
+  lat: 33.2,
+  lng: -96.6,
+  shareRadiusMiles: 5,
+  isOrganization: false,
+  units: 'imperial',
+  locale: 'en-US',
+};
+
+const okra: GrowerCropItem = {
+  id: 'crop-okra',
+  userId: 'grower-1',
+  canonicalId: 'catalog-okra',
+  cropName: 'Okra',
+  varietyId: null,
+  status: 'growing',
+  visibility: 'local',
+  surplusEnabled: false,
+  nickname: null,
+  defaultUnit: null,
+  notes: null,
+  bedId: null,
+  bedName: null,
+  plantingDate: null,
+  expectedHarvestDate: null,
+  plantCount: null,
+  spacingInches: null,
+  pyramidTier: null,
+  createdAt: '2026-05-01',
+  updatedAt: '2026-07-01',
+};
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}{location.hash}</output>;
+}
+
+function renderGuide(profile: GrowerProfile | null = growerProfile, crops = [okra]) {
+  return render(
+    <MemoryRouter>
+      <SeasonalGuide
+        growerProfile={profile}
+        crops={crops}
+        now={new Date(2026, 6, 15)}
+      />
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('SeasonalGuide', () => {
+  it('shows local seasonality and opens crops already in the garden', async () => {
+    const user = userEvent.setup();
+    renderGuide();
+
+    expect(screen.getByRole('heading', { name: 'High summer in Zone 8b' })).toBeInTheDocument();
+    expect(screen.getByText('In your garden')).toBeInTheDocument();
+    expect(screen.getByText(/frost dates, current weather, shade/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Open Okra' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/garden/plants?crop=crop-okra');
+  });
+
+  it('carries a new suggestion into the add-crop flow', async () => {
+    const user = userEvent.setup();
+    renderGuide(growerProfile, []);
+
+    await user.click(screen.getByRole('button', { name: 'Plan Broccoli' }));
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/garden/plants/new?suggestion=Broccoli&source=seasonal-guide'
+    );
+  });
+
+  it('offers a clear recovery path when the growing zone is unavailable', async () => {
+    const user = userEvent.setup();
+    renderGuide(null, []);
+
+    expect(screen.getByRole('heading', { name: 'Make Today local to your garden' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Review growing zone' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/settings#profile');
+  });
+});

--- a/apps/grn/src/components/Seasonality/SeasonalGuide.tsx
+++ b/apps/grn/src/components/Seasonality/SeasonalGuide.tsx
@@ -1,0 +1,153 @@
+import { Button } from '@olivias/ui';
+import type { CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { GrowerCropItem } from '../../types/listing';
+import type { GrowerProfile } from '../../types/user';
+import { CropIcon } from '../CropPlanner/cropIcons';
+import { visualForCrop } from '../CropPlanner/cropVisuals';
+import { createLogger } from '../../utils/logging';
+import { buildSeasonalGuide } from './seasonality';
+import './SeasonalGuide.css';
+
+const logger = createLogger('seasonal-guide');
+
+export interface SeasonalGuideProps {
+  growerProfile?: GrowerProfile | null;
+  crops?: GrowerCropItem[];
+  now?: Date;
+}
+
+function normalizedCropName(name: string): string {
+  return name.trim().toLocaleLowerCase();
+}
+
+export function SeasonalGuide({ growerProfile, crops = [], now }: SeasonalGuideProps) {
+  const navigate = useNavigate();
+  const guide = buildSeasonalGuide({
+    homeZone: growerProfile?.homeZone,
+    lat: growerProfile?.lat,
+    locale: growerProfile?.locale,
+    date: now,
+  });
+
+  if (!guide) {
+    return (
+      <section className="grn-season-guide grn-season-guide--unset" aria-labelledby="season-guide-heading">
+        <div className="grn-season-guide__empty-copy">
+          <span className="grn-season-guide__kicker">Your growing season</span>
+          <h2 id="season-guide-heading">Make Today local to your garden</h2>
+          <p>Add your growing zone to see a seasonal landscape and timely ideas for what to plant.</p>
+          <Button variant="secondary" size="sm" onClick={() => navigate('/settings#profile')}>
+            Review growing zone
+          </Button>
+        </div>
+        <SeasonScene season="spring" />
+      </section>
+    );
+  }
+
+  const cropsByName = new Map(crops.map((crop) => [normalizedCropName(crop.cropName), crop]));
+
+  return (
+    <section
+      className={`grn-season-guide grn-season-guide--${guide.season}`}
+      aria-labelledby="season-guide-heading"
+    >
+      <div className="grn-season-guide__intro">
+        <div className="grn-season-guide__copy">
+          <span className="grn-season-guide__kicker">
+            {guide.monthName} <span aria-hidden="true">·</span> Your local season
+          </span>
+          <h2 id="season-guide-heading">{guide.title}</h2>
+          <p>{guide.summary}</p>
+        </div>
+        <SeasonScene season={guide.season} />
+      </div>
+
+      <div className="grn-season-guide__suggestions">
+        <div className="grn-season-guide__suggestion-heading">
+          <h3>Good to grow now</h3>
+          <span>Three starting points for your garden</span>
+        </div>
+        <ul className="grn-season-guide__crop-grid">
+          {guide.suggestions.map((suggestion) => {
+            const existingCrop = cropsByName.get(normalizedCropName(suggestion.cropName));
+            const visual = visualForCrop(suggestion.cropName);
+            const buttonLabel = existingCrop
+              ? `Open ${suggestion.cropName}`
+              : `Plan ${suggestion.cropName}`;
+
+            return (
+              <li key={suggestion.cropName} className="grn-season-crop">
+                <div
+                  className="grn-season-crop__icon"
+                  style={{ '--season-crop-accent': visual.accent } as CSSProperties}
+                  aria-hidden="true"
+                >
+                  <CropIcon iconKey={visual.iconKey} size={32} />
+                </div>
+                <div className="grn-season-crop__copy">
+                  <div className="grn-season-crop__topline">
+                    <span className="grn-season-crop__action">{suggestion.actionLabel}</span>
+                    {existingCrop ? <span className="grn-season-crop__owned">In your garden</span> : null}
+                  </div>
+                  <h4>{suggestion.cropName}</h4>
+                  <p>{suggestion.why}</p>
+                  <button
+                    type="button"
+                    className="grn-season-crop__link"
+                    onClick={() => {
+                      logger.info('Seasonal suggestion opened', {
+                        cropName: suggestion.cropName,
+                        season: guide.season,
+                        climateBand: guide.climateBand,
+                        alreadyGrowing: Boolean(existingCrop),
+                      });
+                      if (existingCrop) {
+                        navigate(`/garden/plants?crop=${encodeURIComponent(existingCrop.id)}`);
+                      } else {
+                        const params = new URLSearchParams({
+                          suggestion: suggestion.cropName,
+                          source: 'seasonal-guide',
+                        });
+                        navigate(`/garden/plants/new?${params.toString()}`);
+                      }
+                    }}
+                  >
+                    {buttonLabel}
+                    <span aria-hidden="true"> →</span>
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+        <p className="grn-season-guide__note">
+          Planting windows are a starting point. Frost dates, current weather, shade, and your garden’s
+          microclimate can shift the best timing.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function SeasonScene({ season }: { season: 'spring' | 'summer' | 'fall' | 'winter' }) {
+  return (
+    <div className={`grn-season-scene grn-season-scene--${season}`} aria-hidden="true">
+      <span className="grn-season-scene__sun" />
+      <span className="grn-season-scene__cloud grn-season-scene__cloud--one" />
+      <span className="grn-season-scene__cloud grn-season-scene__cloud--two" />
+      <span className="grn-season-scene__hill grn-season-scene__hill--far" />
+      <span className="grn-season-scene__hill grn-season-scene__hill--near" />
+      <span className="grn-season-scene__row" />
+      <span className="grn-season-scene__plant grn-season-scene__plant--one" />
+      <span className="grn-season-scene__plant grn-season-scene__plant--two" />
+      <span className="grn-season-scene__plant grn-season-scene__plant--three" />
+      <span className="grn-season-scene__spark grn-season-scene__spark--one" />
+      <span className="grn-season-scene__spark grn-season-scene__spark--two" />
+      <span className="grn-season-scene__spark grn-season-scene__spark--three" />
+    </div>
+  );
+}
+
+export default SeasonalGuide;

--- a/apps/grn/src/components/Seasonality/seasonality.test.ts
+++ b/apps/grn/src/components/Seasonality/seasonality.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeasonalGuide, parseHardinessZone } from './seasonality';
+
+describe('seasonality guidance', () => {
+  it('builds warm-zone midsummer guidance from a saved hardiness zone', () => {
+    const guide = buildSeasonalGuide({
+      homeZone: '8b',
+      lat: 33.2,
+      locale: 'en-US',
+      date: new Date(2026, 6, 15),
+    });
+
+    expect(guide).toMatchObject({
+      season: 'summer',
+      climateBand: 'warm',
+      zone: '8b',
+      monthName: 'July',
+      title: 'High summer in Zone 8b',
+    });
+    expect(guide?.suggestions.map((suggestion) => suggestion.cropName)).toEqual([
+      'Okra',
+      'Southern peas',
+      'Broccoli',
+    ]);
+  });
+
+  it('shifts the season and planting month in the southern hemisphere', () => {
+    const guide = buildSeasonalGuide({
+      homeZone: '10a',
+      lat: -27.5,
+      locale: 'en-AU',
+      date: new Date(2026, 6, 15),
+    });
+
+    expect(guide).toMatchObject({
+      season: 'winter',
+      climateBand: 'hot',
+      monthName: 'July',
+      title: 'Deep winter in Zone 10a',
+    });
+    expect(guide?.suggestions[0].cropName).toBe('Tomatoes');
+  });
+
+  it('returns three distinct suggestions for every month and climate band', () => {
+    const representativeZones = ['4a', '6b', '8b', '11a'];
+
+    for (const homeZone of representativeZones) {
+      for (let month = 0; month < 12; month += 1) {
+        const guide = buildSeasonalGuide({
+          homeZone,
+          lat: 33,
+          date: new Date(2026, month, 15),
+        });
+        const cropNames = guide?.suggestions.map((suggestion) => suggestion.cropName) ?? [];
+        expect(cropNames).toHaveLength(3);
+        expect(new Set(cropNames).size).toBe(3);
+      }
+    }
+  });
+
+  it('accepts valid USDA half-zones and rejects unusable values', () => {
+    expect(parseHardinessZone(' 8B ')).toEqual({ number: 8, label: '8b' });
+    expect(parseHardinessZone('13')).toEqual({ number: 13, label: '13' });
+    expect(parseHardinessZone('0a')).toBeNull();
+    expect(parseHardinessZone('14')).toBeNull();
+    expect(parseHardinessZone('warm')).toBeNull();
+  });
+});

--- a/apps/grn/src/components/Seasonality/seasonality.ts
+++ b/apps/grn/src/components/Seasonality/seasonality.ts
@@ -1,0 +1,326 @@
+export type SeasonId = 'spring' | 'summer' | 'fall' | 'winter';
+
+export type ClimateBand = 'short-season' | 'temperate' | 'warm' | 'hot';
+
+export type PlantingAction =
+  | 'start-indoors'
+  | 'direct-sow'
+  | 'transplant'
+  | 'plant-cloves'
+  | 'plant-slips'
+  | 'tend-now'
+  | 'plan-ahead';
+
+type CropId =
+  | 'basil'
+  | 'beets'
+  | 'broccoli'
+  | 'bush-beans'
+  | 'carrots'
+  | 'cucumber'
+  | 'eggplant'
+  | 'garlic'
+  | 'herbs'
+  | 'kale'
+  | 'lettuce'
+  | 'okra'
+  | 'onions'
+  | 'peas'
+  | 'peppers'
+  | 'potatoes'
+  | 'radishes'
+  | 'southern-peas'
+  | 'spinach'
+  | 'squash'
+  | 'sweet-potatoes'
+  | 'swiss-chard'
+  | 'tomatoes';
+
+interface CropDefinition {
+  name: string;
+  why: string;
+}
+
+type CropPlan = readonly [cropId: CropId, action: PlantingAction];
+
+export interface SeasonalSuggestion {
+  cropName: string;
+  action: PlantingAction;
+  actionLabel: string;
+  why: string;
+}
+
+export interface SeasonalGuideData {
+  season: SeasonId;
+  climateBand: ClimateBand;
+  zone: string;
+  monthName: string;
+  title: string;
+  summary: string;
+  suggestions: SeasonalSuggestion[];
+}
+
+const CROP_DEFINITIONS: Record<CropId, CropDefinition> = {
+  basil: {
+    name: 'Basil',
+    why: 'Warm soil and regular picking keep this kitchen herb producing.',
+  },
+  beets: {
+    name: 'Beets',
+    why: 'Cooler soil supports tender roots, and the greens are useful too.',
+  },
+  broccoli: {
+    name: 'Broccoli',
+    why: 'A protected start now can set up sturdy plants for cooler weather.',
+  },
+  'bush-beans': {
+    name: 'Bush beans',
+    why: 'They mature quickly in warm soil and fit easily into small garden gaps.',
+  },
+  carrots: {
+    name: 'Carrots',
+    why: 'Even moisture and cooling soil help roots grow straight and sweet.',
+  },
+  cucumber: {
+    name: 'Cucumber',
+    why: 'Warm soil and a simple trellis can turn a small space into a steady harvest.',
+  },
+  eggplant: {
+    name: 'Eggplant',
+    why: 'Long, warm days help these heat-loving plants flower and set fruit.',
+  },
+  garlic: {
+    name: 'Garlic',
+    why: 'A cool-season start gives cloves time to root before spring growth.',
+  },
+  herbs: {
+    name: 'Kitchen herbs',
+    why: 'A sunny windowsill or protected bed keeps fresh flavor close at hand.',
+  },
+  kale: {
+    name: 'Kale',
+    why: 'This sturdy green handles cool weather and becomes sweeter after a light frost.',
+  },
+  lettuce: {
+    name: 'Leaf lettuce',
+    why: 'Fast-growing leaves make good use of mild weather and shorter days.',
+  },
+  okra: {
+    name: 'Okra',
+    why: 'Hot soil and long days are exactly what this resilient crop prefers.',
+  },
+  onions: {
+    name: 'Onions',
+    why: 'An early start gives seedlings time to build size before bulb formation.',
+  },
+  peas: {
+    name: 'Garden peas',
+    why: 'Cool soil and a light trellis support tender shoots and an early harvest.',
+  },
+  peppers: {
+    name: 'Peppers',
+    why: 'Consistent warmth helps transplants settle in and keep setting fruit.',
+  },
+  potatoes: {
+    name: 'Potatoes',
+    why: 'Mild soil gives seed potatoes time to establish before stronger heat arrives.',
+  },
+  radishes: {
+    name: 'Radishes',
+    why: 'These quick roots are a low-friction way to use a short cool-weather window.',
+  },
+  'southern-peas': {
+    name: 'Southern peas',
+    why: 'They tolerate heat well and keep growing when many cool-season crops slow down.',
+  },
+  spinach: {
+    name: 'Spinach',
+    why: 'Cool conditions support tender leaves and delay premature flowering.',
+  },
+  squash: {
+    name: 'Summer squash',
+    why: 'Warm soil supports fast growth and an early, generous harvest.',
+  },
+  'sweet-potatoes': {
+    name: 'Sweet potatoes',
+    why: 'Slips thrive once the soil is warm and have time to fill out before cool weather.',
+  },
+  'swiss-chard': {
+    name: 'Swiss chard',
+    why: 'This resilient leafy green tolerates more warmth than spinach or lettuce.',
+  },
+  tomatoes: {
+    name: 'Tomatoes',
+    why: 'Warm nights and steady sun help established plants flower and ripen fruit.',
+  },
+};
+
+const ACTION_LABELS: Record<PlantingAction, string> = {
+  'start-indoors': 'Start indoors',
+  'direct-sow': 'Direct sow',
+  transplant: 'Transplant',
+  'plant-cloves': 'Plant cloves',
+  'plant-slips': 'Plant slips',
+  'tend-now': 'Sow or tend',
+  'plan-ahead': 'Plan ahead',
+};
+
+// The monthly plans are intentionally broad starting points. A hardiness zone
+// describes winter cold, not an exact planting date, so the UI always reminds
+// growers to account for local frost, weather, shade, and microclimates.
+const MONTHLY_PLANS: Record<ClimateBand, readonly (readonly CropPlan[])[]> = {
+  'short-season': [
+    [['onions', 'start-indoors'], ['broccoli', 'start-indoors'], ['herbs', 'start-indoors'], ['lettuce', 'start-indoors'], ['kale', 'start-indoors']],
+    [['onions', 'start-indoors'], ['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['lettuce', 'start-indoors'], ['herbs', 'start-indoors']],
+    [['peas', 'direct-sow'], ['spinach', 'direct-sow'], ['radishes', 'direct-sow'], ['broccoli', 'start-indoors'], ['lettuce', 'start-indoors']],
+    [['carrots', 'direct-sow'], ['beets', 'direct-sow'], ['lettuce', 'direct-sow'], ['peas', 'direct-sow'], ['kale', 'direct-sow']],
+    [['bush-beans', 'direct-sow'], ['cucumber', 'start-indoors'], ['squash', 'transplant'], ['basil', 'transplant'], ['tomatoes', 'transplant']],
+    [['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['squash', 'direct-sow'], ['basil', 'transplant']],
+    [['bush-beans', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['kale', 'start-indoors'], ['broccoli', 'start-indoors'], ['radishes', 'plan-ahead']],
+    [['spinach', 'direct-sow'], ['radishes', 'direct-sow'], ['kale', 'direct-sow'], ['lettuce', 'direct-sow'], ['carrots', 'direct-sow']],
+    [['garlic', 'plan-ahead'], ['spinach', 'direct-sow'], ['radishes', 'direct-sow'], ['kale', 'transplant'], ['peas', 'direct-sow']],
+    [['garlic', 'plant-cloves'], ['kale', 'tend-now'], ['spinach', 'tend-now'], ['herbs', 'start-indoors'], ['lettuce', 'start-indoors']],
+    [['garlic', 'plant-cloves'], ['herbs', 'start-indoors'], ['lettuce', 'start-indoors'], ['kale', 'tend-now'], ['onions', 'plan-ahead']],
+    [['herbs', 'start-indoors'], ['onions', 'plan-ahead'], ['broccoli', 'plan-ahead'], ['lettuce', 'start-indoors'], ['kale', 'start-indoors']],
+  ],
+  temperate: [
+    [['onions', 'start-indoors'], ['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['lettuce', 'start-indoors'], ['herbs', 'start-indoors']],
+    [['peas', 'direct-sow'], ['lettuce', 'direct-sow'], ['radishes', 'direct-sow'], ['spinach', 'direct-sow'], ['broccoli', 'transplant']],
+    [['carrots', 'direct-sow'], ['beets', 'direct-sow'], ['broccoli', 'transplant'], ['kale', 'direct-sow'], ['peas', 'direct-sow']],
+    [['bush-beans', 'direct-sow'], ['cucumber', 'start-indoors'], ['squash', 'transplant'], ['basil', 'transplant'], ['tomatoes', 'transplant']],
+    [['tomatoes', 'transplant'], ['peppers', 'transplant'], ['basil', 'transplant'], ['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow']],
+    [['bush-beans', 'direct-sow'], ['okra', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['basil', 'tend-now'], ['cucumber', 'direct-sow']],
+    [['swiss-chard', 'direct-sow'], ['bush-beans', 'direct-sow'], ['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['southern-peas', 'direct-sow']],
+    [['kale', 'direct-sow'], ['carrots', 'direct-sow'], ['beets', 'direct-sow'], ['radishes', 'direct-sow'], ['broccoli', 'transplant']],
+    [['lettuce', 'direct-sow'], ['radishes', 'direct-sow'], ['spinach', 'direct-sow'], ['kale', 'direct-sow'], ['carrots', 'direct-sow']],
+    [['garlic', 'plant-cloves'], ['kale', 'direct-sow'], ['spinach', 'direct-sow'], ['onions', 'direct-sow'], ['lettuce', 'direct-sow']],
+    [['garlic', 'plant-cloves'], ['spinach', 'tend-now'], ['kale', 'tend-now'], ['herbs', 'start-indoors'], ['lettuce', 'start-indoors']],
+    [['herbs', 'start-indoors'], ['onions', 'start-indoors'], ['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['lettuce', 'start-indoors']],
+  ],
+  warm: [
+    [['lettuce', 'direct-sow'], ['peas', 'direct-sow'], ['carrots', 'direct-sow'], ['spinach', 'direct-sow'], ['radishes', 'direct-sow']],
+    [['broccoli', 'transplant'], ['potatoes', 'direct-sow'], ['beets', 'direct-sow'], ['carrots', 'direct-sow'], ['peas', 'direct-sow']],
+    [['tomatoes', 'transplant'], ['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow'], ['squash', 'transplant'], ['basil', 'transplant']],
+    [['okra', 'direct-sow'], ['squash', 'direct-sow'], ['basil', 'transplant'], ['southern-peas', 'direct-sow'], ['sweet-potatoes', 'plant-slips']],
+    [['okra', 'direct-sow'], ['southern-peas', 'direct-sow'], ['sweet-potatoes', 'plant-slips'], ['basil', 'transplant'], ['swiss-chard', 'direct-sow']],
+    [['okra', 'direct-sow'], ['southern-peas', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['basil', 'tend-now'], ['sweet-potatoes', 'tend-now']],
+    [['okra', 'tend-now'], ['southern-peas', 'direct-sow'], ['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['tomatoes', 'plan-ahead']],
+    [['broccoli', 'start-indoors'], ['kale', 'start-indoors'], ['carrots', 'plan-ahead'], ['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow']],
+    [['kale', 'transplant'], ['radishes', 'direct-sow'], ['broccoli', 'transplant'], ['lettuce', 'direct-sow'], ['spinach', 'plan-ahead']],
+    [['spinach', 'direct-sow'], ['lettuce', 'direct-sow'], ['carrots', 'direct-sow'], ['garlic', 'plant-cloves'], ['onions', 'direct-sow']],
+    [['garlic', 'plant-cloves'], ['onions', 'direct-sow'], ['peas', 'direct-sow'], ['spinach', 'direct-sow'], ['radishes', 'direct-sow']],
+    [['lettuce', 'direct-sow'], ['spinach', 'direct-sow'], ['radishes', 'direct-sow'], ['carrots', 'direct-sow'], ['peas', 'direct-sow']],
+  ],
+  hot: [
+    [['tomatoes', 'transplant'], ['peppers', 'transplant'], ['lettuce', 'direct-sow'], ['radishes', 'direct-sow'], ['carrots', 'direct-sow']],
+    [['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow'], ['basil', 'transplant'], ['tomatoes', 'transplant'], ['peppers', 'transplant']],
+    [['sweet-potatoes', 'plant-slips'], ['okra', 'direct-sow'], ['eggplant', 'transplant'], ['southern-peas', 'direct-sow'], ['basil', 'transplant']],
+    [['okra', 'direct-sow'], ['peppers', 'transplant'], ['southern-peas', 'direct-sow'], ['sweet-potatoes', 'plant-slips'], ['swiss-chard', 'direct-sow']],
+    [['sweet-potatoes', 'plant-slips'], ['okra', 'direct-sow'], ['southern-peas', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['basil', 'tend-now']],
+    [['okra', 'tend-now'], ['sweet-potatoes', 'tend-now'], ['southern-peas', 'direct-sow'], ['swiss-chard', 'direct-sow'], ['eggplant', 'tend-now']],
+    [['swiss-chard', 'direct-sow'], ['sweet-potatoes', 'tend-now'], ['okra', 'tend-now'], ['tomatoes', 'start-indoors'], ['peppers', 'start-indoors']],
+    [['eggplant', 'transplant'], ['peppers', 'transplant'], ['basil', 'direct-sow'], ['bush-beans', 'direct-sow'], ['cucumber', 'direct-sow']],
+    [['tomatoes', 'transplant'], ['cucumber', 'direct-sow'], ['bush-beans', 'direct-sow'], ['basil', 'transplant'], ['squash', 'direct-sow']],
+    [['lettuce', 'direct-sow'], ['kale', 'direct-sow'], ['radishes', 'direct-sow'], ['broccoli', 'transplant'], ['carrots', 'direct-sow']],
+    [['carrots', 'direct-sow'], ['peas', 'direct-sow'], ['spinach', 'direct-sow'], ['lettuce', 'direct-sow'], ['radishes', 'direct-sow']],
+    [['lettuce', 'direct-sow'], ['tomatoes', 'transplant'], ['peppers', 'transplant'], ['spinach', 'direct-sow'], ['carrots', 'direct-sow']],
+  ],
+};
+
+const SEASON_SUMMARIES: Record<ClimateBand, Record<SeasonId, string>> = {
+  'short-season': {
+    spring: 'The garden is waking up. Cool-weather crops can begin while tender plants stay protected.',
+    summer: 'Long days make every week count. Quick crops and fall starts can share the garden.',
+    fall: 'Cool-weather crops return as the first frost approaches.',
+    winter: 'This quieter stretch is useful for protected growing and planning the next thaw.',
+  },
+  temperate: {
+    spring: 'Warming soil opens a wide planting window, with tender crops following the last frost.',
+    summer: 'Warm soil supports fast growth while fall crops get an early start.',
+    fall: 'Cooling days favor roots, greens, and crops that tolerate a light frost.',
+    winter: 'Protected starts and cold-hardy crops keep the next season moving.',
+  },
+  warm: {
+    spring: 'The warm-season window is opening, and heat-loving crops can begin to take over.',
+    summer: 'Heat-loving crops take the lead while fall vegetables begin in protected spots.',
+    fall: 'Milder days bring leafy greens, roots, and brassicas back into the garden.',
+    winter: 'Cool-season growing weather makes this a productive time for greens and roots.',
+  },
+  hot: {
+    spring: 'Warmth arrives early, giving long-season crops plenty of time to settle in.',
+    summer: 'Heat-tolerant crops carry the garden while tender fall starts stay protected.',
+    fall: 'Gentler temperatures reopen the garden to beans, roots, and leafy crops.',
+    winter: 'Mild days support an active garden of greens, roots, and tender transplants.',
+  },
+};
+
+const SEASON_TITLES: Record<SeasonId, readonly [string, string, string]> = {
+  spring: ['Early spring', 'Mid-spring', 'Late spring'],
+  summer: ['Early summer', 'High summer', 'Late summer'],
+  fall: ['Early fall', 'Mid-fall', 'Late fall'],
+  winter: ['Early winter', 'Deep winter', 'Late winter'],
+};
+
+export function parseHardinessZone(value?: string | null): { number: number; label: string } | null {
+  const match = value?.trim().toLowerCase().match(/^(\d{1,2})([ab])?$/);
+  if (!match) return null;
+  const number = Number(match[1]);
+  if (number < 1 || number > 13) return null;
+  return { number, label: `${number}${match[2] ?? ''}` };
+}
+
+function climateBandForZone(zone: number): ClimateBand {
+  if (zone <= 5) return 'short-season';
+  if (zone <= 7) return 'temperate';
+  if (zone <= 9) return 'warm';
+  return 'hot';
+}
+
+function seasonForMonth(month: number): { season: SeasonId; phase: number } {
+  if (month === 11) return { season: 'winter', phase: 0 };
+  if (month <= 1) return { season: 'winter', phase: month + 1 };
+  if (month <= 4) return { season: 'spring', phase: month - 2 };
+  if (month <= 7) return { season: 'summer', phase: month - 5 };
+  return { season: 'fall', phase: month - 8 };
+}
+
+function monthName(date: Date, locale?: string | null): string {
+  try {
+    return new Intl.DateTimeFormat(locale || 'en-US', { month: 'long' }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat('en-US', { month: 'long' }).format(date);
+  }
+}
+
+export function buildSeasonalGuide(input: {
+  homeZone?: string | null;
+  lat?: number | null;
+  locale?: string | null;
+  date?: Date;
+}): SeasonalGuideData | null {
+  const parsedZone = parseHardinessZone(input.homeZone);
+  if (!parsedZone) return null;
+
+  const date = input.date ?? new Date();
+  const calendarMonth = date.getMonth();
+  const isSouthernHemisphere = typeof input.lat === 'number' && input.lat < 0;
+  const seasonalMonth = isSouthernHemisphere ? (calendarMonth + 6) % 12 : calendarMonth;
+  const { season, phase } = seasonForMonth(seasonalMonth);
+  const climateBand = climateBandForZone(parsedZone.number);
+  const suggestions = MONTHLY_PLANS[climateBand][seasonalMonth].slice(0, 3).map(([cropId, action]) => ({
+    cropName: CROP_DEFINITIONS[cropId].name,
+    action,
+    actionLabel: ACTION_LABELS[action],
+    why: CROP_DEFINITIONS[cropId].why,
+  }));
+
+  return {
+    season,
+    climateBand,
+    zone: parsedZone.label,
+    monthName: monthName(date, input.locale),
+    title: `${SEASON_TITLES[season][phase]} in Zone ${parsedZone.label}`,
+    summary: SEASON_SUMMARIES[climateBand][season],
+    suggestions,
+  };
+}

--- a/apps/grn/src/pages/DashboardPage.tsx
+++ b/apps/grn/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { PlantLoader } from '../components/branding/PlantLoader';
 import { createLogger } from '../utils/logging';
 import { recordTodayActionOpen } from '../utils/todayActionTracking';
 import { buildTodayActions } from './todayActions';
+import { SeasonalGuide } from '../components/Seasonality/SeasonalGuide';
 
 const logger = createLogger('today');
 
@@ -134,6 +135,8 @@ export function DashboardPage({ user }: DashboardPageProps) {
         title={`Today, ${greetingName}`}
         body="A short, prioritized list of what will help your garden most right now."
       />
+
+      <SeasonalGuide growerProfile={user?.growerProfile} crops={crops} />
 
       {!isOnline ? (
         <div className="grn-today-notice" role="status">

--- a/apps/grn/src/pages/DashboardPage.tsx
+++ b/apps/grn/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { createLogger } from '../utils/logging';
 import { recordTodayActionOpen } from '../utils/todayActionTracking';
 import { buildTodayActions } from './todayActions';
 import { SeasonalGuide } from '../components/Seasonality/SeasonalGuide';
+import { HarvestTimeline } from '../components/HarvestTimeline/HarvestTimeline';
 
 const logger = createLogger('today');
 
@@ -186,6 +187,8 @@ export function DashboardPage({ user }: DashboardPageProps) {
           ))}
         </ol>
       )}
+
+      {cropsQuery.data !== undefined ? <HarvestTimeline crops={crops} /> : null}
 
       {cropsQuery.data !== undefined ? (
         <section className="grn-dashboard__glance" aria-labelledby="garden-glance-heading">

--- a/apps/grn/src/pages/NewCropPage.tsx
+++ b/apps/grn/src/pages/NewCropPage.tsx
@@ -18,6 +18,7 @@ export function NewCropPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const requestedBedId = searchParams.get('bedId');
+  const suggestedCropName = searchParams.get('suggestion');
 
   const { data: profile, isLoading: isLoadingProfile } = useQuery({
     queryKey: ['userProfile'],
@@ -61,6 +62,7 @@ export function NewCropPage() {
       <CropForm
         lockedBed={lockedBed}
         initialBedId={requestedBedId}
+        initialCropName={suggestedCropName}
         onCancel={() => navigate('/garden/plants')}
         onSuccess={() => {
           completeTodayAction('start');


### PR DESCRIPTION
## Summary

- add a zone- and hemisphere-aware seasonal guide to the grower Today page
- pair a responsive seasonal landscape with timely crop suggestions and practical planting actions
- add a private harvest timeline for actively growing crops, grouped into ready to check, next 7 days, this month, and later
- deep-link due crops into harvest logging and let growers add or revise planting and expected-harvest dates from the plant library
- include accessible empty, missing-zone, missing-timing, and approximate-date guidance

## Why

Growers already save a USDA hardiness zone and can record planting and expected first-harvest dates, but the app did not use either set of information to make Today feel local or answer “what could I grow now?” and “what may be ready soon?”

This adds that context without a new backend dependency. Seasonal guidance and harvest dates are deliberately framed as starting points rather than promises: USDA zones describe winter cold, and actual planting and harvest timing still varies with frost, weather, variety, shade, and microclimate.

## User impact

- Today now reflects spring, summer, fall, or winter with a visual treatment tuned to the local hemisphere.
- Zones 1–13 receive monthly suggestions grouped into short-season, temperate, warm, and hot climate bands.
- A suggestion already being grown opens that crop; a new suggestion opens the planner prefilled with the matching catalog crop.
- Growing plants with an expected first-harvest date appear in a chronological, mobile-friendly timeline.
- Due crops open directly into harvest logging; crops without timing get a direct path to a date editor with quick estimate choices.
- Growers without a usable zone get a direct path to review profile settings.

## Validation

- `npm run test --workspace @olivias/grn` — 75 files, 604 tests passed
- focused harvest timeline, date grouping, timing editor, dashboard, and plant-library tests passed
- `npm run lint --workspace @olivias/grn` — passed
- `npm run typecheck --workspace @olivias/grn` — passed
- `npm run build --workspace @olivias/grn` — passed
- `npm run perf:budget --workspace @olivias/grn` — passed
- `cargo clippy --manifest-path services/grn-api/Cargo.toml --all-targets --all-features -- -D warnings` — passed
- `cargo test --manifest-path services/grn-api/Cargo.toml --all-features` — passed
- no API endpoints changed, so Postman collections were not affected

## Baseline gate notes

- The root `npm test` command still stops in the unchanged `@olivias/store` workspace because Vitest finds no test files there. The complete changed-app suite passes as listed above.
- `cargo fmt --check` reports newline-style mismatches across unchanged Rust files in this Windows checkout. This PR does not change Rust files.

Please confirm whether those two baseline issues should be handled separately before this PR is merged.
